### PR TITLE
Fix C++20 template ctor/dtor warnings and VertexList memcpy overread

### DIFF
--- a/Sexy.TodLib/DataArray.h
+++ b/Sexy.TodLib/DataArray.h
@@ -34,7 +34,7 @@ public:
 	const char*				mName;
 
 public:
-	DataArray<T>()
+	DataArray()
 	{
 		mBlock = nullptr;
 		mMaxUsedCount = 0U;
@@ -45,7 +45,7 @@ public:
 		mName = nullptr;
 	}
 
-	~DataArray<T>()
+	~DataArray()
 	{
 		DataArrayDispose();
 	}

--- a/Sexy.TodLib/TodList.h
+++ b/Sexy.TodLib/TodList.h
@@ -44,7 +44,7 @@ public:
 	TodAllocator*		mpAllocator;
 
 public:
-    TodList<T>()
+    TodList()
     {
         mHead = nullptr;
         mTail = nullptr;
@@ -52,7 +52,7 @@ public:
         mpAllocator = nullptr;
     }
 
-    ~TodList<T>()
+    ~TodList()
     {
         RemoveAll();
     }

--- a/SexyAppFramework/platform/pc/graphics/GLInterface.h
+++ b/SexyAppFramework/platform/pc/graphics/GLInterface.h
@@ -73,9 +73,10 @@ struct VertexList
 	typedef int size_type;
 
 	VertexList() : mVerts(mStackVerts), mSize(0), mCapacity(MAX_STACK_VERTS) { }
-	VertexList(const VertexList& theList) : mVerts(mStackVerts), mSize(theList.mSize), mCapacity(MAX_STACK_VERTS)
+	VertexList(const VertexList& theList) : mVerts(mStackVerts), mSize(0), mCapacity(MAX_STACK_VERTS)
 	{
-		reserve(mSize);
+		reserve(theList.mSize);
+		mSize = theList.mSize;
 		memcpy(mVerts, theList.mVerts, mSize * sizeof(mVerts[0]));
 	}
 


### PR DESCRIPTION
- Remove invalid template-ids from constructors/destructors inside class templates to comply with C++20 (e.g. change `TodList<T>()`/`~TodList<T>()` to `TodList()`/`~TodList()`).
  - Modified: TodList.h, DataArray.h
- Fix `VertexList` copy constructor to initialize `mSize` correctly before calling `reserve` and set `mSize` prior to `memcpy` to avoid reading past the source buffer (resolves -Wstringop-overread).
  - Modified: GLInterface.h

Reduce compile-time warnings under modern compilers (C++20) and eliminate a potential memcpy over-read bug.