### PR TITLE
Fix: update compile time string in SaveGame.cpp to be consist with GOTY

### DIFF
--- a/src/Lawn/System/SaveGame.cpp
+++ b/src/Lawn/System/SaveGame.cpp
@@ -15,7 +15,7 @@
 #include "../../Sexy.TodLib/TodParticle.h"
 #include "../../Sexy.TodLib/EffectSystem.h"
 
-static const char* FILE_COMPILE_TIME_STRING = "Feb 16 200923:03:38";
+static const char* FILE_COMPILE_TIME_STRING = "Jul  2 201011:47:03"; // The compile time of 1.2.0.1073 GOTY
 static const unsigned int SAVE_FILE_MAGIC_NUMBER = 0xFEEDDEAD;
 static const unsigned int SAVE_FILE_VERSION = 2U;
 static unsigned int SAVE_FILE_DATE = crc32(0, (Bytef*)FILE_COMPILE_TIME_STRING, strlen(FILE_COMPILE_TIME_STRING));  //[0x6AA7EC]


### PR DESCRIPTION
A brute-force attempt revealed that GOTY's build date should be "Jul 2 2010 11:47:03".