### PR TITLE
Fix crash in TodDrawImageCelScaled by swapping DrawImage arguments

### DIFF
--- a/src/Sexy.TodLib/TodCommon.cpp
+++ b/src/Sexy.TodLib/TodCommon.cpp
@@ -457,7 +457,7 @@ void TodDrawImageCelScaled(Graphics* g, Image* theImageStrip, int thePosX, int t
 	int aCelHeight = theImageStrip->GetCelHeight();
 	Rect aSrcRect(aCelWidth * theCelCol, aCelHeight * theCelRow, aCelWidth, aCelHeight);
 	Rect aDestRect(thePosX, thePosY, FloatRoundToInt(aCelWidth * theScaleX), FloatRoundToInt(aCelHeight * theScaleY));
-	g->DrawImage(theImageStrip, aSrcRect, aDestRect);
+	g->DrawImage(theImageStrip, aDestRect, aSrcRect);
 }
 
 static const int POOL_SIZE = 4096;


### PR DESCRIPTION
TodDrawImageCelScaled passed the source and destination Rects to Graphics::DrawImage in the wrong order, causing screen coordinates to be interpreted as texture coordinates. This could produce out-of-bounds texture lookups in TextureData::GetTexture and trigger a SIGABRT when scaling/cell-drawing (e.g. placing plants from the wheelbarrow into the aquarium in Zen Garden). Swap the arguments so the call is DrawImage(destRect, srcRect), preventing the invalid texture access.