### PR TITLE
Make TodPickFromArray type-safe and fix unsafe intptr_t casts (avoid boss-spawn crash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A **cross-platform** community-driven reimplementation of Plants vs. Zombies: Ga
 
 | 🌿 Authentic | 🎮 Portable | 🛠️ Open |
 | :---: | :---: | :---: |
-| Almost 100% gameplay recreation | Run on Linux, Windows, macOS, Switch... | OpenGL & SDL |
+| Almost 100% gameplay recreation | Run on Linux, Windows, macOS, Switch...<br>Support for 32-bit and 64-bit systems | OpenGL & SDL |
 
 ## License
 
@@ -182,7 +182,7 @@ The framework differs from many other APIs in that some class properties are not
 
 ## Thanks
 
-- **[@Headshotnoby](https://www.github.com/headshot2017)**: For fully implementing the 64-bit support and OpenGL backend.
+- **[@Headshotnoby](https://www.github.com/headshot2017)**: For almost fully implementing the 64-bit support and OpenGL backend.
 - **[@Patoke](https://www.github.com/Patoke)**: For the incredible initial reimplementation of PvZ GOTY.
 - **[@rspforhp](https://www.github.com/octokatherine)**: For the 0.9.9 version's work.
 - **[@ruslan831](https://github.com/ruslan831)**: For archiving the 0.9.9 version's re-implementation.

--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -4907,7 +4907,7 @@ void Board::PickSpecialGraveStone()
 
 	if (aPickCount > 0)
 	{
-		((GridItem*)TodPickFromArray((intptr_t*)aPicks, aPickCount))->mGridItemState = GridItemState::GRIDITEM_STATE_GRAVESTONE_SPECIAL;
+		TodPickFromArray(aPicks, aPickCount)->mGridItemState = GridItemState::GRIDITEM_STATE_GRAVESTONE_SPECIAL;
 	}
 }
 

--- a/src/Lawn/Challenge.cpp
+++ b/src/Lawn/Challenge.cpp
@@ -975,7 +975,7 @@ SeedType Challenge::BeghouledPickSeed(int theGridX, int theGridY, BeghouledBoard
 	TOD_ASSERT(theBoardState->mSeedType[theGridX][theGridY] == SEED_NONE);
 	// SeedType* aSeedState = &theBoardState->mSeedType[theGridX][theGridY];
 	int aCount = 0;
-	intptr_t aPickArray[6];
+	SeedType aPickArray[6];
 	
 	for (int i = 0; i < 6; i++)
 	{
@@ -1014,7 +1014,7 @@ SeedType Challenge::BeghouledPickSeed(int theGridX, int theGridY, BeghouledBoard
 	}
 	
 	theBoardState->mSeedType[theGridX][theGridY] = SEED_NONE;
-	return (SeedType)TodPickFromArray(aPickArray, aCount);
+	return TodPickFromArray(aPickArray, aCount);
 }
 
 //0x4216E0

--- a/src/Lawn/Coin.cpp
+++ b/src/Lawn/Coin.cpp
@@ -198,7 +198,7 @@ void Coin::CoinInitialize(int theX, int theY, CoinType theCoinType, CoinMotion t
                 SeedType::SEED_CHOMPER
             };
             
-            SeedType aSeedType = (SeedType)TodPickFromArray((intptr_t*)aSeedList, LENGTH(aSeedList));
+            SeedType aSeedType = TodPickFromArray(aSeedList, LENGTH(aSeedList));
             mPottedPlantSpec.InitializePottedPlant(aSeedType);
         }
         else if (mBoard->mBackground == BackgroundType::BACKGROUND_2_NIGHT)
@@ -214,7 +214,7 @@ void Coin::CoinInitialize(int theX, int theY, CoinType theCoinType, CoinMotion t
                 SeedType::SEED_DOOMSHROOM
             };
 
-            SeedType aSeedType = (SeedType)TodPickFromArray((intptr_t*)aSeedList, LENGTH(aSeedList));
+            SeedType aSeedType = TodPickFromArray(aSeedList, LENGTH(aSeedList));
             mPottedPlantSpec.InitializePottedPlant(aSeedType);
         }
         else if (mBoard->mBackground == BackgroundType::BACKGROUND_3_POOL)
@@ -230,7 +230,7 @@ void Coin::CoinInitialize(int theX, int theY, CoinType theCoinType, CoinMotion t
                 SeedType::SEED_TALLNUT
             };
 
-            SeedType aSeedType = (SeedType)TodPickFromArray((intptr_t*)aSeedList, LENGTH(aSeedList));
+            SeedType aSeedType = TodPickFromArray(aSeedList, LENGTH(aSeedList));
             mPottedPlantSpec.InitializePottedPlant(aSeedType);
         }
         else if (mBoard->mBackground == BackgroundType::BACKGROUND_4_FOG)
@@ -246,7 +246,7 @@ void Coin::CoinInitialize(int theX, int theY, CoinType theCoinType, CoinMotion t
                 SeedType::SEED_MAGNETSHROOM
             };
 
-            SeedType aSeedType = (SeedType)TodPickFromArray((intptr_t*)aSeedList, LENGTH(aSeedList));
+            SeedType aSeedType = TodPickFromArray(aSeedList, LENGTH(aSeedList));
             mPottedPlantSpec.InitializePottedPlant(aSeedType);
         }
         else if (mBoard->mBackground == BackgroundType::BACKGROUND_5_ROOF)
@@ -260,7 +260,7 @@ void Coin::CoinInitialize(int theX, int theY, CoinType theCoinType, CoinMotion t
                 SeedType::SEED_MELONPULT
             };
 
-            SeedType aSeedType = (SeedType)TodPickFromArray((intptr_t*)aSeedList, LENGTH(aSeedList));
+            SeedType aSeedType = TodPickFromArray(aSeedList, LENGTH(aSeedList));
             mPottedPlantSpec.InitializePottedPlant(aSeedType);
         }
         else

--- a/src/Lawn/ZenGarden.cpp
+++ b/src/Lawn/ZenGarden.cpp
@@ -2444,7 +2444,7 @@ SeedType ZenGarden::PickRandomSeedType()
             aSeedCount++;
         }
     }
-    return (SeedType)TodPickFromArray((intptr_t*)aSeedList, aSeedCount);
+    return TodPickFromArray(aSeedList, aSeedCount);
 }
 
 //0x5223F0

--- a/src/Lawn/Zombie.cpp
+++ b/src/Lawn/Zombie.cpp
@@ -9902,7 +9902,7 @@ void Zombie::BossSpawnContact()
             aZombieTypeCount--;
         }
 
-        aZombieType = (ZombieType)TodPickFromArray((intptr_t*)gBossZombieList, aZombieTypeCount);
+        aZombieType = TodPickFromArray(gBossZombieList, aZombieTypeCount);
     }
 
     Zombie* aZombie = mBoard->AddZombieInRow(aZombieType, mTargetRow, 0);

--- a/src/Sexy.TodLib/TodCommon.cpp
+++ b/src/Sexy.TodLib/TodCommon.cpp
@@ -109,12 +109,6 @@ bool TodAppCloseRequest()
 	return false;
 }
 
-intptr_t TodPickFromArray(const intptr_t* theArray, int theCount)
-{
-	TOD_ASSERT(theCount > 0);
-	return theCount > 0 ? theArray[Sexy::Rand(theCount)] : 0;
-}
-
 intptr_t TodPickFromWeightedArray(const TodWeightedArray* theArray, int theCount)
 {
 	return TodPickArrayItemFromWeightedArray(theArray, theCount)->mItem;

--- a/src/Sexy.TodLib/TodCommon.h
+++ b/src/Sexy.TodLib/TodCommon.h
@@ -4,6 +4,7 @@
 #include <cfloat>
 #include "../Lawn/LawnCommon.h"
 #include "../SexyAppFramework/Common.h"
+#include "TodDebug.h"
 #include "misc/ResourceManager.h"
 
 struct TodAllocator;
@@ -44,7 +45,13 @@ public:
 	float		mSecondLastPicked;
 };
 
-/*inline*/ intptr_t		TodPickFromArray(const intptr_t* theArray, int theCount);
+// Modified to a portable inline function that supports 32/64 bit systems
+template <typename T>
+inline T TodPickFromArray(const T* theArray, int theCount)
+{
+	TOD_ASSERT(theCount > 0);
+	return theCount > 0 ? theArray[Sexy::Rand(theCount)] : T{};
+}
 intptr_t				TodPickFromWeightedArray(const TodWeightedArray* theArray, int theCount);
 TodWeightedArray*		TodPickArrayItemFromWeightedArray(const TodWeightedArray* theArray, int theCount);
 TodWeightedGridArray*	TodPickFromWeightedGridArray(const TodWeightedGridArray* theArray, int theCount);


### PR DESCRIPTION
- Replace old intptr_t-based `TodPickFromArray` with a templated, type-safe inline version to avoid reinterpreting arrays as `intptr_t` on 64-bit.
- Remove the old `intptr_t` implementation in TodCommon.cpp and add TodDebug.h include so `TOD_ASSERT` is available to the template.
- Replace unsafe `(intptr_t*)` casts and callers with type-correct calls to `TodPickFromArray`:
  - Challenge.cpp (use `SeedType` array)
  - Board.cpp (pick `GridItem*` safely)
  - ZenGarden.cpp
  - Coin.cpp
  - Zombie.cpp (boss spawn selection now uses typed pick)