### PR TITLE
Fix(playerinfo): align achievements/zombatar save layout with original format

### DIFF
--- a/src/Lawn/System/PlayerInfo.h
+++ b/src/Lawn/System/PlayerInfo.h
@@ -5,6 +5,7 @@
 #define PURCHASE_COUNT_OFFSET 1000
 
 #include <ctime>
+#include <vector>
 #include "../../ConstEnums.h"
 #include "../../SexyAppFramework/Common.h"
 
@@ -75,7 +76,12 @@ public:
     int                 mNumPottedPlants;                   //+0x350
     PottedPlant         mPottedPlant[MAX_POTTED_PLANTS];    //+0x358
     bool                mEarnedAchievements[20];            //+GOTY @Patoke: 0x24
-    bool                mShownAchievements[20];             //+GOTY @Patoke: 0x38
+    bool                mShownAchievements[20];             //+GOTY
+    unsigned char       mZombatarAccepted;                  //+GOTY from @lmintlcx, added by wszqkzqk: 0x28
+    uint32_t            mZombatarHeadCount;                 //+GOTY from @lmintlcx, added by wszqkzqk: 0x29
+    std::vector<unsigned char> mZombatarData;               // raw 0x48 * count
+    unsigned char       mZombatarTrailingUnknown[0x14];     // unknown bytes after Zombatars
+    unsigned char       mZombatarCreatedBefore;             // created at least one Zombatar (0/1)
 
 public:
     PlayerInfo();


### PR DESCRIPTION
This pull request updates the achievement and Zombatar data syncing logic in the `PlayerInfo` system to better match the original Plants vs. Zombies user file format for improved compatibility. The most important changes are grouped below:

Achievement sync improvements:
* Modified the achievement synchronization in `PlayerInfo::SyncDetails` to use 20 x 16-bit values instead of booleans, matching the original file format. This ensures compatibility with existing save files and sets both `mEarnedAchievements` and `mShownAchievements` when reading data.

Zombatar compatibility fields:
* Added new fields `mZombatarAccepted` and `mZombatarHeadCount` to the `PlayerInfo` class, and included them in the sync and reset logic to maintain compatibility with the original format, even though Zombatar is not yet implemented. [[1]](diffhunk://#diff-49c904b1d46683ace480df5e69311fdac9808a8b014fa00b8f978350e8f01369R79-R80) [[2]](diffhunk://#diff-bfb50499bd420d598f30c33e6dbb358fdcc30f952b33244c9f8f0dc2b31e4348L80-R95) [[3]](diffhunk://#diff-bfb50499bd420d598f30c33e6dbb358fdcc30f952b33244c9f8f0dc2b31e4348R181-R182)