### PR TITLE
Refactor: replace deprecated std::wstring_convert with utf8cpp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
           mpg123 \
           ninja \
           sdl2-compat \
-          sudo
+          sudo \
+          utf8cpp
 
     - name: Create Builder User
       run: |
@@ -92,6 +93,7 @@ jobs:
           mingw-w64-ucrt-x86_64-ninja
           mingw-w64-ucrt-x86_64-ntldd
           mingw-w64-ucrt-x86_64-SDL2
+          mingw-w64-ucrt-x86_64-utf8cpp
 
     - name: Compile PvZ-Portable for Windows
       shell: msys2 {0}
@@ -215,7 +217,8 @@ jobs:
           libvorbis \
           mpg123 \
           ninja \
-          sdl2
+          sdl2 \
+          utf8cpp
 
     - name: Build PvZ-Portable
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5...4.0)
+cmake_minimum_required(VERSION 3.11...4.0)
 
 project(pvz-portable LANGUAGES C CXX ASM)
 
@@ -120,6 +120,12 @@ find_package(JPEG REQUIRED)
 find_package(PNG REQUIRED)
 find_package(SDL2 REQUIRED)
 find_package(OpenGL REQUIRED)
+find_package(utf8cpp CONFIG QUIET)
+if (NOT TARGET utf8cpp::utf8cpp AND NOT TARGET utf8cpp)
+	include(FetchContent)
+	FetchContent_Declare(utf8cpp URL https://github.com/nemtrif/utfcpp/archive/refs/tags/v4.0.5.tar.gz)
+	FetchContent_MakeAvailable(utf8cpp)
+endif()
 if (NOT NO_GLEW)
 	find_package(GLEW REQUIRED)
 endif()
@@ -146,6 +152,13 @@ target_include_directories(pvz-portable PRIVATE
 	${SDL2_INCLUDE_DIRS}
 	${PLAT_INCLUDES}
 )
+if (TARGET utf8cpp::utf8cpp)
+	target_link_libraries(pvz-portable PRIVATE utf8cpp::utf8cpp)
+elseif (TARGET utf8cpp)
+	target_link_libraries(pvz-portable PRIVATE utf8cpp)
+else()
+	message(FATAL_ERROR "utf8cpp target not available")
+endif()
 if(MSVC)
 	target_include_directories(pvz-portable PRIVATE ${DIRENT_INCLUDE_DIRS})
 endif()

--- a/README.md
+++ b/README.md
@@ -76,13 +76,14 @@ Before building on PC, ensure you have the necessary dependencies installed:
 - **Audio**: `libopenmpt`, `libogg`, `libvorbis`, `mpg123`
 - **Image**: `libpng`, `libjpeg-turbo`
 - **Windowing/Input**: `SDL2`
+- **Text Encoding**: `utf8cpp`
 
 ### Arch Linux
 
 You can install the required dependencies using the following command:
 
 ```bash
-sudo pacman -S --needed base-devel cmake glew libjpeg-turbo libogg libopenmpt libpng libvorbis mpg123 ninja sdl2-compat
+sudo pacman -S --needed base-devel cmake glew libjpeg-turbo libogg libopenmpt libpng libvorbis mpg123 ninja sdl2-compat utf8cpp
 ```
 
 ### Debian/Ubuntu
@@ -90,7 +91,7 @@ sudo pacman -S --needed base-devel cmake glew libjpeg-turbo libogg libopenmpt li
 You can install the required dependencies using the following command:
 
 ```bash
-sudo apt install cmake ninja-build libogg-dev libglew-dev libjpeg-dev libopenmpt-dev libpng-dev libvorbis-dev libmpg123-dev libsdl2-dev
+sudo apt install cmake ninja-build libogg-dev libglew-dev libjpeg-dev libopenmpt-dev libpng-dev libvorbis-dev libmpg123-dev libsdl2-dev libutf8cpp-dev
 ```
 
 ### Windows (MSYS2 UCRT64)
@@ -98,7 +99,7 @@ sudo apt install cmake ninja-build libogg-dev libglew-dev libjpeg-dev libopenmpt
 You can install the required dependencies using the following command:
 
 ```bash
-pacman -S --needed base-devel mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-glew mingw-w64-ucrt-x86_64-libjpeg-turbo mingw-w64-ucrt-x86_64-libopenmpt mingw-w64-ucrt-x86_64-libogg mingw-w64-ucrt-x86_64-libpng mingw-w64-ucrt-x86_64-libvorbis mingw-w64-ucrt-x86_64-mpg123 mingw-w64-ucrt-x86_64-ninja mingw-w64-ucrt-x86_64-SDL2
+pacman -S --needed base-devel mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-glew mingw-w64-ucrt-x86_64-libjpeg-turbo mingw-w64-ucrt-x86_64-libopenmpt mingw-w64-ucrt-x86_64-libogg mingw-w64-ucrt-x86_64-libpng mingw-w64-ucrt-x86_64-libvorbis mingw-w64-ucrt-x86_64-mpg123 mingw-w64-ucrt-x86_64-ninja mingw-w64-ucrt-x86_64-SDL2 mingw-w64-ucrt-x86_64-utf8cpp
 ```
 
 ### macOS (Homebrew)
@@ -106,7 +107,7 @@ pacman -S --needed base-devel mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-
 You can install the required dependencies using [Homebrew](https://brew.sh/) with the following command:
 
 ```bash
-brew install cmake dylibbundler glew jpeg-turbo libogg libopenmpt libpng libvorbis mpg123 ninja sdl2
+brew install cmake dylibbundler glew jpeg-turbo libogg libopenmpt libpng libvorbis mpg123 ninja sdl2 utf8cpp
 ```
 
 ## Build Instructions

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: wszqkzqk <wszqkzqk@qq.com>
 
 pkgname=pvz-portable
-pkgver=r277.20260126.d9280d8
+pkgver=r292.20260128.a61a635
 pkgrel=1
 pkgdesc="A cross-platform community-driven reimplementation of Plants vs. Zombies: Game of the Year Edition, aiming to bring the **100% authentic PvZ experience** to every platform."
 url="https://github.com/wszqkzqk/${pkgname}"
@@ -21,6 +21,7 @@ makedepends=(
     cmake
     git
     ninja
+    utf8cpp
 )
 source=(
     "${pkgname}::git+file://${startdir}/.."

--- a/src/SexyAppFramework/Common.cpp
+++ b/src/SexyAppFramework/Common.cpp
@@ -1,8 +1,8 @@
 #include "Common.h"
 #include "misc/MTRand.h"
 #include "misc/Debug.h"
-#include <locale>
-#include <codecvt>
+#include <iterator>
+#include <utf8.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
@@ -214,36 +214,40 @@ std::wstring Sexy::StringToLower(const std::wstring& theString)
 
 std::wstring Sexy::StringToWString(const std::string &theString)
 {
-	try
+	std::string aClean;
+	aClean.reserve(theString.size());
+	utf8::replace_invalid(theString.begin(), theString.end(), std::back_inserter(aClean));
+	if constexpr (sizeof(wchar_t) == 2)
 	{
-		std::wstring_convert<std::codecvt_utf8<wchar_t>> aConv;
-		return aConv.from_bytes(theString);
+		std::u16string aTmp;
+		aTmp.reserve(aClean.size());
+		utf8::utf8to16(aClean.begin(), aClean.end(), std::back_inserter(aTmp));
+		return std::wstring(aTmp.begin(), aTmp.end());
 	}
-	catch (const std::range_error&)
+	else
 	{
-		std::wstring aFallback;
-		aFallback.reserve(theString.length());
-		for (size_t i = 0; i < theString.length(); i++)
-			aFallback += (unsigned char)theString[i];
-		return aFallback;
+		std::u32string aTmp;
+		aTmp.reserve(aClean.size());
+		utf8::utf8to32(aClean.begin(), aClean.end(), std::back_inserter(aTmp));
+		return std::wstring(aTmp.begin(), aTmp.end());
 	}
 }
 
 std::string Sexy::WStringToString(const std::wstring &theString)
 {
-	try
+	std::string aOut;
+	aOut.reserve(theString.size());
+	if constexpr (sizeof(wchar_t) == 2)
 	{
-		std::wstring_convert<std::codecvt_utf8<wchar_t>> aConv;
-		return aConv.to_bytes(theString);
+		std::u16string aTmp(theString.begin(), theString.end());
+		utf8::utf16to8(aTmp.begin(), aTmp.end(), std::back_inserter(aOut));
 	}
-	catch (const std::range_error&)
+	else
 	{
-		std::string aFallback;
-		aFallback.reserve(theString.length());
-		for (auto ch : theString)
-			aFallback += (ch <= 0xFF) ? (char)ch : '?';
-		return aFallback;
+		std::u32string aTmp(theString.begin(), theString.end());
+		utf8::utf32to8(aTmp.begin(), aTmp.end(), std::back_inserter(aOut));
 	}
+	return aOut;
 }
 
 SexyString Sexy::StringToSexyString(const std::string& theString)
@@ -1399,8 +1403,7 @@ bool Sexy::StrPrefixNoCase(const char *theStr, const char *thePrefix, int maxLen
 
 std::wstring Sexy::UTF8StringToWString(const std::string theString)
 {
-	std::wstring_convert<std::codecvt_utf8<wchar_t> > cv;
-	return cv.from_bytes(theString);
+	return StringToWString(theString);
 	/*
 	int size = MultiByteToWideChar(CP_UTF8, 0, theString.c_str(), theString.length() + 1, nullptr, 0);
 	wchar_t* buffer = new wchar_t[size];

--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -14,8 +14,6 @@
 
 #ifdef __SWITCH__
 #include <switch.h>
-#include <locale>
-#include <codecvt>
 #elif defined(__3DS__)
 #include <3ds.h>
 #endif
@@ -2930,9 +2928,8 @@ int SexyAppBase::MsgBox(const std::wstring& theText, const std::wstring& theTitl
 	wprintf(L"%s\n===\n%s\n", theTitle.c_str(), theText.c_str());
 
 #ifdef __SWITCH__
-	std::wstring_convert<std::codecvt_utf8<wchar_t> > cv;
 	ErrorApplicationConfig c;
-	errorApplicationCreate(&c, cv.to_bytes(theTitle).c_str(), cv.to_bytes(theText).c_str());
+	errorApplicationCreate(&c, WStringToString(theTitle).c_str(), WStringToString(theText).c_str());
 	errorApplicationShow(&c);
 #endif
 
@@ -2975,9 +2972,8 @@ void SexyAppBase::Popup(const std::wstring& theString)
 		wprintf(L"FATAL ERROR\n===\n%s\n", theString.c_str());
 
 #ifdef __SWITCH__
-	std::wstring_convert<std::codecvt_utf8<wchar_t> > cv;
 	ErrorApplicationConfig c;
-	errorApplicationCreate(&c, "Fatal error", cv.to_bytes(theString).c_str());
+	errorApplicationCreate(&c, "Fatal error", WStringToString(theString).c_str());
 	errorApplicationShow(&c);
 #endif
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,6 +8,7 @@
     "libpng",
     "libvorbis",
     "mpg123",
+    "utf8cpp",
     "pthreads",
     "sdl2",
     "sdl2-mixer",


### PR DESCRIPTION
- Replace deprecated `std::wstring_convert` and `std::codecvt` (removed in C++26) with `utf8cpp` for standard-compliant UTF-8 conversion.
- Update `StringToWString` and `WStringToString` to use `utf8::utf8to16/32` and `utf8::utf16/32to8`.
- Add logic to handle `wchar_t` size differences between Windows (UTF-16) and Unix (UTF-32).
- Clean invalid UTF-8 sequences using `utf8::replace_invalid` instead of manual fallback loops.
- Update CMakeLists to find `utf8cpp` via package config or automatically fetch v4.0.5 via FetchContent.
- Bump minimum CMake version to 3.11 to support FetchContent.
- Update CI workflows, README, and PKGBUILD to include `utf8cpp` as a dependency.