### PR TITLE
Fix BeghouledTwistMoveCausesMatch seed assignment order

### DIFF
--- a/src/Lawn/Challenge.cpp
+++ b/src/Lawn/Challenge.cpp
@@ -565,8 +565,8 @@ int Challenge::BeghouledTwistMoveCausesMatch(int theGridX, int theGridY, Beghoul
 
 	theBoardState->mSeedType[theGridX + 1][theGridY] = aSeed1;
 	theBoardState->mSeedType[theGridX + 1][theGridY + 1] = aSeed2;
-	theBoardState->mSeedType[theGridX][theGridY + 1] = aSeed3;
-	theBoardState->mSeedType[theGridX][theGridY] = aSeed4;
+	theBoardState->mSeedType[theGridX][theGridY + 1] = aSeed4;
+	theBoardState->mSeedType[theGridX][theGridY] = aSeed3;
 
 	int aHasMatch = BeghouledBoardHasMatch(theBoardState);
 


### PR DESCRIPTION
This pull request corrects the assignment order of seed types in the `Challenge::BeghouledTwistMoveCausesMatch` function to ensure that the correct seeds are placed in their intended positions after a twist move.

Bug fix:

* Fixed the assignment of `aSeed3` and `aSeed4` to the correct grid positions in `Challenge::BeghouledTwistMoveCausesMatch`, swapping their placement to match the intended logic.