### PR TITLE
Fix Zen Garden watering can state to water only target pot

### DIFF
--- a/src/Lawn/ZenGarden.cpp
+++ b/src/Lawn/ZenGarden.cpp
@@ -944,7 +944,7 @@ void ZenGarden::MouseDownWithFeedingTool(int x, int y, CursorType theCursorType)
                 Reanimation* aWateringCanReanim = mApp->AddReanimation(aPlantToFeed->mX + 32, aPlantToFeed->mY, 0, ReanimationType::REANIM_ZENGARDEN_WATERINGCAN);
                 aWateringCanReanim->PlayReanim("anim_water", ReanimLoopType::REANIM_PLAY_ONCE_AND_HOLD, 0, 0.0f);
                 aZenTool->mGridItemReanimID = mApp->ReanimationGetID(aWateringCanReanim);
-                aZenTool->mGridItemState = GridItemState::GRIDITEM_STATE_ZEN_TOOL_GOLD_WATERING_CAN;
+                aZenTool->mGridItemState = GridItemState::GRIDITEM_STATE_ZEN_TOOL_WATERING_CAN;
                 mApp->PlayFoley(FoleyType::FOLEY_WATERING);
             }
         }


### PR DESCRIPTION
Previously the normal watering can was incorrectly set to the gold-watering-can state (GRIDITEM_STATE_ZEN_TOOL_GOLD_WATERING_CAN), which caused DoFeedingTool() to run the gold-can area logic and water multiple pots. Change the normal watering-can branch to set GRIDITEM_STATE_ZEN_TOOL_WATERING_CAN so only the intended single potted plant is watered.