### PR TITLE
Fix application hang on window close event

### DIFF
--- a/src/SexyAppFramework/platform/pc/Input.cpp
+++ b/src/SexyAppFramework/platform/pc/Input.cpp
@@ -31,12 +31,16 @@ bool SexyAppBase::ProcessDeferredMessages(bool singleMessage)
 		switch(event.type)
 		{
 			case SDL_QUIT:
-				mShutdown = true;
+				CloseRequestAsync();
 				break;
 
 			case SDL_WINDOWEVENT:
 				switch(event.window.event)
 				{
+					case SDL_WINDOWEVENT_CLOSE:
+						CloseRequestAsync();
+						break;
+
 					case SDL_WINDOWEVENT_RESIZED:
 						mGLInterface->UpdateViewport();
 						mWidgetManager->Resize(mScreenBounds, mGLInterface->mPresentationRect);


### PR DESCRIPTION
The application was previously hanging or entering a paused state when the window close button was clicked because the SDL close events were not being handled correctly.

Changes:
- Modified `src/SexyAppFramework/platform/pc/Input.cpp` to trap `SDL_QUIT` and `SDL_WINDOWEVENT_CLOSE` events.
- Mapped these events to call `CloseRequestAsync()`.

This ensures the application triggers the proper shutdown sequence defined in `LawnApp::CloseRequestAsync` (setting `mExitToTop` and `mCloseRequest`) instead of relying on the default SDL behavior which was bypassing the game's cleanup logic.