### PR TITLE
Fix: use std::atomic for ref counters and try_emplace for maps

### DIFF
--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -6035,7 +6035,7 @@ SharedImageRef SexyAppBase::SetSharedImage(const std::string& theFileName, const
 	
 	{
 		AutoCrit anAutoCrit(mGLInterface->mCritSect);
-		aResultPair = mSharedImageMap.insert(SharedImageMap::value_type(SharedImageMap::key_type(anUpperFileName, anUpperVariant), SharedImage()));
+		aResultPair = mSharedImageMap.try_emplace(SharedImageMap::key_type(anUpperFileName, anUpperVariant));
 		aSharedImageRef = &aResultPair.first->second;
 	}
 
@@ -6060,7 +6060,7 @@ SharedImageRef SexyAppBase::GetSharedImage(const std::string& theFileName, const
 
 	{
 		AutoCrit anAutoCrit(mGLInterface->mCritSect);	
-		aResultPair = mSharedImageMap.insert(SharedImageMap::value_type(SharedImageMap::key_type(anUpperFileName, anUpperVariant), SharedImage()));
+		aResultPair = mSharedImageMap.try_emplace(SharedImageMap::key_type(anUpperFileName, anUpperVariant));
 		aSharedImageRef = &aResultPair.first->second;
 	}
 

--- a/src/SexyAppFramework/graphics/ImageFont.h
+++ b/src/SexyAppFramework/graphics/ImageFont.h
@@ -5,6 +5,7 @@
 #include "misc/DescParser.h"
 #include "SexyAppBase.h"
 #include "SharedImage.h"
+#include <atomic>
 
 namespace Sexy
 {
@@ -73,7 +74,7 @@ class FontData : public DescParser
 {
 public:
 	bool					mInitialized;
-	int						mRefCount;
+	std::atomic<int>		mRefCount;
 	SexyAppBase*			mApp;		
 
 	int						mDefaultPointSize;

--- a/src/SexyAppFramework/graphics/SharedImage.h
+++ b/src/SexyAppFramework/graphics/SharedImage.h
@@ -2,6 +2,7 @@
 #define __SHARED_IMAGE_H__
 
 #include "Common.h"
+#include <atomic>
 
 namespace Sexy
 {
@@ -14,7 +15,7 @@ class SharedImage
 {
 public:
 	GLImage*				mImage;
-	int						mRefCount;		
+	std::atomic<int>		mRefCount;		
 
 	SharedImage();
 };


### PR DESCRIPTION
- Change `mRefCount` from `int` to `std::atomic<int>` in `SharedImage` and `FontData` to ensure thread-safe operations.
- Include `<atomic>` header in `SharedImage.h` and `ImageFont.h`.
- Replace `insert` with `try_emplace` in `SetSharedImage` and `GetSharedImage` for `mSharedImageMap`.
- This avoids unnecessary temporary object construction and simplifies the code.
- Fixes crashes caused by occasional thread race conditions.

```log
Program terminated with signal SIGSEGV, Segmentation fault.
#0  std::_Rb_tree_rebalance_for_erase (__z=__z@entry=0x55a76f0042f0, __header=...)
    at /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++98/tree.cc:370

⚠ warning: 370 /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++98/tree.cc: 没有那个文件或目录
[Current thread is 1 (Thread 0x7f7483a23780 (LWP 775429))]
(gdb) bt
#0  std::_Rb_tree_rebalance_for_erase (__z=__z@entry=0x55a76f0042f0, __header=...)
    at /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++98/tree.cc:370
#1  0x000055a742bec08b in std::__rb_tree::_Node_traits<std::pair<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const, Sexy::SharedImage>, std::pair<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const, Sexy::SharedImage>*>::_S_rebalance_for_erase (
    __z=0x55a76f0042f0, __header=...) at /usr/include/c++/15.2.1/bits/stl_tree.h:698
#2  std::_Rb_tree<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::pair<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const, Sexy::SharedImage>, std::_Select1st<std::pair<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const, Sexy::SharedImage> >, std::less<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::allocator<std::pair<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const, Sexy::SharedImage> > >::_M_erase_aux (this=<optimized out>, __position=...) at /usr/include/c++/15.2.1/bits/stl_tree.h:3115
#3  std::_Rb_tree<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::pair<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const, Sexy::SharedImage>, std::_Select1st<std::pair<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const, Sexy::SharedImage> >, std::less<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::allocator<std::pair<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const, Sexy::SharedImage> > >::erase[abi:cxx11](std::_Rb_tree_iterator<std::pair<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const, Sexy::SharedImage> >) (
    this=<optimized out>, __position={...}) at /usr/include/c++/15.2.1/bits/stl_tree.h:1833
#4  std::map<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, Sexy::SharedImage, std::less<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::allocator<std::pair<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const, Sexy::SharedImage> > >::erase[abi:cxx11](std::_Rb_tree_iterator<std::pair<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > const, Sexy::SharedImage> >) (this=<optimized out>, 
    __position=...) at /usr/include/c++/15.2.1/bits/stl_map.h:1128
--Type <RET> for more, q to quit, c to continue without paging--c
#5  Sexy::SexyAppBase::CleanSharedImages (this=0x55a76e715ac0)
    at /home/wszqkzqk/projects/PvZ-Portable/src/SexyAppFramework/SexyAppBase.cpp:6100
#6  0x000055a742be459a in Sexy::SexyApp::UpdateFrames (this=<optimized out>)
    at /home/wszqkzqk/projects/PvZ-Portable/src/SexyAppFramework/SexyApp.cpp:638
#7  0x000055a742b15341 in LawnApp::UpdateFrames (this=0x55a76e715ac0)
    at /home/wszqkzqk/projects/PvZ-Portable/src/LawnApp.cpp:1701
#8  0x000055a742be90a7 in Sexy::SexyAppBase::DoUpdateFrames (this=<optimized out>)
    at /home/wszqkzqk/projects/PvZ-Portable/src/SexyAppFramework/SexyAppBase.cpp:2403
#9  0x000055a742beaa03 in Sexy::SexyAppBase::Process (this=this@entry=0x55a76e715ac0, allowSleep=allowSleep@entry=true)
    at /home/wszqkzqk/projects/PvZ-Portable/src/SexyAppFramework/SexyAppBase.cpp:4329
#10 0x000055a742bead3f in Sexy::SexyAppBase::UpdateAppStep (this=this@entry=0x55a76e715ac0, updated=updated@entry=0x7ffe1c9255d7)
    at /home/wszqkzqk/projects/PvZ-Portable/src/SexyAppFramework/SexyAppBase.cpp:4542
#11 0x000055a742beae8c in Sexy::SexyAppBase::UpdateAppStep (this=0x55a76e715ac0, updated=0x7ffe1c9255d7)
    at /home/wszqkzqk/projects/PvZ-Portable/src/SexyAppFramework/SexyAppBase.cpp:4554
#12 Sexy::SexyAppBase::UpdateApp (this=0x55a76e715ac0)
    at /home/wszqkzqk/projects/PvZ-Portable/src/SexyAppFramework/SexyAppBase.cpp:4558
#13 0x000055a742bea12c in Sexy::SexyAppBase::DoMainLoop (this=<optimized out>)
    at /home/wszqkzqk/projects/PvZ-Portable/src/SexyAppFramework/SexyAppBase.cpp:4481
#14 Sexy::SexyAppBase::Start (this=0x55a76e715ac0)
    at /home/wszqkzqk/projects/PvZ-Portable/src/SexyAppFramework/SexyAppBase.cpp:4612
#15 Sexy::SexyAppBase::Start (this=0x55a76e715ac0)
    at /home/wszqkzqk/projects/PvZ-Portable/src/SexyAppFramework/SexyAppBase.cpp:4587
#16 0x000055a742cc9b3f in main (argc=1, argv=0x7ffe1c9257a8) at /home/wszqkzqk/projects/PvZ-Portable/src/main.cpp:34
```