### PR TITLE
Optimize image loading and resource path normalization in the image library and pak interface

### DIFF
--- a/src/SexyAppFramework/imagelib/ImageLib.cpp
+++ b/src/SexyAppFramework/imagelib/ImageLib.cpp
@@ -4,6 +4,10 @@
 #include "ImageLib.h"
 #include "png.h"
 #include <math.h>
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <string_view>
 #include "paklib/PakInterface.h"
 
 extern "C"
@@ -13,6 +17,7 @@ extern "C"
 }
 
 using namespace ImageLib;
+using namespace std::string_view_literals;
 
 Image::Image()
 {
@@ -1299,124 +1304,183 @@ static unsigned char *Rescale(int Width, int Height, int NewWidth, int NewHeight
 	return pTmpData;
 }
 
+using ImageLoader = Image* (*)(const std::string&);
+using ImageExtEntry = std::pair<std::string_view, ImageLoader>;
+static constexpr std::array<ImageExtEntry, 4> kImageExts = {
+	ImageExtEntry{ ".png"sv, GetPNGImage },
+	ImageExtEntry{ ".jpg"sv, GetJPEGImage },
+	ImageExtEntry{ ".gif"sv, GetGIFImage },
+	ImageExtEntry{ ".tga"sv, GetTGAImage },
+};
+
+static bool EqualsIgnoreCase(std::string_view theLeft, std::string_view theRight)
+{
+	if (theLeft.size() != theRight.size())
+		return false;
+
+	for (size_t i = 0; i < theLeft.size(); i++)
+	{
+		const unsigned char aLeftChar = static_cast<unsigned char>(theLeft[i]);
+		const unsigned char aRightChar = static_cast<unsigned char>(theRight[i]);
+		if (std::tolower(aLeftChar) != std::tolower(aRightChar))
+			return false;
+	}
+
+	return true;
+}
+
+static bool CheckSinglePath(std::string_view thePath)
+{
+	if (thePath.empty())
+		return false;
+
+	if (gPakInterface)
+	{
+		if (gPakInterface->mPakRecordMap.contains(PakInterface::NormalizePakPath(thePath)))
+			return true;
+	}
+
+	const std::string aPathString(thePath);
+	const std::filesystem::path aFilePath = Sexy::PathFromU8(aPathString);
+	if (!aFilePath.has_root_path())
+	{
+		const auto& aResourceBase = Sexy::GetResourceFolder();
+		if (!aResourceBase.empty())
+			return Sexy::FileExists(Sexy::GetResourcePath(aPathString));
+	}
+
+	return Sexy::FileExists(aPathString);
+}
+
+static bool FastFileExists(std::string_view thePath)
+{
+	if (thePath.empty())
+		return false;
+
+	const auto aFilePath = Sexy::PathFromU8(std::string(thePath));
+	if (aFilePath.has_extension())
+		return CheckSinglePath(thePath);
+
+	std::string aCandidate(thePath);
+	const auto aBaseLen = aCandidate.size();
+	for (const auto& [aExt, _] : kImageExts)
+	{
+		aCandidate.resize(aBaseLen);
+		aCandidate.append(aExt);
+		if (CheckSinglePath(aCandidate))
+			return true;
+	}
+
+	return false;
+}
+
+static Image* TryLoadByExt(const std::string& theBaseName, std::string_view theExt)
+{
+	for (const auto& [aKnownExt, aLoader] : kImageExts)
+	{
+		if (theExt.empty() || EqualsIgnoreCase(theExt, aKnownExt))
+		{
+			if (Image* aImage = aLoader(theBaseName + std::string(aKnownExt)))
+				return aImage;
+		}
+	}
+	return nullptr;
+}
+
+static void ComposeAlpha(Image* theImage, Image* theAlphaImage)
+{
+	if (theImage->mWidth != theAlphaImage->mWidth ||
+		theImage->mHeight != theAlphaImage->mHeight)
+		return;
+
+	uint32_t* aDstBits = theImage->mBits;
+	const uint32_t* aSrcBits = theAlphaImage->mBits;
+	const int aSize = theImage->mWidth * theImage->mHeight;
+
+	for (int i = 0; i < aSize; i++)
+		aDstBits[i] = (aDstBits[i] & 0x00FFFFFF) | ((aSrcBits[i] & 0xFF) << 24);
+}
+
+static void ApplyAlphaAsImage(Image* theImage, uint32_t theBaseColor)
+{
+	uint32_t* aBits = theImage->mBits;
+	const int aSize = theImage->mWidth * theImage->mHeight;
+
+	for (int i = 0; i < aSize; i++)
+		aBits[i] = theBaseColor | ((aBits[i] & 0xFF) << 24);
+}
+
 Image* ImageLib::GetImage(const std::string& theFilename, bool lookForAlphaImage)
 {
 	if (!gAutoLoadAlpha)
 		lookForAlphaImage = false;
 
-	int aLastDotPos = theFilename.rfind('.');
-	int aLastSlashPos = (int)theFilename.rfind('/');
+	const auto aLastSlashPos = theFilename.rfind('/');
+	const auto aLastDotPos = theFilename.rfind('.');
 
-	std::string anExt;
+	std::string_view anExt;
 	std::string aFilename;
 
-	if (aLastDotPos > aLastSlashPos)
+	if (aLastDotPos != std::string::npos &&
+		(aLastSlashPos == std::string::npos || aLastDotPos > aLastSlashPos))
 	{
-		anExt = theFilename.substr(aLastDotPos, theFilename.length() - aLastDotPos);
+		anExt = std::string_view(theFilename).substr(aLastDotPos);
 		aFilename = theFilename.substr(0, aLastDotPos);
 	}
 	else
 		aFilename = theFilename;
 
-	Image* anImage = nullptr;
+	// Load image, trying each supported format
+	Image* anImage = TryLoadByExt(aFilename, anExt);
 
-	if ((anImage == nullptr) && ((strcasecmp(anExt.c_str(), ".png") == 0) || (anExt.length() == 0)))
-		anImage = GetPNGImage(aFilename + ".png");
-
-	if ((anImage == nullptr) && ((strcasecmp(anExt.c_str(), ".jpg") == 0) || (anExt.length() == 0)))
-		anImage = GetJPEGImage(aFilename + ".jpg");
-
-	if ((anImage == nullptr) && ((strcasecmp(anExt.c_str(), ".gif") == 0) || (anExt.length() == 0)))
-		anImage = GetGIFImage(aFilename + ".gif");
-
-	if ((anImage == nullptr) && ((strcasecmp(anExt.c_str(), ".tga") == 0) || (anExt.length() == 0)))
-		anImage = GetTGAImage(aFilename + ".tga");
-
-	if ((anImage == nullptr) && (strcasecmp(anExt.c_str(), ".j2k") == 0))
-		unreachable(); // There are no JPEG2000 files in the project
-		//anImage = GetJPEG2000Image(aFilename + ".j2k");
-	if ((anImage == nullptr) && (strcasecmp(anExt.c_str(), ".jp2") == 0))
-		unreachable(); // There are no JPEG2000 files in the project
-		//anImage = GetJPEG2000Image(aFilename + ".jp2");
-
-
+	// Downscale only when configured to do so
+#if IMG_DOWNSCALE != 1
 	if (anImage)
 	{
-		int aNewWidth = anImage->mWidth/IMG_DOWNSCALE;
-		int aNewHeight = anImage->mHeight/IMG_DOWNSCALE;
+		const int aNewWidth = anImage->mWidth / IMG_DOWNSCALE;
+		const int aNewHeight = anImage->mHeight / IMG_DOWNSCALE;
 		if (aNewWidth > 0 && aNewHeight > 0)
 		{
-			unsigned char* aNewData = Rescale(anImage->mWidth, anImage->mHeight, aNewWidth, aNewHeight, (unsigned char*)anImage->mBits);
+			auto* aNewData = Rescale(anImage->mWidth, anImage->mHeight, aNewWidth, aNewHeight, (unsigned char*)anImage->mBits);
 			delete[] anImage->mBits;
 			anImage->mBits = (uint32_t*)aNewData;
 			anImage->mWidth = aNewWidth;
 			anImage->mHeight = aNewHeight;
 		}
 	}
+#endif
 
-	// Check for alpha images
+	// Probe alpha images with fast existence check
 	Image* anAlphaImage = nullptr;
-	if(lookForAlphaImage)
+	if (lookForAlphaImage)
 	{
-		// Check _ImageName
-		anAlphaImage = GetImage(theFilename.substr(0, aLastSlashPos+1) + "_" +
-			theFilename.substr(aLastSlashPos+1, theFilename.length() - aLastSlashPos - 1), false);
+		const auto slashEnd = (aLastSlashPos != std::string::npos) ? aLastSlashPos + 1 : 0;
+		const std::string alphaPath1 = theFilename.substr(0, slashEnd) + "_" +
+			theFilename.substr(slashEnd);
 
-		// Check ImageName_
-		if(anAlphaImage==nullptr)
-			anAlphaImage = GetImage(theFilename + "_", false);
+		if (FastFileExists(alphaPath1))
+			anAlphaImage = GetImage(alphaPath1, false);
+
+		if (!anAlphaImage)
+		{
+			const std::string alphaPath2 = theFilename + "_";
+			if (FastFileExists(alphaPath2))
+				anAlphaImage = GetImage(alphaPath2, false);
+		}
 	}
 
-
-
 	// Compose alpha channel with image
-	if (anAlphaImage != nullptr) 
+	if (anAlphaImage)
 	{
-		if (anImage != nullptr)
+		if (anImage)
 		{
-			if ((anImage->mWidth == anAlphaImage->mWidth) &&
-				(anImage->mHeight == anAlphaImage->mHeight))
-			{
-				uint32_t* aBits1 = anImage->mBits;
-				uint32_t* aBits2 = anAlphaImage->mBits;
-				int aSize = anImage->mWidth*anImage->mHeight;
-
-				for (int i = 0; i < aSize; i++)
-				{
-					*aBits1 = (*aBits1 & 0x00FFFFFF) | ((*aBits2 & 0xFF) << 24);
-					++aBits1;
-					++aBits2;
-				}
-			}
-
+			ComposeAlpha(anImage, anAlphaImage);
 			delete anAlphaImage;
-		}
-		else if (gAlphaComposeColor==0xFFFFFF)
-		{
-			anImage = anAlphaImage;
-
-			uint32_t* aBits1 = anImage->mBits;
-
-			int aSize = anImage->mWidth*anImage->mHeight;
-			for (int i = 0; i < aSize; i++)
-			{
-				*aBits1 = (0x00FFFFFF) | ((*aBits1 & 0xFF) << 24);
-				++aBits1;
-			}
 		}
 		else
 		{
-			const int aColor = gAlphaComposeColor;
 			anImage = anAlphaImage;
-
-			uint32_t* aBits1 = anImage->mBits;
-
-			int aSize = anImage->mWidth*anImage->mHeight;
-			for (int i = 0; i < aSize; i++)
-			{
-				*aBits1 = aColor | ((*aBits1 & 0xFF) << 24);
-				++aBits1;
-			}
+			ApplyAlphaAsImage(anImage, static_cast<uint32_t>(gAlphaComposeColor));
 		}
 	}
 

--- a/src/SexyAppFramework/imagelib/ImageLib.h
+++ b/src/SexyAppFramework/imagelib/ImageLib.h
@@ -1,6 +1,7 @@
 #ifndef __IMAGELIB_H__
 #define __IMAGELIB_H__
 
+#include <cstdint>
 #include <string>
 
 namespace ImageLib

--- a/src/SexyAppFramework/paklib/PakInterface.cpp
+++ b/src/SexyAppFramework/paklib/PakInterface.cpp
@@ -27,38 +27,38 @@ PakInterface::~PakInterface()
 }
 
 // Normalize path for pak lookup.
-static std::string NormalizePakPath(const char* theFileName)
+std::string PakInterface::NormalizePakPath(std::string_view theFileName)
 {
-	std::filesystem::path filePath = Sexy::PathFromU8(theFileName);
+	std::filesystem::path aFilePath = Sexy::PathFromU8(std::string(theFileName));
 
 	// Make absolute paths relative to resource folder.
-	if (filePath.is_absolute())
+	if (aFilePath.has_root_directory())
 	{
-		const std::string& resourceFolder = Sexy::GetResourceFolder();
-		if (!resourceFolder.empty())
+		const std::string& aResourceFolder = Sexy::GetResourceFolder();
+		if (!aResourceFolder.empty())
 		{
-			std::filesystem::path resPath = Sexy::PathFromU8(resourceFolder);
-			auto [resEnd, fileIt] = std::mismatch(resPath.begin(), resPath.end(), 
-			                                       filePath.begin(), filePath.end());
-			if (resEnd == resPath.end())
+			std::filesystem::path aResPath = Sexy::PathFromU8(aResourceFolder);
+			auto [aResEnd, aFileIt] = std::mismatch(aResPath.begin(), aResPath.end(), 
+			                                       aFilePath.begin(), aFilePath.end());
+			if (aResEnd == aResPath.end())
 			{
-				std::filesystem::path relativePath;
-				for (; fileIt != filePath.end(); ++fileIt)
-					relativePath /= *fileIt;
-				filePath = relativePath;
+				std::filesystem::path aRelativePath;
+				for (; aFileIt != aFilePath.end(); ++aFileIt)
+					aRelativePath /= *aFileIt;
+				aFilePath = aRelativePath;
 			}
 		}
 	}
 
-	std::string result = Sexy::PathToU8(filePath.lexically_normal());
+	std::string aResult = Sexy::PathToU8(aFilePath.lexically_normal());
 	
-	if (result.size() >= 2 && result[0] == '.' && result[1] == '/')
-		result = result.substr(2);
+	if (aResult.size() >= 2 && aResult[0] == '.' && aResult[1] == '/')
+		aResult = aResult.substr(2);
 	
-	std::transform(result.begin(), result.end(), result.begin(),
+	std::transform(aResult.begin(), aResult.end(), aResult.begin(),
 	               [](unsigned char c) { return std::toupper(c); });
 	
-	return result;
+	return aResult;
 }
 
 bool PakInterface::AddPakFile(const std::string& theFileName)
@@ -85,7 +85,7 @@ bool PakInterface::AddPakFile(const std::string& theFileName)
 	for (size_t i = 0; i < aFileSize; i++)
 		*aDataPtr++ ^= 0xF7;
 
-	std::string aPakKey = NormalizePakPath(theFileName.c_str());
+	std::string aPakKey = NormalizePakPath(theFileName);
 	auto aRecordItr = mPakRecordMap.emplace(aPakKey, PakRecord()).first;
 	PakRecord* aPakRecord = &aRecordItr->second;
 	aPakRecord->mCollection = aPakCollection;

--- a/src/SexyAppFramework/paklib/PakInterface.h
+++ b/src/SexyAppFramework/paklib/PakInterface.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <list>
 #include <string>
+#include <string_view>
 #include <cstdint>
 
 class PakCollection;
@@ -69,6 +70,8 @@ class PakInterface : public PakInterfaceBase
 public:
 	PakCollectionList		mPakCollectionList;		//+0x4：通过 AddPakFile() 添加的各个资源包的内存映射文件数据的链表
 	PakRecordMap			mPakRecordMap;			//+0x10：所有已添加的资源包中的所有资源文件的、从文件名到文件数据的映射容器
+
+	static std::string		NormalizePakPath(std::string_view theFileName);
 
 public:
 


### PR DESCRIPTION
This pull request refactors and improves image loading and resource path normalization in the image library and pak interface. The changes modernize the codebase by using C++17 features, simplify image format handling, and enhance alpha image support. Additionally, resource path normalization is made more robust and accessible.

**Image loading improvements:**

* Refactored image loading logic in `ImageLib.cpp` to use a new `TryLoadByExt` function with a constexpr array of supported extensions (`.png`, `.jpg`, `.gif`, `.tga`), replacing repetitive conditional logic and enabling case-insensitive extension matching.
* Added helper functions (`EqualsIgnoreCase`, `CheckSinglePath`, `FastFileExists`) to streamline file existence checks and extension handling for images.
* Improved alpha image handling by checking for alpha images only if they exist, and refactored alpha channel composition into dedicated helper functions (`ComposeAlpha`, `ApplyAlphaAsImage`).

**Resource path normalization and pak interface changes:**

* Promoted `NormalizePakPath` to a public static method of `PakInterface`, updated it to accept `std::string_view`, and improved its logic for handling absolute paths and case normalization. [[1]](diffhunk://#diff-f0043bfa618fa82e89574b80763f9b703e47fe3c4c5e78ec04893fe2b96cad31L30-R61) [[2]](diffhunk://#diff-5bebf2d1a99115cb79e80f49206fa0ade3c943ffe17a19573bba5eb374191788R74-R75) [[3]](diffhunk://#diff-5bebf2d1a99115cb79e80f49206fa0ade3c943ffe17a19573bba5eb374191788R7)
* Updated usage of `NormalizePakPath` throughout the pak interface to use the new signature and improved normalization logic.

**Modernization and code cleanup:**

* Included additional headers (`<algorithm>`, `<array>`, `<cctype>`, `<string_view>`) and adopted `std::string_view` and C++17 structured bindings for improved performance and readability. [[1]](diffhunk://#diff-831f68f6dea57f4d80e70c3ca81c4be4e44c6947e8f4592945e4eddc23ae3b92R7-R10) [[2]](diffhunk://#diff-831f68f6dea57f4d80e70c3ca81c4be4e44c6947e8f4592945e4eddc23ae3b92R20) [[3]](diffhunk://#diff-5bebf2d1a99115cb79e80f49206fa0ade3c943ffe17a19573bba5eb374191788R7)

These changes collectively make the codebase cleaner, more maintainable, and more robust in handling various image formats and resource paths.