### PR TITLE
Unify save cleanup; prevent premature save deletions

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -1740,8 +1740,6 @@ void Board::StartLevel()
 
 	if (mApp->IsSurvivalMode() && mChallenge->mSurvivalStage > 0)
 	{
-		mApp->EraseFile(GetSavedGameName(mApp->mGameMode, mApp->mPlayerInfo->mId));
-		mApp->EraseFile(GetLegacySavedGameName(mApp->mGameMode, mApp->mPlayerInfo->mId));
 		FreezeEffectsForCutscene(false);
 		mApp->mSoundSystem->GamePause(false);
 	}

--- a/src/Lawn/Widget/ContinueDialog.cpp
+++ b/src/Lawn/Widget/ContinueDialog.cpp
@@ -114,14 +114,6 @@ void ContinueDialog::ButtonDepress(int theId)
 {
     if (theId == ContinueDialog::ContinueDialog_Continue)
     {
-        if (mApp->mBoard->mNextSurvivalStageCounter != 1)
-        {
-            std::string aFileName = GetSavedGameName(mApp->mGameMode, mApp->mPlayerInfo->mId);
-            mApp->EraseFile(aFileName);
-            std::string aLegacyFileName = GetLegacySavedGameName(mApp->mGameMode, mApp->mPlayerInfo->mId);
-            mApp->EraseFile(aLegacyFileName);
-        }
-
         RestartLoopingSounds();
         mApp->KillDialog(mId);
     }

--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -316,6 +316,18 @@ void LawnApp::KillBoard()
 	KillSeedChooserScreen();
 	if (mBoard)
 	{
+		if (mPlayerInfo && (
+			mBoardResult == BoardResult::BOARDRESULT_WON ||
+			mBoardResult == BoardResult::BOARDRESULT_LOST ||
+			mBoardResult == BoardResult::BOARDRESULT_RESTART ||
+			mBoardResult == BoardResult::BOARDRESULT_CHEAT))
+		{
+			std::string aFileName = GetSavedGameName(mGameMode, mPlayerInfo->mId);
+			EraseFile(aFileName);
+			std::string aLegacyFileName = GetLegacySavedGameName(mGameMode, mPlayerInfo->mId);
+			EraseFile(aLegacyFileName);
+		}
+
 /*
 #ifdef _PVZ_DEBUG
 		BetaRecordLevelStats();
@@ -460,6 +472,7 @@ bool LawnApp::TryLoadGame()
 		if (mBoard->LoadGame(aSaveName))
 		{
 			mFirstTimeGameSelector = false;
+			mBoardResult = BoardResult::BOARDRESULT_NONE;
 			DoContinueDialog();
 			return true;
 		}
@@ -472,6 +485,7 @@ bool LawnApp::TryLoadGame()
 		if (mBoard->LoadGame(aLegacySaveName))
 		{
 			mFirstTimeGameSelector = false;
+			mBoardResult = BoardResult::BOARDRESULT_NONE;
 			DoContinueDialog();
 			return true;
 		}


### PR DESCRIPTION
Unify save cleanup; prevent premature save deletions

- Remove premature `EraseFile` calls that deleted saves during survival stage
  transitions and the Continue dialog (`Board::StartLevel`, `ContinueDialog`).
- Centralize save-file deletion in `LawnApp::KillBoard()` — delete only when the
  game definitively ends (`WON`, `LOST`, `RESTART`, `CHEAT`).
- Preserve saves for `QUIT`/`QUIT_APP`/`NONE` so users can return or recover.
- Reset `mBoardResult` to `BOARDRESULT_NONE` after loading a saved game to
  avoid stale state causing accidental deletion.

Rationale:
1. Stability (Priority): In the original game, saves are deleted immediately upon loading or starting a stage. If the game crashes mid-level, the user loses ALL progress. This change ensures saves persist until a definitive outcome is reached.
2. Trade-off: This intentionally deviates from the original "Anti-Save-Scumming" logic. Users can now force-quit to restart a wave. We accept this trade-off because preventing data loss from crashes is critical for a "Portable" version, whereas strict anti-cheat is secondary.

Verified typical flows: survival normal/endless stage transitions, cheat skips, quit-to-menu, and final win/lose behavior.
