### PR TITLE
Refactor rendering flags and update related code

### DIFF
--- a/src/Lawn/System/PoolEffect.cpp
+++ b/src/Lawn/System/PoolEffect.cpp
@@ -6,7 +6,6 @@
 #include "graphics/GLImage.h"
 #include "graphics/Graphics.h"
 #include "graphics/GLInterface.h"
-//#include "graphics/D3DInterface.h"
 
 //effect documentation by @windowslover1234
 
@@ -237,13 +236,9 @@ void PoolEffect::PoolEffectDraw(Sexy::Graphics* g, bool theIsNight)
     UpdateWaterEffect();
     //send something to OpenGL
     GLInterface* anInterface = ((GLImage*)g->mDestImage)->mGLInterface;
-    //anInterface->CheckDXError(anInterface->mD3DDevice->SetTextureStageState(0, D3DTEXTURESTAGESTATETYPE::D3DTSS_ADDRESSU, D3DTEXTUREADDRESS::D3DTADDRESS_WRAP), "DrawPool");
-    //anInterface->CheckDXError(anInterface->mD3DDevice->SetTextureStageState(0, D3DTEXTURESTAGESTATETYPE::D3DTSS_ADDRESSV, D3DTEXTUREADDRESS::D3DTADDRESS_WRAP), "DrawPool");
     
     //Send caustic effect tris to OpenGL (tex, verts, tris)
     g->DrawTrianglesTex(mCausticImage, aVertArray[2], 150);
-    //anInterface->CheckDXError(anInterface->mD3DDevice->SetTextureStageState(0, D3DTEXTURESTAGESTATETYPE::D3DTSS_ADDRESSU, D3DTEXTUREADDRESS::D3DTADDRESS_CLAMP), "DrawPool");
-    //anInterface->CheckDXError(anInterface->mD3DDevice->SetTextureStageState(0, D3DTEXTURESTAGESTATETYPE::D3DTSS_ADDRESSV, D3DTEXTUREADDRESS::D3DTADDRESS_CLAMP), "DrawPool");
 }
 
 void PoolEffect::PoolEffectUpdate()

--- a/src/Sexy.TodLib/TodCommon.cpp
+++ b/src/Sexy.TodLib/TodCommon.cpp
@@ -692,18 +692,18 @@ void SexyMatrix3ExtractScale(const SexyMatrix3& m, float& theScaleX, float& theS
 
 void TodMarkImageForSanding(Image* theImage)
 {
-	((MemoryImage*)theImage)->mD3DFlags |= D3DIMAGEFLAG_SANDING;
+	((MemoryImage*)theImage)->mRenderFlags |= RENDERIMAGEFLAG_SANDING;
 }
 
 void TodSandImageIfNeeded(Image* theImage)
 {
 	MemoryImage* aImage = (MemoryImage*)theImage;
-	/*if (TestBit(aImage->mD3DFlags, D3DIMAGEFLAG_SANDING))*/ // UB shift by a billion
-	if (aImage->mD3DFlags & D3DIMAGEFLAG_SANDING)
+	/*if (TestBit(aImage->mRenderFlags, RENDERIMAGEFLAG_SANDING))*/ // UB shift by a billion
+	if (aImage->mRenderFlags & RENDERIMAGEFLAG_SANDING)
 	{
 		FixPixelsOnAlphaEdgeForBlending(theImage);
-		((MemoryImage*)theImage)->mD3DFlags &= ~D3DIMAGEFLAG_SANDING; // Unset the sanding flag
-		//SetBit((unsigned int&)aImage->mD3DFlags, D3DIMAGEFLAG_SANDING, false);  // 清除标记 Also UB!?!
+		((MemoryImage*)theImage)->mRenderFlags &= ~RENDERIMAGEFLAG_SANDING; // Unset the sanding flag
+		//SetBit((unsigned int&)aImage->mRenderFlags, RENDERIMAGEFLAG_SANDING, false);  // 清除标记 Also UB!?!
 	}
 }
 

--- a/src/Sexy.TodLib/TodCommon.h
+++ b/src/Sexy.TodLib/TodCommon.h
@@ -17,7 +17,7 @@ namespace Sexy
 //using namespace std;
 using namespace Sexy;
 
-#define D3DIMAGEFLAG_SANDING 0x1000
+#define RENDERIMAGEFLAG_SANDING 0x1000
 #define DEG_TO_RAD(deg) ((deg) * 0.017453292f)
 #define RAD_TO_DEG(rad) ((rad) * 57.29578f)
 

--- a/src/Sexy.TodLib/TodParticle.cpp
+++ b/src/Sexy.TodLib/TodParticle.cpp
@@ -174,7 +174,7 @@ bool TodParticleLoadADef(TodParticleDefinition* theParticleDef, const char* theP
 			FloatTrackSetDefault(aDef.mClipRight, 0.0f);
 			FloatTrackSetDefault(aDef.mAnimationRate, 0.0f);
 			if (aDef.mImage)
-				reinterpret_cast<MemoryImage*>(aDef.mImage)->mD3DFlags |= D3DImageFlags::D3DImageFlag_MinimizeNumSubdivisions;
+				reinterpret_cast<MemoryImage*>(aDef.mImage)->mRenderFlags |= RenderImageFlags::RenderImageFlag_MinimizeNumSubdivisions;
 		}
 		return true;
 	}

--- a/src/SexyAppFramework/SexyAppBase.h
+++ b/src/SexyAppFramework/SexyAppBase.h
@@ -19,7 +19,7 @@ extern HMODULE gDDrawDLL;
 extern HMODULE gDSoundDLL;
 extern HMODULE gVersionDLL;
 
-extern bool gD3DInterfacePreDrawError;
+extern bool gRenderInterfacePreDrawError;
 */
 
 namespace ImageLib

--- a/src/SexyAppFramework/graphics/MemoryImage.cpp
+++ b/src/SexyAppFramework/graphics/MemoryImage.cpp
@@ -34,8 +34,8 @@ MemoryImage::MemoryImage(SexyAppBase* theApp)
 MemoryImage::MemoryImage(const MemoryImage& theMemoryImage) :
 	Image(theMemoryImage),
 	mBitsChangedCount(theMemoryImage.mBitsChangedCount),
-	mD3DData(nullptr),
-	mD3DFlags(theMemoryImage.mD3DFlags),
+	mRenderData(nullptr),
+	mRenderFlags(theMemoryImage.mRenderFlags),
 	mHasTrans(theMemoryImage.mHasTrans),
 	mHasAlpha(theMemoryImage.mHasAlpha),
 	mIsVolatile(theMemoryImage.mIsVolatile),
@@ -149,8 +149,8 @@ void MemoryImage::Init()
 	mForcedMode = false;
 	mIsVolatile = false;
 
-	mD3DData = nullptr;
-	mD3DFlags = 0;
+	mRenderData = nullptr;
+	mRenderFlags = 0;
 	mBitsChangedCount = 0;
 
 	mPurgeBits = false;
@@ -1106,9 +1106,9 @@ void MemoryImage::PurgeBits()
 
 	if (mApp->Is3DAccelerated())
 	{
-		// Due to potential D3D threading issues we have to defer the texture creation
+		// Due to potential render backend threading issues we have to defer the texture creation
 		//  and therefore the actual purging
-		if (mD3DData == nullptr)
+		if (mRenderData == nullptr)
 			return;
 	}
 	else
@@ -1122,7 +1122,7 @@ void MemoryImage::PurgeBits()
 	delete [] mBits;
 	mBits = nullptr;
 	
-	if (mD3DData != nullptr)
+	if (mRenderData != nullptr)
 	{
 		delete [] mColorIndices;
 		mColorIndices = nullptr;
@@ -1273,7 +1273,7 @@ uint32_t* MemoryImage::GetBits()
 				*(aDestPtr++) = (r << 16) | (g << 8) | (b) | (anAlpha << 24);
 			}
 		}
-		else if ((mD3DData == nullptr) || (!mApp->mGLInterface->RecoverBits(this)))
+		else if ((mRenderData == nullptr) || (!mApp->mGLInterface->RecoverBits(this)))
 		{
 			memset(mBits, 0, aSize*sizeof(uint32_t));
 		}

--- a/src/SexyAppFramework/graphics/MemoryImage.h
+++ b/src/SexyAppFramework/graphics/MemoryImage.h
@@ -21,8 +21,8 @@ class MemoryImage : public Image
 public:
 	uint32_t*				mBits;
 	int						mBitsChangedCount;
-	void*					mD3DData;
-	uint32_t					mD3DFlags;	// see D3DInterface.h for possible values
+	void*					mRenderData;
+	uint32_t				mRenderFlags;	// see GLInterface.h for possible values
 
 	uint32_t*				mColorTable;	
 	uchar*					mColorIndices;

--- a/src/SexyAppFramework/misc/ResourceManager.cpp
+++ b/src/SexyAppFramework/misc/ResourceManager.cpp
@@ -759,13 +759,13 @@ bool ResourceManager::DoLoadImage(ImageRes *theRes)
 	}	
 
 	if (theRes->mA4R4G4B4)
-		aGLImage->mD3DFlags |= D3DImageFlag_UseA4R4G4B4;
+		aGLImage->mRenderFlags |= RenderImageFlag_UseA4R4G4B4;
 
 	if (theRes->mA8R8G8B8)
-		aGLImage->mD3DFlags |= D3DImageFlag_UseA8R8G8B8;
+		aGLImage->mRenderFlags |= RenderImageFlag_UseA8R8G8B8;
 
 	if (theRes->mMinimizeSubdivisions)
-		aGLImage->mD3DFlags |= D3DImageFlag_MinimizeNumSubdivisions;
+		aGLImage->mRenderFlags |= RenderImageFlag_MinimizeNumSubdivisions;
 
 	if (theRes->mAnimInfo.mAnimType != AnimType_None)
 		aGLImage->mAnimInfo = new AnimInfo(theRes->mAnimInfo);

--- a/src/SexyAppFramework/platform/3ds/graphics/GLInterface.cpp
+++ b/src/SexyAppFramework/platform/3ds/graphics/GLInterface.cpp
@@ -562,8 +562,8 @@ static bool IsPowerOf2(int theNum)
 ///////////////////////////////////////////////////////////////////////////////
 static void GetBestTextureDimensions(int &theWidth, int &theHeight, bool isEdge, bool usePow2, uint32_t theImageFlags)
 {
-//	theImageFlags = D3DImageFlag_MinimizeNumSubdivisions;
-	if (theImageFlags & D3DImageFlag_Use64By64Subdivisions)
+//	theImageFlags = RenderImageFlag_MinimizeNumSubdivisions;
+	if (theImageFlags & RenderImageFlag_Use64By64Subdivisions)
 	{
 		theWidth = theHeight = 64;
 		return;
@@ -603,7 +603,7 @@ static void GetBestTextureDimensions(int &theWidth, int &theHeight, bool isEdge,
 
 	if (usePow2)
 	{
-		if (isEdge || (theImageFlags & D3DImageFlag_MinimizeNumSubdivisions))
+		if (isEdge || (theImageFlags & RenderImageFlag_MinimizeNumSubdivisions))
 		{
 			aWidth = aWidth >= gMaxTextureWidth ? gMaxTextureWidth : GetClosestPowerOf2Above(aWidth);
 			aHeight = aHeight >= gMaxTextureHeight ? gMaxTextureHeight : GetClosestPowerOf2Above(aHeight);
@@ -746,12 +746,12 @@ void TextureData::CreateTextures(MemoryImage *theImage)
 
 	// Choose appropriate pixel format
 	PixelFormat aFormat = PixelFormat_A8R8G8B8;
-	//theImage->mD3DFlags = D3DImageFlag_UseA4R4G4B4;
+	//theImage->mRenderFlags = RenderImageFlag_UseA4R4G4B4;
 
 	theImage->CommitBits();
 	if (!theImage->mHasAlpha && !theImage->mHasTrans && (gSupportedPixelFormats & PixelFormat_R5G6B5))
 	{
-		if (!(theImage->mD3DFlags & D3DImageFlag_UseA8R8G8B8))
+		if (!(theImage->mRenderFlags & RenderImageFlag_UseA8R8G8B8))
 			aFormat = PixelFormat_R5G6B5;
 	}
 
@@ -759,7 +759,7 @@ void TextureData::CreateTextures(MemoryImage *theImage)
 	{
 	}
 
-	if ((theImage->mD3DFlags & D3DImageFlag_UseA4R4G4B4) && aFormat==PixelFormat_A8R8G8B8 && (gSupportedPixelFormats & PixelFormat_A4R4G4B4))
+	if ((theImage->mRenderFlags & RenderImageFlag_UseA4R4G4B4) && aFormat==PixelFormat_A8R8G8B8 && (gSupportedPixelFormats & PixelFormat_A4R4G4B4))
 		aFormat = PixelFormat_A4R4G4B4;
 
 	if (aFormat==PixelFormat_A8R8G8B8 && !(gSupportedPixelFormats & PixelFormat_A8R8G8B8))
@@ -767,12 +767,12 @@ void TextureData::CreateTextures(MemoryImage *theImage)
 
 	// Release texture if image size has changed
 	bool createTextures = false;
-	if (mWidth!=theImage->mWidth || mHeight!=theImage->mHeight || aFormat!=mPixelFormat || theImage->mD3DFlags!=mImageFlags)
+	if (mWidth!=theImage->mWidth || mHeight!=theImage->mHeight || aFormat!=mPixelFormat || theImage->mRenderFlags!=mImageFlags)
 	{
 		ReleaseTextures();
 
 		mPixelFormat = aFormat;
-		mImageFlags = theImage->mD3DFlags;
+		mImageFlags = theImage->mRenderFlags;
 		CreateTextureDimensions(theImage);
 		createTextures = true;
 	}
@@ -821,7 +821,7 @@ void TextureData::CreateTextures(MemoryImage *theImage)
 ///////////////////////////////////////////////////////////////////////////////
 void TextureData::CheckCreateTextures(MemoryImage *theImage)
 {
-	if(mPixelFormat==PixelFormat_Unknown || theImage->mWidth != mWidth || theImage->mHeight != mHeight || theImage->mBitsChangedCount != mBitsChangedCount || theImage->mD3DFlags != mImageFlags)
+	if(mPixelFormat==PixelFormat_Unknown || theImage->mWidth != mWidth || theImage->mHeight != mHeight || theImage->mBitsChangedCount != mBitsChangedCount || theImage->mRenderFlags != mImageFlags)
 		CreateTextures(theImage);
 }
 
@@ -1315,8 +1315,8 @@ GLInterface::~GLInterface()
 	for(anItr = mImageSet.begin(); anItr != mImageSet.end(); ++anItr)
 	{
 		MemoryImage *anImage = *anItr;
-		delete (TextureData*)anImage->mD3DData;
-		anImage->mD3DData = nullptr;
+		delete (TextureData*)anImage->mRenderData;
+		anImage->mRenderData = nullptr;
 	}
 
 	delete[] gVertices;
@@ -1352,10 +1352,10 @@ void GLInterface::RemoveGLImage(GLImage* theGLImage)
 
 void GLInterface::Remove3DData(MemoryImage* theImage)
 {
-	if (theImage->mD3DData != nullptr)
+	if (theImage->mRenderData != nullptr)
 	{
-		delete (TextureData*)theImage->mD3DData;
-		theImage->mD3DData = nullptr;
+		delete (TextureData*)theImage->mRenderData;
+		theImage->mRenderData = nullptr;
 
 		std::scoped_lock aCrit(mCritSect); // Make images thread safe
 		mImageSet.erase(theImage);
@@ -1513,9 +1513,9 @@ bool GLInterface::CreateImageTexture(MemoryImage *theImage)
 {
 	bool wantPurge = false;
 
-	if(theImage->mD3DData==nullptr)
+	if(theImage->mRenderData==nullptr)
 	{
-		theImage->mD3DData = new TextureData();
+		theImage->mRenderData = new TextureData();
 		
 		// The actual purging was deferred
 		wantPurge = theImage->mPurgeBits;
@@ -1524,7 +1524,7 @@ bool GLInterface::CreateImageTexture(MemoryImage *theImage)
 		mImageSet.insert(theImage);
 	}
 
-	TextureData *aData = (TextureData*)theImage->mD3DData;
+	TextureData *aData = (TextureData*)theImage->mRenderData;
 	aData->CheckCreateTextures(theImage);
 
 	if (wantPurge)
@@ -1535,10 +1535,10 @@ bool GLInterface::CreateImageTexture(MemoryImage *theImage)
 
 bool GLInterface::RecoverBits(MemoryImage* theImage)
 {
-	if (theImage->mD3DData == nullptr)
+	if (theImage->mRenderData == nullptr)
 		return false;
 
-	TextureData* aData = (TextureData*) theImage->mD3DData;
+	TextureData* aData = (TextureData*) theImage->mRenderData;
 	if (aData->mBitsChangedCount != theImage->mBitsChangedCount) // bits have changed since texture was created
 		return false;
 
@@ -1601,7 +1601,7 @@ void GLInterface::Blt(Image* theImage, float theX, float theY, const Rect& theSr
 
 	SetDrawMode(theDrawMode);
 
-	TextureData *aData = (TextureData*)aSrcMemoryImage->mD3DData;
+	TextureData *aData = (TextureData*)aSrcMemoryImage->mRenderData;
 
 	SetLinearFilter(linearFilter);
 	aData->Blt(theX,theY,theSrcRect,theColor);
@@ -1667,7 +1667,7 @@ void GLInterface::BltTransformed(Image* theImage, const Rect* theClipRect, const
 
 	SetDrawMode(theDrawMode);
 
-	TextureData *aData = (TextureData*)aSrcMemoryImage->mD3DData;
+	TextureData *aData = (TextureData*)aSrcMemoryImage->mRenderData;
 
 	if (!mTransformStack.empty())
 	{
@@ -1822,7 +1822,7 @@ void GLInterface::DrawTrianglesTex(const TriVertex theVertices[][3], int theNumT
 
 	SetDrawMode(theDrawMode);
 
-	TextureData *aData = (TextureData*)aSrcMemoryImage->mD3DData;
+	TextureData *aData = (TextureData*)aSrcMemoryImage->mRenderData;
 
 	SetLinearFilter(blend);
 

--- a/src/SexyAppFramework/platform/3ds/graphics/GLInterface.h
+++ b/src/SexyAppFramework/platform/3ds/graphics/GLInterface.h
@@ -21,12 +21,12 @@ class TriVertex;
 
 typedef std::set<GLImage*> GLImageSet;
 
-enum D3DImageFlags 
+enum RenderImageFlags 
 {
-	D3DImageFlag_MinimizeNumSubdivisions	=			0x0001,		// subdivide image into fewest possible textures (may use more memory)
-	D3DImageFlag_Use64By64Subdivisions		=			0x0002,		// good to use with image strips so the entire texture isn't pulled in when drawing just a piece
-	D3DImageFlag_UseA4R4G4B4				=			0x0004,		// images with not too many color gradients work well in this format
-	D3DImageFlag_UseA8R8G8B8				=			0x0008		// non-alpha images will be stored as R5G6B5 by default so use this option if you want a 32-bit non-alpha image
+	RenderImageFlag_MinimizeNumSubdivisions	=			0x0001,		// subdivide image into fewest possible textures (may use more memory)
+	RenderImageFlag_Use64By64Subdivisions	=			0x0002,		// good to use with image strips so the entire texture isn't pulled in when drawing just a piece
+	RenderImageFlag_UseA4R4G4B4				=			0x0004,		// images with not too many color gradients work well in this format
+	RenderImageFlag_UseA8R8G8B8				=			0x0008		// non-alpha images will be stored as R5G6B5 by default so use this option if you want a 32-bit non-alpha image
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/SexyAppFramework/platform/pc/graphics/GLInterface.cpp
+++ b/src/SexyAppFramework/platform/pc/graphics/GLInterface.cpp
@@ -406,8 +406,8 @@ static bool IsPowerOf2(int theNum)
 ///////////////////////////////////////////////////////////////////////////////
 static void GetBestTextureDimensions(int &theWidth, int &theHeight, bool isEdge, bool usePow2, uint32_t theImageFlags)
 {
-//	theImageFlags = D3DImageFlag_MinimizeNumSubdivisions;
-	if (theImageFlags & D3DImageFlag_Use64By64Subdivisions)
+//	theImageFlags = RenderImageFlag_MinimizeNumSubdivisions;
+	if (theImageFlags & RenderImageFlag_Use64By64Subdivisions)
 	{
 		theWidth = theHeight = 64;
 		return;
@@ -449,7 +449,7 @@ static void GetBestTextureDimensions(int &theWidth, int &theHeight, bool isEdge,
 
 	if (usePow2)
 	{
-		if (isEdge || (theImageFlags & D3DImageFlag_MinimizeNumSubdivisions))
+		if (isEdge || (theImageFlags & RenderImageFlag_MinimizeNumSubdivisions))
 		{
 			aWidth = aWidth >= gMaxTextureWidth ? gMaxTextureWidth : GetClosestPowerOf2Above(aWidth);
 			aHeight = aHeight >= gMaxTextureHeight ? gMaxTextureHeight : GetClosestPowerOf2Above(aHeight);
@@ -593,12 +593,12 @@ void TextureData::CreateTextures(MemoryImage *theImage)
 
 	// Choose appropriate pixel format
 	PixelFormat aFormat = PixelFormat_A8R8G8B8;
-	//theImage->mD3DFlags = D3DImageFlag_UseA4R4G4B4;
+	//theImage->mRenderFlags = RenderImageFlag_UseA4R4G4B4;
 
 	theImage->CommitBits();
 	if (!theImage->mHasAlpha && !theImage->mHasTrans && (gSupportedPixelFormats & PixelFormat_R5G6B5))
 	{
-		if (!(theImage->mD3DFlags & D3DImageFlag_UseA8R8G8B8))
+		if (!(theImage->mRenderFlags & RenderImageFlag_UseA8R8G8B8))
 			aFormat = PixelFormat_R5G6B5;
 	}
 
@@ -606,7 +606,7 @@ void TextureData::CreateTextures(MemoryImage *theImage)
 	{
 	}
 
-	if ((theImage->mD3DFlags & D3DImageFlag_UseA4R4G4B4) && aFormat==PixelFormat_A8R8G8B8 && (gSupportedPixelFormats & PixelFormat_A4R4G4B4))
+	if ((theImage->mRenderFlags & RenderImageFlag_UseA4R4G4B4) && aFormat==PixelFormat_A8R8G8B8 && (gSupportedPixelFormats & PixelFormat_A4R4G4B4))
 		aFormat = PixelFormat_A4R4G4B4;
 
 	if (aFormat==PixelFormat_A8R8G8B8 && !(gSupportedPixelFormats & PixelFormat_A8R8G8B8))
@@ -614,12 +614,12 @@ void TextureData::CreateTextures(MemoryImage *theImage)
 
 	// Release texture if image size has changed
 	bool createTextures = false;
-	if (mWidth!=theImage->mWidth || mHeight!=theImage->mHeight || aFormat!=mPixelFormat || theImage->mD3DFlags!=mImageFlags)
+	if (mWidth!=theImage->mWidth || mHeight!=theImage->mHeight || aFormat!=mPixelFormat || theImage->mRenderFlags!=mImageFlags)
 	{
 		ReleaseTextures();
 
 		mPixelFormat = aFormat;
-		mImageFlags = theImage->mD3DFlags;
+		mImageFlags = theImage->mRenderFlags;
 		CreateTextureDimensions(theImage);
 		createTextures = true;
 	}
@@ -662,7 +662,7 @@ void TextureData::CreateTextures(MemoryImage *theImage)
 ///////////////////////////////////////////////////////////////////////////////
 void TextureData::CheckCreateTextures(MemoryImage *theImage)
 {
-	if(mPixelFormat==PixelFormat_Unknown || theImage->mWidth != mWidth || theImage->mHeight != mHeight || theImage->mBitsChangedCount != mBitsChangedCount || theImage->mD3DFlags != mImageFlags)
+	if(mPixelFormat==PixelFormat_Unknown || theImage->mWidth != mWidth || theImage->mHeight != mHeight || theImage->mBitsChangedCount != mBitsChangedCount || theImage->mRenderFlags != mImageFlags)
 		CreateTextures(theImage);
 }
 
@@ -1188,8 +1188,8 @@ GLInterface::~GLInterface()
 	for(anItr = mImageSet.begin(); anItr != mImageSet.end(); ++anItr)
 	{
 		MemoryImage *anImage = *anItr;
-		delete (TextureData*)anImage->mD3DData;
-		anImage->mD3DData = nullptr;
+		delete (TextureData*)anImage->mRenderData;
+		anImage->mRenderData = nullptr;
 	}
 
 	delete[] gVertices;
@@ -1225,10 +1225,10 @@ void GLInterface::RemoveGLImage(GLImage* theGLImage)
 
 void GLInterface::Remove3DData(MemoryImage* theImage)
 {
-	if (theImage->mD3DData != nullptr)
+	if (theImage->mRenderData != nullptr)
 	{
-		delete (TextureData*)theImage->mD3DData;
-		theImage->mD3DData = nullptr;
+		delete (TextureData*)theImage->mRenderData;
+		theImage->mRenderData = nullptr;
 
 		std::scoped_lock aCrit(mCritSect); // Make images thread safe
 		mImageSet.erase(theImage);
@@ -1373,9 +1373,9 @@ bool GLInterface::CreateImageTexture(MemoryImage *theImage)
 {
 	bool wantPurge = false;
 
-	if(theImage->mD3DData==nullptr)
+	if(theImage->mRenderData==nullptr)
 	{
-		theImage->mD3DData = new TextureData();
+		theImage->mRenderData = new TextureData();
 		
 		// The actual purging was deferred
 		wantPurge = theImage->mPurgeBits;
@@ -1384,7 +1384,7 @@ bool GLInterface::CreateImageTexture(MemoryImage *theImage)
 		mImageSet.insert(theImage);
 	}
 
-	TextureData *aData = (TextureData*)theImage->mD3DData;
+	TextureData *aData = (TextureData*)theImage->mRenderData;
 	aData->CheckCreateTextures(theImage);
 	
 	if (wantPurge)
@@ -1395,10 +1395,10 @@ bool GLInterface::CreateImageTexture(MemoryImage *theImage)
 
 bool GLInterface::RecoverBits(MemoryImage* theImage)
 {
-	if (theImage->mD3DData == nullptr)
+	if (theImage->mRenderData == nullptr)
 		return false;
 
-	TextureData* aData = (TextureData*) theImage->mD3DData;
+	TextureData* aData = (TextureData*) theImage->mRenderData;
 	if (aData->mBitsChangedCount != theImage->mBitsChangedCount) // bits have changed since texture was created
 		return false;
 
@@ -1460,7 +1460,7 @@ void GLInterface::Blt(Image* theImage, float theX, float theY, const Rect& theSr
 
 	SetDrawMode(theDrawMode);
 
-	TextureData *aData = (TextureData*)aSrcMemoryImage->mD3DData;
+	TextureData *aData = (TextureData*)aSrcMemoryImage->mRenderData;
 
 	SetLinearFilter(linearFilter);
 	aData->Blt(theX,theY,theSrcRect,theColor);
@@ -1526,7 +1526,7 @@ void GLInterface::BltTransformed(Image* theImage, const Rect* theClipRect, const
 
 	SetDrawMode(theDrawMode);
 
-	TextureData *aData = (TextureData*)aSrcMemoryImage->mD3DData;
+	TextureData *aData = (TextureData*)aSrcMemoryImage->mRenderData;
 
 	if (!mTransformStack.empty())
 	{
@@ -1681,7 +1681,7 @@ void GLInterface::DrawTrianglesTex(const TriVertex theVertices[][3], int theNumT
 
 	SetDrawMode(theDrawMode);
 
-	TextureData *aData = (TextureData*)aSrcMemoryImage->mD3DData;
+	TextureData *aData = (TextureData*)aSrcMemoryImage->mRenderData;
 
 	SetLinearFilter(blend);
 

--- a/src/SexyAppFramework/platform/pc/graphics/GLInterface.h
+++ b/src/SexyAppFramework/platform/pc/graphics/GLInterface.h
@@ -26,12 +26,12 @@ class TriVertex;
 
 typedef std::set<GLImage*> GLImageSet;
 
-enum D3DImageFlags 
+enum RenderImageFlags 
 {
-	D3DImageFlag_MinimizeNumSubdivisions	=			0x0001,		// subdivide image into fewest possible textures (may use more memory)
-	D3DImageFlag_Use64By64Subdivisions		=			0x0002,		// good to use with image strips so the entire texture isn't pulled in when drawing just a piece
-	D3DImageFlag_UseA4R4G4B4				=			0x0004,		// images with not too many color gradients work well in this format
-	D3DImageFlag_UseA8R8G8B8				=			0x0008		// non-alpha images will be stored as R5G6B5 by default so use this option if you want a 32-bit non-alpha image
+	RenderImageFlag_MinimizeNumSubdivisions	=			0x0001,		// subdivide image into fewest possible textures (may use more memory)
+	RenderImageFlag_Use64By64Subdivisions	=			0x0002,		// good to use with image strips so the entire texture isn't pulled in when drawing just a piece
+	RenderImageFlag_UseA4R4G4B4				=			0x0004,		// images with not too many color gradients work well in this format
+	RenderImageFlag_UseA8R8G8B8				=			0x0008		// non-alpha images will be stored as R5G6B5 by default so use this option if you want a 32-bit non-alpha image
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/SexyAppFramework/platform/switch/graphics/GLInterface.cpp
+++ b/src/SexyAppFramework/platform/switch/graphics/GLInterface.cpp
@@ -498,8 +498,8 @@ static bool IsPowerOf2(int theNum)
 ///////////////////////////////////////////////////////////////////////////////
 static void GetBestTextureDimensions(int &theWidth, int &theHeight, bool isEdge, bool usePow2, uint32_t theImageFlags)
 {
-//	theImageFlags = D3DImageFlag_MinimizeNumSubdivisions;
-	if (theImageFlags & D3DImageFlag_Use64By64Subdivisions)
+//	theImageFlags = RenderImageFlag_MinimizeNumSubdivisions;
+	if (theImageFlags & RenderImageFlag_Use64By64Subdivisions)
 	{
 		theWidth = theHeight = 64;
 		return;
@@ -541,7 +541,7 @@ static void GetBestTextureDimensions(int &theWidth, int &theHeight, bool isEdge,
 
 	if (usePow2)
 	{
-		if (isEdge || (theImageFlags & D3DImageFlag_MinimizeNumSubdivisions))
+		if (isEdge || (theImageFlags & RenderImageFlag_MinimizeNumSubdivisions))
 		{
 			aWidth = aWidth >= gMaxTextureWidth ? gMaxTextureWidth : GetClosestPowerOf2Above(aWidth);
 			aHeight = aHeight >= gMaxTextureHeight ? gMaxTextureHeight : GetClosestPowerOf2Above(aHeight);
@@ -685,12 +685,12 @@ void TextureData::CreateTextures(MemoryImage *theImage)
 
 	// Choose appropriate pixel format
 	PixelFormat aFormat = PixelFormat_A8R8G8B8;
-	//theImage->mD3DFlags = D3DImageFlag_UseA4R4G4B4;
+	//theImage->mRenderFlags = RenderImageFlag_UseA4R4G4B4;
 
 	theImage->CommitBits();
 	if (!theImage->mHasAlpha && !theImage->mHasTrans && (gSupportedPixelFormats & PixelFormat_R5G6B5))
 	{
-		if (!(theImage->mD3DFlags & D3DImageFlag_UseA8R8G8B8))
+		if (!(theImage->mRenderFlags & RenderImageFlag_UseA8R8G8B8))
 			aFormat = PixelFormat_R5G6B5;
 	}
 
@@ -698,7 +698,7 @@ void TextureData::CreateTextures(MemoryImage *theImage)
 	{
 	}
 
-	if ((theImage->mD3DFlags & D3DImageFlag_UseA4R4G4B4) && aFormat==PixelFormat_A8R8G8B8 && (gSupportedPixelFormats & PixelFormat_A4R4G4B4))
+	if ((theImage->mRenderFlags & RenderImageFlag_UseA4R4G4B4) && aFormat==PixelFormat_A8R8G8B8 && (gSupportedPixelFormats & PixelFormat_A4R4G4B4))
 		aFormat = PixelFormat_A4R4G4B4;
 
 	if (aFormat==PixelFormat_A8R8G8B8 && !(gSupportedPixelFormats & PixelFormat_A8R8G8B8))
@@ -706,12 +706,12 @@ void TextureData::CreateTextures(MemoryImage *theImage)
 
 	// Release texture if image size has changed
 	bool createTextures = false;
-	if (mWidth!=theImage->mWidth || mHeight!=theImage->mHeight || aFormat!=mPixelFormat || theImage->mD3DFlags!=mImageFlags)
+	if (mWidth!=theImage->mWidth || mHeight!=theImage->mHeight || aFormat!=mPixelFormat || theImage->mRenderFlags!=mImageFlags)
 	{
 		ReleaseTextures();
 
 		mPixelFormat = aFormat;
-		mImageFlags = theImage->mD3DFlags;
+		mImageFlags = theImage->mRenderFlags;
 		CreateTextureDimensions(theImage);
 		createTextures = true;
 	}
@@ -754,7 +754,7 @@ void TextureData::CreateTextures(MemoryImage *theImage)
 ///////////////////////////////////////////////////////////////////////////////
 void TextureData::CheckCreateTextures(MemoryImage *theImage)
 {
-	if(mPixelFormat==PixelFormat_Unknown || theImage->mWidth != mWidth || theImage->mHeight != mHeight || theImage->mBitsChangedCount != mBitsChangedCount || theImage->mD3DFlags != mImageFlags)
+	if(mPixelFormat==PixelFormat_Unknown || theImage->mWidth != mWidth || theImage->mHeight != mHeight || theImage->mBitsChangedCount != mBitsChangedCount || theImage->mRenderFlags != mImageFlags)
 		CreateTextures(theImage);
 }
 
@@ -1263,8 +1263,8 @@ GLInterface::~GLInterface()
 	for(anItr = mImageSet.begin(); anItr != mImageSet.end(); ++anItr)
 	{
 		MemoryImage *anImage = *anItr;
-		delete (TextureData*)anImage->mD3DData;
-		anImage->mD3DData = nullptr;
+		delete (TextureData*)anImage->mRenderData;
+		anImage->mRenderData = nullptr;
 	}
 
 	delete[] gVertices;
@@ -1300,10 +1300,10 @@ void GLInterface::RemoveGLImage(GLImage* theGLImage)
 
 void GLInterface::Remove3DData(MemoryImage* theImage)
 {
-	if (theImage->mD3DData != nullptr)
+	if (theImage->mRenderData != nullptr)
 	{
-		delete (TextureData*)theImage->mD3DData;
-		theImage->mD3DData = nullptr;
+		delete (TextureData*)theImage->mRenderData;
+		theImage->mRenderData = nullptr;
 
 		std::scoped_lock aCrit(mCritSect); // Make images thread safe
 		mImageSet.erase(theImage);
@@ -1466,9 +1466,9 @@ bool GLInterface::CreateImageTexture(MemoryImage *theImage)
 {
 	bool wantPurge = false;
 
-	if(theImage->mD3DData==nullptr)
+	if(theImage->mRenderData==nullptr)
 	{
-		theImage->mD3DData = new TextureData();
+		theImage->mRenderData = new TextureData();
 		
 		// The actual purging was deferred
 		wantPurge = theImage->mPurgeBits;
@@ -1477,7 +1477,7 @@ bool GLInterface::CreateImageTexture(MemoryImage *theImage)
 		mImageSet.insert(theImage);
 	}
 
-	TextureData *aData = (TextureData*)theImage->mD3DData;
+	TextureData *aData = (TextureData*)theImage->mRenderData;
 	aData->CheckCreateTextures(theImage);
 	
 	if (wantPurge)
@@ -1488,10 +1488,10 @@ bool GLInterface::CreateImageTexture(MemoryImage *theImage)
 
 bool GLInterface::RecoverBits(MemoryImage* theImage)
 {
-	if (theImage->mD3DData == nullptr)
+	if (theImage->mRenderData == nullptr)
 		return false;
 
-	TextureData* aData = (TextureData*) theImage->mD3DData;
+	TextureData* aData = (TextureData*) theImage->mRenderData;
 	if (aData->mBitsChangedCount != theImage->mBitsChangedCount) // bits have changed since texture was created
 		return false;
 
@@ -1554,7 +1554,7 @@ void GLInterface::Blt(Image* theImage, float theX, float theY, const Rect& theSr
 
 	SetDrawMode(theDrawMode);
 
-	TextureData *aData = (TextureData*)aSrcMemoryImage->mD3DData;
+	TextureData *aData = (TextureData*)aSrcMemoryImage->mRenderData;
 
 	SetLinearFilter(linearFilter);
 	aData->Blt(theX,theY,theSrcRect,theColor);
@@ -1620,7 +1620,7 @@ void GLInterface::BltTransformed(Image* theImage, const Rect* theClipRect, const
 
 	SetDrawMode(theDrawMode);
 
-	TextureData *aData = (TextureData*)aSrcMemoryImage->mD3DData;
+	TextureData *aData = (TextureData*)aSrcMemoryImage->mRenderData;
 
 	if (!mTransformStack.empty())
 	{
@@ -1778,7 +1778,7 @@ void GLInterface::DrawTrianglesTex(const TriVertex theVertices[][3], int theNumT
 
 	SetDrawMode(theDrawMode);
 
-	TextureData *aData = (TextureData*)aSrcMemoryImage->mD3DData;
+	TextureData *aData = (TextureData*)aSrcMemoryImage->mRenderData;
 
 	SetLinearFilter(blend);
 

--- a/src/SexyAppFramework/platform/switch/graphics/GLInterface.h
+++ b/src/SexyAppFramework/platform/switch/graphics/GLInterface.h
@@ -22,12 +22,12 @@ class TriVertex;
 
 typedef std::set<GLImage*> GLImageSet;
 
-enum D3DImageFlags 
+enum RenderImageFlags 
 {
-	D3DImageFlag_MinimizeNumSubdivisions	=			0x0001,		// subdivide image into fewest possible textures (may use more memory)
-	D3DImageFlag_Use64By64Subdivisions		=			0x0002,		// good to use with image strips so the entire texture isn't pulled in when drawing just a piece
-	D3DImageFlag_UseA4R4G4B4				=			0x0004,		// images with not too many color gradients work well in this format
-	D3DImageFlag_UseA8R8G8B8				=			0x0008		// non-alpha images will be stored as R5G6B5 by default so use this option if you want a 32-bit non-alpha image
+	RenderImageFlag_MinimizeNumSubdivisions	=			0x0001,		// subdivide image into fewest possible textures (may use more memory)
+	RenderImageFlag_Use64By64Subdivisions	=			0x0002,		// good to use with image strips so the entire texture isn't pulled in when drawing just a piece
+	RenderImageFlag_UseA4R4G4B4				=			0x0004,		// images with not too many color gradients work well in this format
+	RenderImageFlag_UseA8R8G8B8				=			0x0008		// non-alpha images will be stored as R5G6B5 by default so use this option if you want a 32-bit non-alpha image
 };
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Replaced D3D image flags with render image flags across the codebase.
- Updated MemoryImage class to use mRenderFlags instead of mD3DFlags.
- Modified functions in TodCommon, TodParticle, ResourceManager, and GLInterface files to accommodate the new render flags.
- Ensured compatibility with existing functionality while improving code clarity and maintainability.