### PR TITLE
Fix Stinky time handling by removing redundant future-time reset check

### DIFF
--- a/src/Lawn/ZenGarden.cpp
+++ b/src/Lawn/ZenGarden.cpp
@@ -1526,14 +1526,8 @@ void ZenGarden::ResetStinkyTimers()
 void ZenGarden::StinkyUpdate(GridItem* theStinky)
 {
     Reanimation* aStinkyReanim = mApp->ReanimationGet(theStinky->mGridItemReanimID);
-
-    uint32_t aNow = static_cast<uint32_t>(time(0));
-    if (mApp->mPlayerInfo->mLastStinkyChocolateTime > aNow || 
-        static_cast<uint32_t>(mApp->mPlayerInfo->mPurchases[StoreItem::STORE_ITEM_STINKY_THE_SNAIL]) > aNow)
-    {
-        ResetStinkyTimers();
-    }
-
+    // Unsigned delta checks already treat "time moved before event" as expired.
+    // Extra reset-on-future-time logic is unnecessary now.
     bool aStinkyHighOnChocolate = IsStinkyHighOnChocolate();
     UpdateStinkyMotionTrail(theStinky, aStinkyHighOnChocolate);
 


### PR DESCRIPTION
Unsigned delta comparisons already treat "time moved before event" as expired, so the extra `LastTime > NowTime` reset path is unnecessary. This keeps behavior correct under clock rollback, avoids false reset at 2106 wrap-around, and preserves ResetStinkyTimers() for explicit debug/manual use.