### PR TITLE
Fix: apply half-texel inset to texture sampling to prevent LINEAR filtering bleeding

### DIFF
--- a/src/SexyAppFramework/graphics/GLInterface.cpp
+++ b/src/SexyAppFramework/graphics/GLInterface.cpp
@@ -647,8 +647,8 @@ GLuint& TextureData::GetTexture(int x, int y, int &width, int &height,
 	width  = right - left;
 	height = bottom - top;
 
-	u1 = (float)left  / p.mWidth;  v1 = (float)top    / p.mHeight;
-	u2 = (float)right / p.mWidth;  v2 = (float)bottom / p.mHeight;
+	u1 = (left  + 0.5f) / p.mWidth;  v1 = (top    + 0.5f) / p.mHeight;
+	u2 = (right - 0.5f) / p.mWidth;  v2 = (bottom - 0.5f) / p.mHeight;
 	return p.mTexture;
 }
 
@@ -665,8 +665,8 @@ GLuint& TextureData::GetTextureF(float x, float y, float &width, float &height,
 	width  = right - left;
 	height = bottom - top;
 
-	u1 = left   / p.mWidth;  v1 = top    / p.mHeight;
-	u2 = right  / p.mWidth;  v2 = bottom / p.mHeight;
+	u1 = (left  + 0.5f) / p.mWidth;  v1 = (top    + 0.5f) / p.mHeight;
+	u2 = (right - 0.5f) / p.mWidth;  v2 = (bottom - 0.5f) / p.mHeight;
 	return p.mTexture;
 }
 


### PR DESCRIPTION
This pull request updates the texture coordinate calculations in the `TextureData::GetTexture` and `TextureData::GetTextureF` methods to use a half-texel inset. This change helps prevent visual artifacts (such as bleeding) when using LINEAR filtering by ensuring sampling occurs at texel centers.

Texture coordinate calculation improvements:

* Both `GetTexture` and `GetTextureF` in `GLInterface.cpp` now add a half-texel offset to the left/top coordinates and subtract a half-texel from the right/bottom coordinates when computing texture UVs, improving rendering quality with LINEAR filtering. [[1]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L650-R652) [[2]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L668-R671)