### PR TITLE
Clamp texture coordinates in the fragment shader using per-quad UV bounds to fix font bleeding

### DIFF
--- a/src/SexyAppFramework/graphics/GLInterface.cpp
+++ b/src/SexyAppFramework/graphics/GLInterface.cpp
@@ -83,6 +83,8 @@ static void GfxEnd()
 	glEnableVertexAttribArray(1);
 	glVertexAttribPointer(2, 2, GL_FLOAT,         GL_FALSE, sizeof(GLVertex), (const void*)(sizeof(float)*3 + sizeof(uint32_t)));
 	glEnableVertexAttribArray(2);
+	glVertexAttribPointer(3, 4, GL_FLOAT,         GL_FALSE, sizeof(GLVertex), (const void*)(sizeof(float)*3 + sizeof(uint32_t) + sizeof(float)*2));
+	glEnableVertexAttribArray(3);
 
 	glDrawArrays(gVertexMode, 0, gNumVertices);
 
@@ -144,6 +146,10 @@ static void GfxAddVertices(const TriVertex arr[][3], int arrCount, unsigned int 
 			gVertices[gNumVertices + i].color = GetColorFromTriVertex(v[i], theColor);
 			gVertices[gNumVertices + i].tu    = v[i].u * aMaxTotalU;
 			gVertices[gNumVertices + i].tv    = v[i].v * aMaxTotalV;
+			gVertices[gNumVertices + i].uvBounds[0] = 0;
+			gVertices[gNumVertices + i].uvBounds[1] = 0;
+			gVertices[gNumVertices + i].uvBounds[2] = aMaxTotalU;
+			gVertices[gNumVertices + i].uvBounds[3] = aMaxTotalV;
 		}
 		gNumVertices += 3;
 	}
@@ -153,15 +159,18 @@ static void GfxAddVertices(const TriVertex arr[][3], int arrCount, unsigned int 
 static constexpr const char *SHADER_CODE = R"DELIMITER(
 V2F vec4 v_color;
 V2F vec2 v_uv;
+V2F vec4 v_uvBounds;
 
 #ifdef VERTEX
 	uniform mat4 u_viewProj;
 	VERT_IN vec3 a_position;
 	VERT_IN vec4 a_color;
 	VERT_IN vec2 a_uv;
+	VERT_IN vec4 a_uvBounds;
 	void main() {
 		v_color = a_color;
 		v_uv = a_uv;
+		v_uvBounds = a_uvBounds;
 		gl_Position = u_viewProj * vec4(a_position, 1.0);
 	}
 #endif
@@ -170,7 +179,7 @@ V2F vec2 v_uv;
 	uniform int u_useTexture;
 	void main() {
 		if (u_useTexture == 1)
-			FRAG_OUT = TEX2D(u_texture, v_uv) * v_color;
+			FRAG_OUT = TEX2D(u_texture, clamp(v_uv, v_uvBounds.xy, v_uvBounds.zw)) * v_color;
 		else
 			FRAG_OUT = v_color;
 	}
@@ -219,8 +228,8 @@ static GLuint shaderLoad(const char *src)
 	glAttachShader(prog, vert);
 	glAttachShader(prog, frag);
 
-	const char *attribs[] = { "a_position", "a_color", "a_uv" };
-	for (int i = 0; i < 3; i++)
+	const char *attribs[] = { "a_position", "a_color", "a_uv", "a_uvBounds" };
+	for (int i = 0; i < 4; i++)
 		glBindAttribLocation(prog, i, attribs[i]);
 
 	glLinkProgram(prog);
@@ -636,7 +645,8 @@ void TextureData::CheckCreateTextures(MemoryImage *theImage)
 }
 
 GLuint& TextureData::GetTexture(int x, int y, int &width, int &height,
-                                float &u1, float &v1, float &u2, float &v2)
+                                float &u1, float &v1, float &u2, float &v2,
+                                float *uvBounds)
 {
 	int tx = x / mTexPieceWidth, ty = y / mTexPieceHeight;
 	TextureDataPiece &p = mTextures[ty * mTexVecWidth + tx];
@@ -649,11 +659,18 @@ GLuint& TextureData::GetTexture(int x, int y, int &width, int &height,
 
 	u1 = (float)left  / p.mWidth;  v1 = (float)top    / p.mHeight;
 	u2 = (float)right / p.mWidth;  v2 = (float)bottom / p.mHeight;
+
+	// Half-texel inset for shader UV clamping; midpoint fallback guarantees min <= max.
+	float halfU = 0.5f / p.mWidth, halfV = 0.5f / p.mHeight;
+	float midU = (u1 + u2) * 0.5f, midV = (v1 + v2) * 0.5f;
+	uvBounds[0] = std::min(u1 + halfU, midU);  uvBounds[1] = std::min(v1 + halfV, midV);
+	uvBounds[2] = std::max(u2 - halfU, midU);  uvBounds[3] = std::max(v2 - halfV, midV);
 	return p.mTexture;
 }
 
 GLuint& TextureData::GetTextureF(float x, float y, float &width, float &height,
-                                 float &u1, float &v1, float &u2, float &v2)
+                                 float &u1, float &v1, float &u2, float &v2,
+                                 float *uvBounds)
 {
 	int tx = (int)(x / mTexPieceWidth), ty = (int)(y / mTexPieceHeight);
 	TextureDataPiece &p = mTextures[ty * mTexVecWidth + tx];
@@ -667,6 +684,11 @@ GLuint& TextureData::GetTextureF(float x, float y, float &width, float &height,
 
 	u1 = left   / p.mWidth;  v1 = top    / p.mHeight;
 	u2 = right  / p.mWidth;  v2 = bottom / p.mHeight;
+
+	float halfU = 0.5f / p.mWidth, halfV = 0.5f / p.mHeight;
+	float midU = (u1 + u2) * 0.5f, midV = (v1 + v2) * 0.5f;
+	uvBounds[0] = std::min(u1 + halfU, midU);  uvBounds[1] = std::min(v1 + halfV, midV);
+	uvBounds[2] = std::max(u2 - halfU, midU);  uvBounds[3] = std::max(v2 - halfV, midV);
 	return p.mTexture;
 }
 
@@ -699,6 +721,7 @@ void TextureData::Blt(float theX, float theY, const Rect& theSrcRect, const Colo
 	float dstX, dstY;
 	int w, h;
 	float u1, v1, u2, v2;
+	float uvb[4];
 
 	srcY = srcTop; dstY = theY;
 	while (srcY < srcBottom)
@@ -707,14 +730,14 @@ void TextureData::Blt(float theX, float theY, const Rect& theSrcRect, const Colo
 		while (srcX < srcRight)
 		{
 			w = srcRight - srcX; h = srcBottom - srcY;
-			GLuint &tex = GetTexture(srcX, srcY, w, h, u1, v1, u2, v2);
+			GLuint &tex = GetTexture(srcX, srcY, w, h, u1, v1, u2, v2, uvb);
 			float x = dstX, y = dstY;
 
 			GLVertex v[4] = {
-				{ x,     y,     0, aColor, u1, v1 },
-				{ x,     y + h, 0, aColor, u1, v2 },
-				{ x + w, y,     0, aColor, u2, v1 },
-				{ x + w, y + h, 0, aColor, u2, v2 },
+				{ x,     y,     0, aColor, u1, v1, {uvb[0], uvb[1], uvb[2], uvb[3]} },
+				{ x,     y + h, 0, aColor, u1, v2, {uvb[0], uvb[1], uvb[2], uvb[3]} },
+				{ x + w, y,     0, aColor, u2, v1, {uvb[0], uvb[1], uvb[2], uvb[3]} },
+				{ x + w, y + h, 0, aColor, u2, v2, {uvb[0], uvb[1], uvb[2], uvb[3]} },
 			};
 			GfxBindTexture(tex);
 			GfxBegin(GL_TRIANGLE_STRIP);
@@ -736,6 +759,7 @@ static inline float GetCoord(const GLVertex& v, int n)
 	}
 }
 
+// uvBounds not interpolated: all vertices in a draw call share the same bounds.
 static inline GLVertex Interpolate(const GLVertex &a, const GLVertex &b, float t)
 {
 	GLVertex r = a;
@@ -847,6 +871,7 @@ void TextureData::BltTransformed(const SexyMatrix3 &theTrans, const Rect& theSrc
 	float dstX, dstY;
 	int w, h;
 	float u1, v1, u2, v2;
+	float uvb[4];
 
 	srcY = srcTop; dstY = starty;
 	while (srcY < srcBottom)
@@ -855,7 +880,7 @@ void TextureData::BltTransformed(const SexyMatrix3 &theTrans, const Rect& theSrc
 		while (srcX < srcRight)
 		{
 			w = srcRight - srcX; h = srcBottom - srcY;
-			GLuint &tex = GetTexture(srcX, srcY, w, h, u1, v1, u2, v2);
+			GLuint &tex = GetTexture(srcX, srcY, w, h, u1, v1, u2, v2, uvb);
 
 			float x = dstX, y = dstY;
 			SexyVector2 p[4] = { {x, y}, {x, y+h}, {x+w, y}, {x+w, y+h} };
@@ -878,10 +903,10 @@ void TextureData::BltTransformed(const SexyMatrix3 &theTrans, const Rect& theSrc
 			}
 
 			GLVertex vtx[4] = {
-				{ tp[0].x, tp[0].y, 0, aColor, u1, v1 },
-				{ tp[1].x, tp[1].y, 0, aColor, u1, v2 },
-				{ tp[2].x, tp[2].y, 0, aColor, u2, v1 },
-				{ tp[3].x, tp[3].y, 0, aColor, u2, v2 },
+				{ tp[0].x, tp[0].y, 0, aColor, u1, v1, {uvb[0], uvb[1], uvb[2], uvb[3]} },
+				{ tp[1].x, tp[1].y, 0, aColor, u1, v2, {uvb[0], uvb[1], uvb[2], uvb[3]} },
+				{ tp[2].x, tp[2].y, 0, aColor, u2, v1, {uvb[0], uvb[1], uvb[2], uvb[3]} },
+				{ tp[3].x, tp[3].y, 0, aColor, u2, v2, {uvb[0], uvb[1], uvb[2], uvb[3]} },
 			};
 			GfxBindTexture(tex);
 
@@ -926,9 +951,9 @@ void TextureData::BltTriangles(const TriVertex theVertices[][3], int theNumTrian
 	{
 		TriVertex* tv = (TriVertex*)theVertices[tri];
 		GLVertex vtx[3] = {
-			{ tv[0].x+tx, tv[0].y+ty, 0, GetColorFromTriVertex(tv[0], theColor), tv[0].u*mMaxTotalU, tv[0].v*mMaxTotalV },
-			{ tv[1].x+tx, tv[1].y+ty, 0, GetColorFromTriVertex(tv[1], theColor), tv[1].u*mMaxTotalU, tv[1].v*mMaxTotalV },
-			{ tv[2].x+tx, tv[2].y+ty, 0, GetColorFromTriVertex(tv[2], theColor), tv[2].u*mMaxTotalU, tv[2].v*mMaxTotalV },
+			{ tv[0].x+tx, tv[0].y+ty, 0, GetColorFromTriVertex(tv[0], theColor), tv[0].u*mMaxTotalU, tv[0].v*mMaxTotalV, {0, 0, 1, 1} },
+			{ tv[1].x+tx, tv[1].y+ty, 0, GetColorFromTriVertex(tv[1], theColor), tv[1].u*mMaxTotalU, tv[1].v*mMaxTotalV, {0, 0, 1, 1} },
+			{ tv[2].x+tx, tv[2].y+ty, 0, GetColorFromTriVertex(tv[2], theColor), tv[2].u*mMaxTotalU, tv[2].v*mMaxTotalV, {0, 0, 1, 1} },
 		};
 
 		float minU = mMaxTotalU, minV = mMaxTotalV, maxU = 0, maxV = 0;

--- a/src/SexyAppFramework/graphics/GLInterface.h
+++ b/src/SexyAppFramework/graphics/GLInterface.h
@@ -53,6 +53,7 @@ struct GLVertex
 	uint32_t color;
 	float tu;
 	float tv;
+	float uvBounds[4]; // {uMin, vMin, uMax, vMax} half-texel inset for LINEAR anti-bleed
 };
 
 struct VertexList
@@ -142,8 +143,8 @@ public:
 	void CreateTextureDimensions(MemoryImage *theImage);
 	void CreateTextures(MemoryImage *theImage);
 	void CheckCreateTextures(MemoryImage *theImage);
-	GLuint& GetTexture(int x, int y, int &width, int &height, float &u1, float &v1, float &u2, float &v2);
-	GLuint& GetTextureF(float x, float y, float &width, float &height, float &u1, float &v1, float &u2, float &v2);
+	GLuint& GetTexture(int x, int y, int &width, int &height, float &u1, float &v1, float &u2, float &v2, float *uvBounds);
+	GLuint& GetTextureF(float x, float y, float &width, float &height, float &u1, float &v1, float &u2, float &v2, float *uvBounds);
 
 	void Blt(float theX, float theY, const Rect& theSrcRect, const Color& theColor);
 	void BltTransformed(const SexyMatrix3 &theTrans, const Rect& theSrcRect, const Color& theColor, const Rect *theClipRect = nullptr, float theX = 0, float theY = 0, bool center = false);	


### PR DESCRIPTION
This pull request implements improvements to the OpenGL image rendering pipeline to address texture bleeding issues when using linear filtering. The main strategy is to clamp texture coordinates in the fragment shader using per-quad UV bounds, which are calculated with a half-texel inset. This change affects both the shader code and the rendering logic, and also updates the related APIs to support the new parameters.

**Texture Bleed Fixes and Rendering Pipeline Improvements:**

* Added per-vertex UV bounds (`uvMin` and `uvMax`) to the `GLVertex` struct, and updated the vertex and fragment shaders to clamp texture coordinates within these bounds, preventing linear filtering from sampling outside the intended region. [[1]](diffhunk://#diff-d9282684f190466f2e663e4bfef07fbae731886de85db9b8eb389d8f89259199R56-R57) [[2]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787R162-R173) [[3]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L173-R182)
* Updated `TextureData::GetTexture` and `GetTextureF` to compute and return UV bounds for each texture piece, using a half-texel inset to define the clamp region. [[1]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L639-R649) [[2]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787R662-R674) [[3]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787R688-R692)
* Modified all relevant rendering functions (`Blt`, `BltTransformed`, etc.) to use and propagate the new UV bounds, ensuring all draw calls provide correct clamping data to the shader. [[1]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787R725) [[2]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L710-R741) [[3]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L835-L840) [[4]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787R876) [[5]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L859-R894) [[6]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L882-R911) [[7]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L930-R958)

**API and Function Signature Changes:**

* Updated the `GLImage::Blt` and `GLImage::BltMirror` methods (and their interface in `GLImage.h`) to accept a `linearFilter` parameter, defaulting to `true`, allowing callers to control filtering behavior. [[1]](diffhunk://#diff-f1ee609030437d2657c95652260394fd7ba31e1c18de103cc3425fc5d2218fecL104-R104) [[2]](diffhunk://#diff-f1ee609030437d2657c95652260394fd7ba31e1c18de103cc3425fc5d2218fecL118-R118) [[3]](diffhunk://#diff-f1ee609030437d2657c95652260394fd7ba31e1c18de103cc3425fc5d2218fecL173-R173) [[4]](diffhunk://#diff-f1ee609030437d2657c95652260394fd7ba31e1c18de103cc3425fc5d2218fecL182-R182) [[5]](diffhunk://#diff-baa6208da2bb0af75d3e44f2f9438a80928f3be36865ba094a4b0a16b39172afL37-R44)
* Updated internal GL interface functions (`Blt`, `BltClipF`, etc.) to propagate the `linearFilter` parameter and ensure correct filtering is used throughout the rendering stack. [[1]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L1260-R1286) [[2]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L1274-R1304)

**Shader and Pipeline Adjustments:**

* Extended the shader attribute bindings and vertex attribute pointer setup to include the new UV bounds attributes, ensuring data is correctly passed from CPU to GPU. [[1]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787R86-R87) [[2]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L222-R232)
* Adjusted the orthographic projection matrix setup to use the full width and height, ensuring correct pixel alignment after the removal of -0.5f offsets in vertex positions.

**Coordinate and Pixel Alignment Cleanups:**

* Removed legacy -0.5f pixel offsets from vertex positions in several drawing functions, as the new UV clamping and projection matrix changes make them unnecessary and improve pixel-perfect rendering. [[1]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L835-L840) [[2]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L1390-R1416) [[3]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L1407-R1434)

These changes together provide more robust and visually correct rendering when using linear filtering, especially for atlased textures or sub-texture blits.