### PR TITLE
Fix msvc build

### DIFF
--- a/src/SexyAppFramework/fcaseopen/fcaseopen.c
+++ b/src/SexyAppFramework/fcaseopen/fcaseopen.c
@@ -305,7 +305,7 @@ FILE *fcaseopenat(char const *base, char const *path, char const *mode)
 
     size_t baseLen = strlen(base);
     size_t pathLen = strlen(path);
-    char *full = alloca(baseLen + pathLen + 3);
+    char *full = (char *)alloca(baseLen + pathLen + 3);
     strcpy(full, base);
     size_t fl = strlen(full);
     if (fl > 0 && full[fl - 1] != '/' && full[fl - 1] != '\\')


### PR DESCRIPTION
```console
src\SexyAppFramework\fcaseopen\fcaseopen.c(308): error C2440: 'initializing': cannot convert from 'void *' to 'char *'
src\SexyAppFramework\fcaseopen\fcaseopen.c(308): note: Conversion from 'void*' to pointer to non-'void' requires an explicit cast
```
msvc version
```sh
> cl
Microsoft (R) C/C++ Optimizing Compiler Version 19.50.35724 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

usage: cl [ option... ] filename... [ /link linkoption... ]
```