### PR TITLE
Fix: prevent infinite reward farming by restoring BOARDRESULT_WON on save load

### DIFF
--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -472,7 +472,8 @@ bool LawnApp::TryLoadGame()
 		if (mBoard->LoadGame(aSaveName))
 		{
 			mFirstTimeGameSelector = false;
-			mBoardResult = BoardResult::BOARDRESULT_NONE;
+			if (mBoard->mLevelAwardSpawned) // Ensure save cleanup after award collection
+				mBoardResult = BoardResult::BOARDRESULT_WON;
 			DoContinueDialog();
 			return true;
 		}
@@ -489,7 +490,8 @@ bool LawnApp::TryLoadGame()
 				EraseFile(aLegacySaveName);
 			}
 			mFirstTimeGameSelector = false;
-			mBoardResult = BoardResult::BOARDRESULT_NONE;
+			if (mBoard->mLevelAwardSpawned) // Ensure save cleanup after award collection
+				mBoardResult = BoardResult::BOARDRESULT_WON;
 			DoContinueDialog();
 			return true;
 		}


### PR DESCRIPTION
When loading a save where the level award has already been spawned (mLevelAwardSpawned == true), restore mBoardResult to BOARDRESULT_WON. This ensures that KillBoard() properly erases the save file after the player collects the award and completes the level.

Without this fix, players could exploit the save system by:
1. Winning a level and exiting before collecting the award
2. Reloading the save, collecting the award, then exiting to menu
3. Since mBoardResult was BOARDRESULT_NONE, the save wasn't erased
4. Repeating to farm unlimited rewards

The quit and shutdown paths already override mBoardResult to BOARDRESULT_QUIT/QUIT_APP before TryToSaveGame(), so normal exit behavior (preserving progress) is unchanged.