### PR TITLE
Fix: use resolved imitater seed type when classifying flying plants in board

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -2297,7 +2297,7 @@ void Board::GetPlantsOnLawn(int theGridX, int theGridY, PlantsOnLawn* thePlantOn
 		}
 
 		// 将植物写入 thePlantOnLawn 的记录
-		if (Plant::IsFlying(aPlant->mSeedType))
+		if (Plant::IsFlying(aSeedType))
 		{
 			TOD_ASSERT(!thePlantOnLawn->mFlyingPlant);
 			thePlantOnLawn->mFlyingPlant = aPlant;


### PR DESCRIPTION
Fix a crash when planting an imitater coffee bean on a sleeping mushroom. In GetPlantsOnLawn, use the resolved seed type (aSeedType) for IsFlying instead of the raw plant seed type, so imitater instant coffee is correctly treated as a flying plant and does not conflict with normal-plant slot asserts.