### PR TITLE
Fix: resolve Upsell CrazyDave speech loop and reanimation crash

### DIFF
--- a/src/Lawn/CutScene.cpp
+++ b/src/Lawn/CutScene.cpp
@@ -2201,8 +2201,8 @@ void CutScene::UpdateUpsell()
 		Reanimation* aReanimSquash = mApp->AddReanimation(0, 0, 0, ReanimationType::REANIM_SQUASH);
 		aReanimSquash->PlayReanim("anim_idle", ReanimLoopType::REANIM_LOOP, 0, 15.0f);
 		AttachEffect* anAttachEffect = AttachReanim(aCrazyDaveReanim->GetTrackInstanceByName("Dave_handinghand")->mAttachmentID, aReanimSquash, 92.0f, 387.0f);
+		anAttachEffect->mOffset.m00 = 1.2f;
 		anAttachEffect->mOffset.m11 = 1.2f;
-		anAttachEffect->mOffset.m22 = 1.2f;
 		aCrazyDaveReanim->Update();
 		break;
 	}
@@ -2220,7 +2220,7 @@ void CutScene::UpdateUpsell()
 			aReanimHead->AttachToAnotherReanimation(aReanimThreepeater, StrFormat("anim_head%d", i).c_str());
 		}
 		AttachEffect* anAttachEffect = AttachReanim(aCrazyDaveReanim->GetTrackInstanceByName("Dave_body1")->mAttachmentID, aReanimThreepeater, 0.0f, 0.0f);
-		TodScaleRotateTransformMatrix(anAttachEffect->mOffset, -50, 230, 0.5f, 1.2f, 1.2f);
+		TodScaleRotateTransformMatrix(anAttachEffect->mOffset, -70.0f, 260.0f, 0.5f, 1.2f, 1.2f);
 		aCrazyDaveReanim->Update();
 		aReanimThreepeater->Update();
 		break;
@@ -2231,9 +2231,9 @@ void CutScene::UpdateUpsell()
 		Reanimation* aReanimMagnet = mApp->AddReanimation(0, 0, 0, ReanimationType::REANIM_MAGNETSHROOM);
 		aReanimMagnet->PlayReanim("anim_idle", ReanimLoopType::REANIM_LOOP, 0, 15.0f);
 		TodScaleRotateTransformMatrix(aReanimMagnet->mOverlayMatrix, 0, 0, 0.3f, 1, 1);
-		AttachEffect* anAttachEffect = AttachReanim(aCrazyDaveReanim->GetTrackInstanceByName("Dave_pot")->mAttachmentID, aReanimMagnet, 49.0f, 25.0f);
+		AttachEffect* anAttachEffect = AttachReanim(aCrazyDaveReanim->GetTrackInstanceByName("Dave_pot")->mAttachmentID, aReanimMagnet, 25.0f, 49.0f);
+		anAttachEffect->mOffset.m00 = 1.2f;
 		anAttachEffect->mOffset.m11 = 1.2f;
-		anAttachEffect->mOffset.m22 = 1.2f;
 		aCrazyDaveReanim->Update();
 		break;
 	}

--- a/src/SexyAppFramework/misc/SexyMatrix.h
+++ b/src/SexyAppFramework/misc/SexyMatrix.h
@@ -16,9 +16,9 @@ public:
         float m[3][3];
         struct
         {
-            float m00, m01, m02;
-            float m10, m11, m12;
-            float m20, m21, m22;
+            float m00, m01, m02; // scaleX*cos,	skewX*sin,	translateX
+            float m10, m11, m12; // skewY*-sin,	scaleY*cos,	translateY
+            float m20, m21, m22; // projective;	in this project always (0, 0, 1)
         };
     };
 


### PR DESCRIPTION
The Upsell CrazyDave dialog had three related issues:

* UpdateUpsell() failed to update mCrazyDaveLastTalkIndex when initiating the first dialog line, causing the initialization branch to re-trigger every frame and rapidly restart the first speech from the beginning in an infinite loop.
* ClearUpsellBoard() destroyed all reanimations including CrazyDave's own reanimation and blink overlay. Once the speech loop fix allowed dialog to advance to stages that call ClearUpsellBoard, CrazyDaveStopTalking() would crash on ReanimationGet() with a dangling reanimation ID.
* AnimateBoard() competed with UpdateUpsell() to start dialog at TimeEarlyDaveEnterEnd, potentially double-starting speech or consuming mCrazyDaveDialogStart before UpdateUpsell could use it.

Close #90