### PR TITLE
Fix: correct siren sound trigger in Whack-A-Zombie mode

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -5448,7 +5448,7 @@ void Board::NextWaveComing()
 	{
 		mApp->PlaySample(Sexy::SOUND_AWOOGA);
 	}
-	else if ((mApp->IsWhackAZombieLevel() && mCurrentWave == mNumWaves - 1) || IsFlagWave(mCurrentWave))
+	else if (mApp->IsWhackAZombieLevel() ? (mCurrentWave == mNumWaves - 1) : IsFlagWave(mCurrentWave))
 	{
 		mApp->PlaySample(Sexy::SOUND_SIREN);
 	}


### PR DESCRIPTION
- Change IsFlagWave check to ternary operator in Board::NextWaveComing()
- Whack-A-Zombie mode now only plays siren on final wave (wave 11)
- Close #93