### PR TITLE
Fix: Unexpected flickering of final tutorial arrow in Zombiquarium minigame

### DIFF
--- a/src/Lawn/Challenge.cpp
+++ b/src/Lawn/Challenge.cpp
@@ -3719,7 +3719,7 @@ void Challenge::ZombiquariumUpdate()
 		mBoard->TutorialArrowShow(aPosX, aPosY);
 		mBoard->DisplayAdvice("[ADVICE_ZOMBIQUARIUM_CLICK_TROPHY]", MESSAGE_STYLE_HINT_TALL_FAST, ADVICE_ZOMBIQUARIUM_CLICK_TROPHY);
 	}
-	else if (aScore <= ZOMBIQUARIUM_WINNING_SCORE && mBoard->mTutorialState == TUTORIAL_ZOMBIQUARIUM_CLICK_TROPHY)
+	else if (aScore < ZOMBIQUARIUM_WINNING_SCORE && mBoard->mTutorialState == TUTORIAL_ZOMBIQUARIUM_CLICK_TROPHY)
 	{
 		mBoard->TutorialArrowRemove();
 		mBoard->ClearAdvice(ADVICE_ZOMBIQUARIUM_CLICK_TROPHY);


### PR DESCRIPTION
got how much sun
change the number to make sure the maximum number is 1000
number >=1000 : change to click trophy
number <=1000:  change to buy snorkel
so change it. make <= to <

should be no problem