### PR TITLE
Fix: resolve Zombiquarium arrow flicker and zombie jitter

### DIFF
--- a/src/Lawn/Challenge.cpp
+++ b/src/Lawn/Challenge.cpp
@@ -3719,7 +3719,7 @@ void Challenge::ZombiquariumUpdate()
 		mBoard->TutorialArrowShow(aPosX, aPosY);
 		mBoard->DisplayAdvice("[ADVICE_ZOMBIQUARIUM_CLICK_TROPHY]", MESSAGE_STYLE_HINT_TALL_FAST, ADVICE_ZOMBIQUARIUM_CLICK_TROPHY);
 	}
-	else if (aScore <= ZOMBIQUARIUM_WINNING_SCORE && mBoard->mTutorialState == TUTORIAL_ZOMBIQUARIUM_CLICK_TROPHY)
+	else if (aScore < ZOMBIQUARIUM_WINNING_SCORE && mBoard->mTutorialState == TUTORIAL_ZOMBIQUARIUM_CLICK_TROPHY)
 	{
 		mBoard->TutorialArrowRemove();
 		mBoard->ClearAdvice(ADVICE_ZOMBIQUARIUM_CLICK_TROPHY);

--- a/src/Lawn/Zombie.cpp
+++ b/src/Lawn/Zombie.cpp
@@ -3202,7 +3202,7 @@ void Zombie::UpdateZombiquarium()
             mVelZ = 0.0f;
         }
 
-        if (mPosX > 550.0f || aVelX > 0.0f)
+        if (mPosX > 550.0f && aVelX > 0.0f)
         {
             mVelZ = PI;
         }


### PR DESCRIPTION
- Fix trophy arrow flickering when sun equals ZOMBIQUARIUM_WINNING_SCORE by changing <= to < in the score fallback check, preventing the tutorial state from oscillating between show and remove each frame
- Fix zombie jittering in BACK_AND_FORTH phase by changing || to && in the right-boundary direction flip, so the flip only triggers when the zombie is both past x=550 and moving right, matching the symmetric left-boundary logic

Closes #96