### PR TITLE
 Fix: resolve missing tap sound when tapping zombies during choosing …

### DIFF
--- a/src/Lawn/Widget/SeedChooserScreen.cpp
+++ b/src/Lawn/Widget/SeedChooserScreen.cpp
@@ -1046,6 +1046,7 @@ void SeedChooserScreen::MouseDown(int x, int y, int theClickCount)
 			Zombie* aZombie = mBoard->ZombieHitTest(x - mBoard->mX, y - mBoard->mY);
 			if (aZombie && aZombie->mFromWave == Zombie::ZOMBIE_WAVE_CUTSCENE && aZombie->mZombieType != ZOMBIE_REDEYE_GARGANTUAR)
 			{
+				mApp->PlaySample(Sexy::SOUND_TAP);
 				mApp->DoAlmanacDialog(SEED_NONE, aZombie->mZombieType)->WaitForResult(true);
 				mApp->mMusic->MakeSureMusicIsPlaying(MUSIC_TUNE_CHOOSE_YOUR_SEEDS);
 				return;


### PR DESCRIPTION
…plants to enter the Almanac

Before DoAlmanacDialog(), I add a PlaySample(Sexy::SOUND_TAP) to add the sound.

Closes #102 