### PR TITLE
Fix: Update dialog button text to use consistent format

### DIFF
--- a/src/Lawn/Widget/CheatDialog.cpp
+++ b/src/Lawn/Widget/CheatDialog.cpp
@@ -119,7 +119,7 @@ bool CheatDialog::ApplyCheat()
 			true, 
 			"Enter Level", 
 			"Invalid Level. Do 'number' or 'area-subarea' or 'Cnumber' or 'Farea-subarea'.", 
-			"OK", 
+			"[DIALOG_BUTTON_OK]", 
 			Dialog::BUTTONS_FOOTER
 		);
 		return false;

--- a/src/Lawn/Widget/NewOptionsDialog.cpp
+++ b/src/Lawn/Widget/NewOptionsDialog.cpp
@@ -233,7 +233,7 @@ void NewOptionsDialog::CheckboxChecked(int theId, bool checked)
                 "Windowed mode is only available if your desktop was running in either\n"
                     "16 bit or 32 bit color mode when you started the game.\n\n"
                     "If you'd like to run in Windowed mode then you need to quit the game and switch your desktop to 16 or 32 bit color mode.", 
-                "OK", 
+                "[DIALOG_BUTTON_OK]", 
                 Dialog::BUTTONS_FOOTER
             );
 
@@ -255,7 +255,7 @@ void NewOptionsDialog::CheckboxChecked(int theId, bool checked)
                         "Your video card does not\n"
                         "meet the minimum requirements\n"
                         "for this game.",
-                    "OK",
+                    "[DIALOG_BUTTON_OK]",
                     Dialog::BUTTONS_FOOTER
                 );
             }
@@ -267,7 +267,7 @@ void NewOptionsDialog::CheckboxChecked(int theId, bool checked)
                     "Warning",
                     "Your video card may not fully support this feature.\n\n"
                         "If you experience slower performance, please disable Hardware Acceleration.\n",
-                    "OK",
+                    "[DIALOG_BUTTON_OK]",
                     Dialog::BUTTONS_FOOTER
                 );
             }

--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -896,7 +896,7 @@ void LawnApp::FinishCreateUserDialog(bool isYes)
 			true,
 			"Enter Your Name",
 			"Please enter your name to create a new user profile for storing high score data and game progress",
-			"OK",
+			"[DIALOG_BUTTON_OK]",
 			Dialog::BUTTONS_FOOTER
 		);
 	}
@@ -907,7 +907,7 @@ void LawnApp::FinishCreateUserDialog(bool isYes)
 			true,
 			"Enter Your Name"/*"[ENTER_YOUR_NAME]"*/,
 			"Please enter your name to create a new user profile for storing high score data and game progress"/*"[ENTER_NEW_USER]"*/,
-			"OK"/*"[DIALOG_BUTTON_OK]"*/,
+			"[DIALOG_BUTTON_OK]",
 			Dialog::BUTTONS_FOOTER
 		);
 	}
@@ -925,7 +925,7 @@ void LawnApp::FinishCreateUserDialog(bool isYes)
 				true,
 				"Name Conflict"/*"[NAME_CONFLICT]"*/,
 				"The name you entered is already being used.  Please enter a unique player name"/*"[ENTER_UNIQUE_PLAYER_NAME]"*/,
-				"OK"/*"[DIALOG_BUTTON_OK]"*/,
+				"[DIALOG_BUTTON_OK]",
 				Dialog::BUTTONS_FOOTER
 			);
 		}
@@ -1047,7 +1047,7 @@ void LawnApp::FinishRenameUserDialog(bool isYes)
 			true,
 			"Name Conflict"/*"[NAME_CONFLICT]"*/,
 			"The name you entered is already being used.  Please enter a unique player name"/*"[ENTER_UNIQUE_PLAYER_NAME]"*/,
-			"OK"/*"[DIALOG_BUTTON_OK]"*/,
+			"[DIALOG_BUTTON_OK]",
 			Dialog::BUTTONS_FOOTER
 		);
 		return;
@@ -1881,7 +1881,7 @@ void LawnApp::URLOpenFailed(const std::string& theURL)
 		theURL + 
 		"\n\nFor your convenience, this URL has already been copied to your clipboard.";
 
-	DoDialog(Dialogs::DIALOG_OPENURL_WAIT, true, "Open Browser", "OK", aString, Dialog::BUTTONS_FOOTER);
+	DoDialog(Dialogs::DIALOG_OPENURL_WAIT, true, "Open Browser", "[DIALOG_BUTTON_OK]", aString, Dialog::BUTTONS_FOOTER);
 }
 
 //0x452EE0

--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -248,8 +248,8 @@ SexyAppBase::SexyAppBase()
 		mAdd8BitMaxTable[i] = 255;
 	
 	// Set default strings.  Init could read in overrides from partner.xml
-	SetString("DIALOG_BUTTON_OK",		"OK");
-	SetString("DIALOG_BUTTON_CANCEL","CANCEL");
+	SetString("DIALOG_BUTTON_OK",		"Ok");
+	SetString("DIALOG_BUTTON_CANCEL","Cancel");
 
 	SetString("UPDATE_CHECK_TITLE",		"Update Check");
 	SetString("UPDATE_CHECK_BODY",		"Checking if there are any updates available for this product ...");

--- a/src/SexyAppFramework/platform/3ds/Input.cpp
+++ b/src/SexyAppFramework/platform/3ds/Input.cpp
@@ -46,7 +46,7 @@ bool SexyAppBase::StartTextInput(std::string& theInput)
 	swkbdConfigSetType(&kbd, SwkbdType_Normal);
 
 	swkbdConfigSetGuideText(&kbd, "Enter text...");
-	swkbdConfigSetOkButtonText(&kbd, "OK");
+	swkbdConfigSetOkButtonText(&kbd, "[DIALOG_BUTTON_OK]");
 
 	Result rc = swkbdShow(&kbd, buf, sizeof(buf));
 	swkbdClose(&kbd);

--- a/src/SexyAppFramework/widget/Dialog.cpp
+++ b/src/SexyAppFramework/widget/Dialog.cpp
@@ -10,10 +10,10 @@
 using namespace Sexy;
 
 
-std::string Sexy::DIALOG_YES_STRING				= "YES";
-std::string Sexy::DIALOG_NO_STRING				= "NO";
-std::string Sexy::DIALOG_OK_STRING				= "OK";
-std::string Sexy::DIALOG_CANCEL_STRING			= "CANCEL";
+std::string Sexy::DIALOG_YES_STRING				= "Yes";
+std::string Sexy::DIALOG_NO_STRING				= "No";
+std::string Sexy::DIALOG_OK_STRING				= "Ok";
+std::string Sexy::DIALOG_CANCEL_STRING			= "Cancel";
 
 static int gDialogColors[][3] = 
 {{255, 255, 255},


### PR DESCRIPTION
This pull request standardizes dialog button labels across the codebase by replacing hardcoded strings like `"OK"` with the string key `"[DIALOG_BUTTON_OK]"`, and updates the default values for dialog button strings to use title case (e.g., `"Ok"` instead of `"OK"`). These changes improve consistency and support localization by ensuring all dialog buttons use string keys rather than hardcoded text.

**String key standardization for dialog buttons:**
* Replaced all instances of `"OK"` in dialog creation calls with `"[DIALOG_BUTTON_OK]"` in `CheatDialog.cpp`, `NewOptionsDialog.cpp`, `LawnApp.cpp`, and `Input.cpp`. [[1]](diffhunk://#diff-93601fbd937b4f5abdf2befb67ee0d1bdeed2e226350ed8dd5afd54f5c83fd16L122-R122) [[2]](diffhunk://#diff-a683cc68bbd4072c4a2fa3073dd8adae188bbf0377946ffcb2b372b16b212cbaL236-R236) [[3]](diffhunk://#diff-a683cc68bbd4072c4a2fa3073dd8adae188bbf0377946ffcb2b372b16b212cbaL258-R258) [[4]](diffhunk://#diff-a683cc68bbd4072c4a2fa3073dd8adae188bbf0377946ffcb2b372b16b212cbaL270-R270) [[5]](diffhunk://#diff-1c00cd8f01c06fc7fc8e6d5a7dbb33b8feed136800c331e2b822444b1627669eL899-R899) [[6]](diffhunk://#diff-1c00cd8f01c06fc7fc8e6d5a7dbb33b8feed136800c331e2b822444b1627669eL910-R910) [[7]](diffhunk://#diff-1c00cd8f01c06fc7fc8e6d5a7dbb33b8feed136800c331e2b822444b1627669eL928-R928) [[8]](diffhunk://#diff-1c00cd8f01c06fc7fc8e6d5a7dbb33b8feed136800c331e2b822444b1627669eL1050-R1050) [[9]](diffhunk://#diff-1c00cd8f01c06fc7fc8e6d5a7dbb33b8feed136800c331e2b822444b1627669eL1884-R1884) [[10]](diffhunk://#diff-cddafd6e39ffb225c213971ee14eea68251b9ff4ea962d428b3b0bad95e1e946L49-R49)

**Dialog string value updates:**
* Changed the default values for dialog button strings from uppercase (e.g., `"OK"`, `"CANCEL"`, `"YES"`, `"NO"`) to title case (e.g., `"Ok"`, `"Cancel"`, `"Yes"`, `"No"`) in `SexyAppBase.cpp` and `Dialog.cpp`. [[1]](diffhunk://#diff-5f42c26c42c5f9fca660eaabd6949353ffb61cae9ff16888c920fd800d4c5951L251-R252) [[2]](diffhunk://#diff-d82ebd9bbcd222a47fa9fee33100bf034ffb99895e6ebfcc47c86b4fc794ff59L13-R16)