### PR TITLE
Fix: Correct shovel button rect height

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -1361,7 +1361,7 @@ void Board::InitSurvivalStage()
 //0x40AE70
 Rect Board::GetShovelButtonRect()
 {
-	Rect aRect(GetSeedBankExtraWidth() + 456, 0, Sexy::IMAGE_SHOVELBANK->GetWidth(), Sexy::IMAGE_SEEDBANK->GetHeight());
+	Rect aRect(GetSeedBankExtraWidth() + 456, 0, Sexy::IMAGE_SHOVELBANK->GetWidth(), Sexy::IMAGE_SHOVELBANK->GetHeight());
 	if (mApp->IsSlotMachineLevel() || mApp->IsSquirrelLevel())
 	{
 		aRect.mX = 600;


### PR DESCRIPTION
The `GetShovelButtonRect()` previously used `IMAGE_SEEDBANK->GetHeight()`, which caused the tutorial arrow to be positioned too low.

Using `IMAGE_SHOVELBANK->GetHeight()` fixes the tutorial arrow offset, and also accurately corrects the click detection height for both the shovel and the Zen Garden tools.

Fix #110
Close #112