### PR TITLE
Fix: enable immersive mode by setting decor fits system windows to false

### DIFF
--- a/android/app/src/main/java/io/github/wszqkzqk/pvzportable/PvZPortableActivity.java
+++ b/android/app/src/main/java/io/github/wszqkzqk/pvzportable/PvZPortableActivity.java
@@ -64,6 +64,7 @@ public class PvZPortableActivity extends SDLActivity {
     private void hideSystemUI() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             Window window = getWindow();
+            window.setDecorFitsSystemWindows(false);
             WindowInsetsController controller = window.getInsetsController();
             if (controller != null) {
                 controller.hide(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());


### PR DESCRIPTION
Prevent extra top and bottom letterboxing on Android 11-14