### PR TITLE
Fix: save game on pause for better experience on mobile

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -4890,6 +4890,11 @@ void Board::Pause(bool thePause)
 		mApp->mSoundSystem->GamePause(thePause);
 		mApp->mMusic->GameMusicPause(thePause);
 	}
+
+	if (thePause && NeedSaveGame())
+	{
+		TryToSaveGame();
+	}
 }
 
 //0x412850


### PR DESCRIPTION
Previously on mobile platforms, background apps might be deleted by the system, leading to data loss. Since mobile devices automatically pause when switched to the background, we now prevent progress loss by saving the progress during pause. Saving overhead is minimal, with no regression effect.