### PR TITLE
Fix: improve object initialization in DataArray and TrailDefinition

### DIFF
--- a/src/Lawn/System/PlayerInfo.cpp
+++ b/src/Lawn/System/PlayerInfo.cpp
@@ -276,7 +276,7 @@ void PlayerInfo::ResetChallengeRecord(GameMode theGameMode)
 //0x469A00
 void PottedPlant::InitializePottedPlant(SeedType theSeedType)
 {
-	memset(this, 0, sizeof(PottedPlant));
+	*this = PottedPlant{};
 	mSeedType = theSeedType;
 	mDrawVariation = DrawVariation::VARIATION_NORMAL;
 	mLastWateredTime = 0;

--- a/src/Sexy.TodLib/DataArray.h
+++ b/src/Sexy.TodLib/DataArray.h
@@ -158,12 +158,12 @@ public:
 		}
 
 		DataArray<T>::DataArrayItem* aNewItem = &mBlock[aNext];
-		memset(aNewItem, 0, sizeof(DataArrayItem));
+		memset(static_cast<void*>(&aNewItem->mItem), 0, sizeof(T));
+		new (&aNewItem->mItem) T{};
 		aNewItem->mID = (mNextKey++ << DATA_ARRAY_KEY_SHIFT) | aNext;
 		if (mNextKey == DATA_ARRAY_MAX_SIZE) mNextKey = 1;
 		mSize++;
 
-		new (aNewItem)T();
 		return reinterpret_cast<T*>(aNewItem);
 	}
 

--- a/src/Sexy.TodLib/Trail.cpp
+++ b/src/Sexy.TodLib/Trail.cpp
@@ -32,12 +32,16 @@ TrailParams gLawnTrailArray[TrailType::NUM_TRAILS] = { //0x6A19F4
 };
 
 TrailDefinition::TrailDefinition()
+	: mImage(nullptr),
+	  mMaxPoints(2),
+	  mMinPointDistance(1.0f),
+	  mTrailFlags(0),
+	  mTrailDuration{},
+	  mWidthOverLength{},
+	  mWidthOverTime{},
+	  mAlphaOverLength{},
+	  mAlphaOverTime{}
 {
-	memset(this, 0, sizeof(TrailDefinition));
-	mMinPointDistance = 1.0f;
-	mMaxPoints = 2;
-	mTrailFlags = 0U;
-	mImage = nullptr;
 }
 
 TrailDefinition::~TrailDefinition()


### PR DESCRIPTION
- Replace memset with explicit member initialization in DataArray to avoid overwriting vtable
- Use member initialization list and explicit value initialization in TrailDefinition constructor
- Ensure proper construction of C++ objects while maintaining memory safety