### PR TITLE
Feat: map Android back button to escape key

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:hasFragileUserData="true"
+        android:enableOnBackInvokedCallback="true"
         android:supportsRtl="true">
 
         <activity

--- a/android/app/src/main/java/io/github/wszqkzqk/pvzportable/PvZPortableActivity.java
+++ b/android/app/src/main/java/io/github/wszqkzqk/pvzportable/PvZPortableActivity.java
@@ -25,11 +25,14 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
 import android.view.WindowManager;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
 
 import org.libsdl.app.SDLActivity;
 
@@ -37,6 +40,7 @@ import java.io.File;
 
 public class PvZPortableActivity extends SDLActivity {
     private static final String TAG = "PvZPortable";
+    private OnBackInvokedCallback mBackCallback;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -53,12 +57,39 @@ public class PvZPortableActivity extends SDLActivity {
 
         super.onCreate(savedInstanceState);
         hideSystemUI();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            mBackCallback = this::dispatchBackToSdl;
+            getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
+                OnBackInvokedDispatcher.PRIORITY_DEFAULT,
+                mBackCallback
+            );
+        }
     }
 
     @Override
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
         if (hasFocus) hideSystemUI();
+    }
+
+    @Override
+    public void onBackPressed() {
+        dispatchBackToSdl();
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && mBackCallback != null) {
+            getOnBackInvokedDispatcher().unregisterOnBackInvokedCallback(mBackCallback);
+            mBackCallback = null;
+        }
+        super.onDestroy();
+    }
+
+    private void dispatchBackToSdl() {
+        SDLActivity.onNativeKeyDown(KeyEvent.KEYCODE_BACK);
+        SDLActivity.onNativeKeyUp(KeyEvent.KEYCODE_BACK);
     }
 
     private void hideSystemUI() {

--- a/android/app/src/main/java/io/github/wszqkzqk/pvzportable/PvZPortableActivity.java
+++ b/android/app/src/main/java/io/github/wszqkzqk/pvzportable/PvZPortableActivity.java
@@ -80,7 +80,7 @@ public class PvZPortableActivity extends SDLActivity {
 
     @Override
     protected void onDestroy() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && mBackCallback != null) {
+        if (mBackCallback != null) {
             getOnBackInvokedDispatcher().unregisterOnBackInvokedCallback(mBackCallback);
             mBackCallback = null;
         }

--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -5231,6 +5231,7 @@ void Board::ZombiesWon(Zombie* theZombie)
 
 	GameOverDialog* aGameOverDialog = new GameOverDialog(aGameOverMsg, true);
 	mApp->AddDialog(Dialogs::DIALOG_GAME_OVER, aGameOverDialog);
+	mApp->mWidgetManager->SetFocus(aGameOverDialog);
 
 	mApp->mMusic->StopAllMusic();
 	StopAllZombieSounds();

--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -7858,7 +7858,6 @@ static void TodCrash()
 	TOD_ASSERT(false, "Crash%s", "!!!!");
 }
 
-//0x41B950（原版中废弃）
 void Board::KeyChar(char theChar)
 {
 	if (!mApp->mDebugKeysEnabled)

--- a/src/Lawn/CutScene.cpp
+++ b/src/Lawn/CutScene.cpp
@@ -1562,11 +1562,13 @@ void CutScene::UpdateZombiesWon()
 			std::string aStr = TodReplaceString("[SURVIVAL_DEATH_MESSAGE]", "{FLAGS}", aFlagsStr);
 			GameOverDialog* aDialog = new GameOverDialog(aStr, true);
 			mApp->AddDialog(Dialogs::DIALOG_GAME_OVER, aDialog);
+			mApp->mWidgetManager->SetFocus(aDialog);
 		}
 		else
 		{
 			GameOverDialog* aDialog = new GameOverDialog("", false);
 			mApp->AddDialog(Dialogs::DIALOG_GAME_OVER, aDialog);
+			mApp->mWidgetManager->SetFocus(aDialog);
 		}
 	}
 }

--- a/src/Lawn/Widget/AchievementsScreen.cpp
+++ b/src/Lawn/Widget/AchievementsScreen.cpp
@@ -191,6 +191,10 @@ void AchievementsWidget::KeyDown(KeyCode theKey) {
 		mScrollValue = mDefaultScrollValue;
 		mScrollDirection = -1;
 	}
+	else if (theKey == KEYCODE_ESCAPE) {
+		mApp->mGameSelector->SlideTo(0, 0);
+		mApp->mGameSelector->mWidgetManager->SetFocus(mApp->mGameSelector);
+	}
 }
 
 // GOTY @Patoke: 0x4017F0

--- a/src/Lawn/Widget/AchievementsScreen.cpp
+++ b/src/Lawn/Widget/AchievementsScreen.cpp
@@ -192,6 +192,10 @@ void AchievementsWidget::KeyDown(KeyCode theKey) {
 		mScrollValue = mDefaultScrollValue;
 		mScrollDirection = -1;
 	}
+	else if (theKey == KEYCODE_ESCAPE) {
+		mApp->mGameSelector->SlideTo(0, 0);
+		mApp->mGameSelector->mWidgetManager->SetFocus(mApp->mGameSelector);
+	}
 }
 
 // GOTY @Patoke: 0x4017F0

--- a/src/Lawn/Widget/AlmanacDialog.cpp
+++ b/src/Lawn/Widget/AlmanacDialog.cpp
@@ -692,6 +692,20 @@ void AlmanacDialog::MouseDown(int x, int y, int theClickCount)
 	}
 }
 
+void AlmanacDialog::KeyDown(KeyCode theKey)
+{
+	if (theKey == KeyCode::KEYCODE_ESCAPE)
+	{
+		if (mOpenPage == AlmanacPage::ALMANAC_PAGE_INDEX)
+			mApp->KillAlmanacDialog();
+		else
+			SetPage(AlmanacPage::ALMANAC_PAGE_INDEX);
+		return;
+	}
+
+	LawnDialog::KeyDown(theKey);
+}
+
 void AlmanacInitForPlayer()
 {
 	for (int i = 0; i < ZombieType::NUM_ZOMBIE_TYPES; i++)

--- a/src/Lawn/Widget/AlmanacDialog.h
+++ b/src/Lawn/Widget/AlmanacDialog.h
@@ -89,6 +89,7 @@ public:
 	ZombieType					ZombieHitTest(int x, int y);
 	virtual void				MouseUp(int x, int y, int theClickCount);
 	virtual void				MouseDown(int x, int y, int theClickCount);
+	virtual void				KeyDown(KeyCode theKey);
 //	virtual void				KeyChar(char theChar);
 
 	static ZombieType			GetZombieType(int theIndex);

--- a/src/Lawn/Widget/AlmanacDialog.h
+++ b/src/Lawn/Widget/AlmanacDialog.h
@@ -89,6 +89,7 @@ public:
 	ZombieType					ZombieHitTest(int x, int y);
 	void						MouseUp(int x, int y, int theClickCount) override;
 	void						MouseDown(int x, int y, int theClickCount) override;
+	void						KeyDown(KeyCode theKey) override;
 //	virtual void				KeyChar(char theChar);
 
 	static ZombieType			GetZombieType(int theIndex);

--- a/src/Lawn/Widget/AwardScreen.cpp
+++ b/src/Lawn/Widget/AwardScreen.cpp
@@ -462,10 +462,26 @@ void AwardScreen::Update()
 	if (mFadeInCounter > 0) mFadeInCounter--;
 }
 
-void AwardScreen::KeyChar(char theChar)
+void AwardScreen::KeyDown(KeyCode theKey)
 {
-	if (theChar == ' ' || theChar == '\r' || theChar == '\u001B')
+	if (theKey == KeyCode::KEYCODE_SPACE || theKey == KeyCode::KEYCODE_RETURN)
+	{
 		StartButtonPressed();
+		return;
+	}
+
+	if (theKey == KeyCode::KEYCODE_ESCAPE)
+	{
+		if (!mMenuButton->mDisabled && !mMenuButton->mBtnNoDraw)
+		{
+			mApp->KillAwardScreen();
+			mApp->ShowGameSelector();
+		}
+		else
+		{
+			StartButtonPressed();
+		}
+	}
 }
 
 // GOTY @Patoke: 0x409530

--- a/src/Lawn/Widget/AwardScreen.h
+++ b/src/Lawn/Widget/AwardScreen.h
@@ -74,7 +74,7 @@ public:
 	virtual void		Update();
 	virtual void		AddedToManager(WidgetManager* theWidgetManager) { Widget::AddedToManager(theWidgetManager); }
 	virtual void		RemovedFromManager(WidgetManager* theWidgetManager) { Widget::RemovedFromManager(theWidgetManager); }
-	virtual void		KeyChar(char theChar);
+	virtual void		KeyDown(KeyCode theKey);
 	void				StartButtonPressed();
 	virtual void		MouseDown(int x, int y, int theClickCount);
 	virtual void		MouseUp(int x, int y, int theClickCount);

--- a/src/Lawn/Widget/AwardScreen.h
+++ b/src/Lawn/Widget/AwardScreen.h
@@ -74,7 +74,7 @@ public:
 	void				Update() override;
 	void				AddedToManager(WidgetManager* theWidgetManager) override { Widget::AddedToManager(theWidgetManager); }
 	void				RemovedFromManager(WidgetManager* theWidgetManager) override { Widget::RemovedFromManager(theWidgetManager); }
-	void				KeyChar(char theChar) override;
+	void				KeyDown(KeyCode theKey) override;
 	void				StartButtonPressed();
 	void				MouseDown(int x, int y, int theClickCount) override;
 	void				MouseUp(int x, int y, int theClickCount) override;

--- a/src/Lawn/Widget/ChallengeScreen.cpp
+++ b/src/Lawn/Widget/ChallengeScreen.cpp
@@ -645,6 +645,14 @@ void ChallengeScreen::ButtonDepress(int theId)
 	}
 }
 
+void ChallengeScreen::KeyDown(KeyCode theKey)
+{
+	if (theKey == KeyCode::KEYCODE_ESCAPE)
+	{
+		ButtonDepress(ChallengeScreen::ChallengeScreen_Back);
+	}
+}
+
 void ChallengeScreen::UpdateToolTip()
 {
 	if (!mApp->mWidgetManager->mMouseIn || !mApp->mActive)

--- a/src/Lawn/Widget/ChallengeScreen.cpp
+++ b/src/Lawn/Widget/ChallengeScreen.cpp
@@ -642,6 +642,15 @@ void ChallengeScreen::ButtonDepress(int theId)
 	}
 }
 
+void ChallengeScreen::KeyDown(KeyCode theKey)
+{
+	if (theKey == KeyCode::KEYCODE_ESCAPE)
+	{
+		ButtonDepress(ChallengeScreen::ChallengeScreen_Back);
+	}
+}
+
+//0x42F7E0
 void ChallengeScreen::UpdateToolTip()
 {
 	if (!mApp->mWidgetManager->mMouseIn || !mApp->mActive)

--- a/src/Lawn/Widget/ChallengeScreen.h
+++ b/src/Lawn/Widget/ChallengeScreen.h
@@ -74,6 +74,7 @@ public:
     virtual void                ButtonMouseLeave(int){}
     virtual void                ButtonMouseMove(int, int, int){}
     virtual void                ButtonDepress(int theId);
+    virtual void                KeyDown(KeyCode theKey);
     void                        UpdateToolTip();
 //  virtual void                KeyChar(char theChar);
 

--- a/src/Lawn/Widget/ChallengeScreen.h
+++ b/src/Lawn/Widget/ChallengeScreen.h
@@ -72,11 +72,12 @@ public:
     void                        AddedToManager(WidgetManager* theWidgetManager) override;
     void                        RemovedFromManager(WidgetManager* theWidgetManager) override;
     void                        ButtonPress(int theId) override;
-    void                        ButtonDownTick(int) override{}
-    void                        ButtonMouseEnter(int) override{}
-    void                        ButtonMouseLeave(int) override{}
-    void                        ButtonMouseMove(int, int, int) override{}
+    void                        ButtonDownTick(int) override {}
+    void                        ButtonMouseEnter(int) override {}
+    void                        ButtonMouseLeave(int) override {}
+    void                        ButtonMouseMove(int, int, int) override {}
     void                        ButtonDepress(int theId) override;
+    void                        KeyDown(KeyCode theKey) override;
     void                        UpdateToolTip();
     void                        MouseDown(int x, int y, int theClickCount) override;
 //  virtual void                KeyChar(char theChar);

--- a/src/Lawn/Widget/ContinueDialog.cpp
+++ b/src/Lawn/Widget/ContinueDialog.cpp
@@ -106,6 +106,18 @@ void ContinueDialog::RemovedFromManager(WidgetManager* theWidgetManager)
     RemoveWidget(mNewGameButton);
 }
 
+void ContinueDialog::KeyDown(KeyCode theKey)
+{
+    if (theKey == KeyCode::KEYCODE_ESCAPE)
+    {
+        ButtonDepress(Dialog::ID_FOOTER);
+        return;
+    }
+
+    LawnDialog::KeyDown(theKey);
+}
+
+//0x4335D0
 void ContinueDialog::RestartLoopingSounds()
 {
     if (mApp->mGameMode == GameMode::GAMEMODE_CHALLENGE_RAINING_SEEDS || mApp->IsStormyNightLevel())

--- a/src/Lawn/Widget/ContinueDialog.cpp
+++ b/src/Lawn/Widget/ContinueDialog.cpp
@@ -114,6 +114,12 @@ void ContinueDialog::KeyDown(KeyCode theKey)
         return;
     }
 
+    if (theKey == KeyCode::KEYCODE_RETURN || theKey == KeyCode::KEYCODE_SPACE)
+    {
+        ButtonDepress(ContinueDialog::ContinueDialog_Continue);
+        return;
+    }
+
     LawnDialog::KeyDown(theKey);
 }
 

--- a/src/Lawn/Widget/ContinueDialog.cpp
+++ b/src/Lawn/Widget/ContinueDialog.cpp
@@ -106,6 +106,17 @@ void ContinueDialog::RemovedFromManager(WidgetManager* theWidgetManager)
     RemoveWidget(mNewGameButton);
 }
 
+void ContinueDialog::KeyDown(KeyCode theKey)
+{
+    if (theKey == KeyCode::KEYCODE_ESCAPE)
+    {
+        ButtonDepress(Dialog::ID_FOOTER);
+        return;
+    }
+
+    LawnDialog::KeyDown(theKey);
+}
+
 void ContinueDialog::RestartLoopingSounds()
 {
     if (mApp->mGameMode == GameMode::GAMEMODE_CHALLENGE_RAINING_SEEDS || mApp->IsStormyNightLevel())

--- a/src/Lawn/Widget/ContinueDialog.h
+++ b/src/Lawn/Widget/ContinueDialog.h
@@ -45,6 +45,7 @@ public:
 	virtual void		Resize(int theX, int theY, int theWidth, int theHeight);
 	virtual void		AddedToManager(WidgetManager* theWidgetManager);
 	virtual void		RemovedFromManager(WidgetManager* theWidgetManager);
+	virtual void		KeyDown(KeyCode theKey);
 	virtual void		ButtonDepress(int theId);
 	void				RestartLoopingSounds();
 };

--- a/src/Lawn/Widget/ContinueDialog.h
+++ b/src/Lawn/Widget/ContinueDialog.h
@@ -45,6 +45,7 @@ public:
 	void				Resize(int theX, int theY, int theWidth, int theHeight) override;
 	void				AddedToManager(WidgetManager* theWidgetManager) override;
 	void				RemovedFromManager(WidgetManager* theWidgetManager) override;
+	void				KeyDown(KeyCode theKey) override;
 	void				ButtonDepress(int theId) override;
 	void				RestartLoopingSounds();
 };

--- a/src/Lawn/Widget/CreditScreen.cpp
+++ b/src/Lawn/Widget/CreditScreen.cpp
@@ -1745,10 +1745,23 @@ void CreditScreen::PauseCredits()
 
 void CreditScreen::KeyDown(KeyCode theKey)
 {
+    if (theKey == KeyCode::KEYCODE_ESCAPE)
+    {
+        if (mCreditsPaused)
+        {
+            ButtonDepress(CreditScreen::Credits_Button_MainMenu);
+        }
+        else
+        {
+            PauseCredits();
+        }
+        return;
+    }
+
     if (mCreditsPaused)
         return;
 
-    if (theKey == KeyCode::KEYCODE_SPACE || theKey == KeyCode::KEYCODE_RETURN || theKey == KeyCode::KEYCODE_ESCAPE)
+    if (theKey == KeyCode::KEYCODE_SPACE || theKey == KeyCode::KEYCODE_RETURN)
     {
         PauseCredits();
     }

--- a/src/Lawn/Widget/CreditScreen.cpp
+++ b/src/Lawn/Widget/CreditScreen.cpp
@@ -1745,23 +1745,7 @@ void CreditScreen::PauseCredits()
 
 void CreditScreen::KeyDown(KeyCode theKey)
 {
-    if (theKey == KeyCode::KEYCODE_ESCAPE)
-    {
-        if (mCreditsPaused)
-        {
-            ButtonDepress(CreditScreen::Credits_Button_MainMenu);
-        }
-        else
-        {
-            PauseCredits();
-        }
-        return;
-    }
-
-    if (mCreditsPaused)
-        return;
-
-    if (theKey == KeyCode::KEYCODE_SPACE || theKey == KeyCode::KEYCODE_RETURN)
+    if (theKey == KeyCode::KEYCODE_SPACE || theKey == KeyCode::KEYCODE_RETURN || theKey == KeyCode::KEYCODE_ESCAPE)
     {
         PauseCredits();
     }

--- a/src/Lawn/Widget/GameSelector.cpp
+++ b/src/Lawn/Widget/GameSelector.cpp
@@ -1080,6 +1080,12 @@ void GameSelector::OrderInManagerChanged()
 // GOTY @Patoke: 0x44EB11
 void GameSelector::KeyDown(KeyCode theKey)
 {
+	if (theKey == KeyCode::KEYCODE_ESCAPE)
+	{
+		mApp->ConfirmQuit();
+		return;
+	}
+
 	if (mApp->mKonamiCheck->Check(theKey))
 	{
 		mApp->PlayFoley(FoleyType::FOLEY_DROP);

--- a/src/Lawn/Widget/LawnDialog.cpp
+++ b/src/Lawn/Widget/LawnDialog.cpp
@@ -478,6 +478,18 @@ GameOverDialog::~GameOverDialog()
     delete mMenuButton;
 }
 
+void GameOverDialog::KeyDown(KeyCode theKey)
+{
+    if (theKey == KeyCode::KEYCODE_ESCAPE)
+    {
+        ButtonDepress(1);
+        return;
+    }
+
+    LawnDialog::KeyDown(theKey);
+}
+
+//0x457E50
 void GameOverDialog::ButtonDepress(int theId)
 {
     if (theId == 1)

--- a/src/Lawn/Widget/LawnDialog.cpp
+++ b/src/Lawn/Widget/LawnDialog.cpp
@@ -229,9 +229,16 @@ void LawnDialog::KeyDown(KeyCode theKey)
         {
             Dialog::ButtonDepress(Dialog::ID_YES);
         }
-        else if ((theKey == KEYCODE_ESCAPE || theKey == 'n' || theKey == 'N') && mLawnNoButton)
+        else if (theKey == KEYCODE_ESCAPE || theKey == 'n' || theKey == 'N')
         {
-            Dialog::ButtonDepress(Dialog::ID_NO);
+            if (mLawnNoButton)
+            {
+                Dialog::ButtonDepress(Dialog::ID_NO);
+            }
+            else if (theKey == KEYCODE_ESCAPE && mLawnYesButton)
+            {
+                Dialog::ButtonDepress(Dialog::ID_YES);
+            }
         }
     }
 }

--- a/src/Lawn/Widget/LawnDialog.cpp
+++ b/src/Lawn/Widget/LawnDialog.cpp
@@ -478,6 +478,17 @@ GameOverDialog::~GameOverDialog()
     delete mMenuButton;
 }
 
+void GameOverDialog::KeyDown(KeyCode theKey)
+{
+    if (theKey == KeyCode::KEYCODE_ESCAPE)
+    {
+        ButtonDepress(1);
+        return;
+    }
+
+    LawnDialog::KeyDown(theKey);
+}
+
 void GameOverDialog::ButtonDepress(int theId)
 {
     if (theId == 1)

--- a/src/Lawn/Widget/LawnDialog.h
+++ b/src/Lawn/Widget/LawnDialog.h
@@ -102,6 +102,7 @@ public:
 	GameOverDialog(const std::string& theMessage, bool theShowChallengeName);
 	virtual ~GameOverDialog();
 
+	virtual void			KeyDown(KeyCode theKey);
 	virtual void			ButtonDepress(int theId);
 	virtual void			AddedToManager(WidgetManager* theWidgetManager);
 	virtual void			RemovedFromManager(WidgetManager* theWidgetManager);

--- a/src/Lawn/Widget/LawnDialog.h
+++ b/src/Lawn/Widget/LawnDialog.h
@@ -102,6 +102,7 @@ public:
 	GameOverDialog(const std::string& theMessage, bool theShowChallengeName);
 	~GameOverDialog() override;
 
+	void					KeyDown(KeyCode theKey) override;
 	void					ButtonDepress(int theId) override;
 	void					AddedToManager(WidgetManager* theWidgetManager) override;
 	void					RemovedFromManager(WidgetManager* theWidgetManager) override;

--- a/src/Lawn/Widget/SeedChooserScreen.cpp
+++ b/src/Lawn/Widget/SeedChooserScreen.cpp
@@ -1119,15 +1119,23 @@ void SeedChooserScreen::CloseSeedChooser()
 void SeedChooserScreen::KeyDown(KeyCode theKey)
 {
 	mBoard->DoTypingCheck(theKey);
+
+	if (mChooseState == CHOOSE_VIEW_LAWN && (theKey == KeyCode::KEYCODE_SPACE || theKey == KeyCode::KEYCODE_RETURN || theKey == KeyCode::KEYCODE_ESCAPE))
+	{
+		CancelLawnView();
+	}
+	else if (theKey == KeyCode::KEYCODE_ESCAPE)
+	{
+		if (mApp->mTodCheatKeys)
+			PickRandomSeeds();
+		else
+			ButtonDepress(SeedChooserScreen::SeedChooserScreen_Menu);
+	}
 }
 
 void SeedChooserScreen::KeyChar(char theChar)
 {
-	if (mChooseState == CHOOSE_VIEW_LAWN && (theChar == ' ' || theChar == '\r' || theChar == '\u001B'))
-		CancelLawnView();
-	else if (mApp->mTodCheatKeys && theChar == '\u001B')
-		PickRandomSeeds();
-	else mBoard->KeyChar(theChar);
+	mBoard->KeyChar(theChar);
 }
 
 void SeedChooserScreen::UpdateAfterPurchase()

--- a/src/Lawn/Widget/SeedChooserScreen.cpp
+++ b/src/Lawn/Widget/SeedChooserScreen.cpp
@@ -1120,15 +1120,23 @@ void SeedChooserScreen::CloseSeedChooser()
 void SeedChooserScreen::KeyDown(KeyCode theKey)
 {
 	mBoard->DoTypingCheck(theKey);
+
+	if (mChooseState == CHOOSE_VIEW_LAWN && (theKey == KeyCode::KEYCODE_SPACE || theKey == KeyCode::KEYCODE_RETURN || theKey == KeyCode::KEYCODE_ESCAPE))
+	{
+		CancelLawnView();
+	}
+	else if (theKey == KeyCode::KEYCODE_ESCAPE)
+	{
+		if (mApp->mTodCheatKeys)
+			PickRandomSeeds();
+		else
+			ButtonDepress(SeedChooserScreen::SeedChooserScreen_Menu);
+	}
 }
 
 void SeedChooserScreen::KeyChar(char theChar)
 {
-	if (mChooseState == CHOOSE_VIEW_LAWN && (theChar == ' ' || theChar == '\r' || theChar == '\u001B'))
-		CancelLawnView();
-	else if (mApp->mTodCheatKeys && theChar == '\u001B')
-		PickRandomSeeds();
-	else mBoard->KeyChar(theChar);
+	mBoard->KeyChar(theChar);
 }
 
 void SeedChooserScreen::UpdateAfterPurchase()

--- a/src/Lawn/Widget/StoreScreen.cpp
+++ b/src/Lawn/Widget/StoreScreen.cpp
@@ -860,9 +860,21 @@ void StoreScreen::ButtonDepress(int theId)
     }
 }
 
-void StoreScreen::KeyChar(char theChar)
+void StoreScreen::KeyDown(KeyCode theKey)
 {
-    if (mBubbleClickToContinue && (theChar == ' ' || theChar == '\r')) AdvanceCrazyDaveDialog();
+    if (theKey == KeyCode::KEYCODE_ESCAPE)
+    {
+        ButtonDepress(StoreScreen::StoreScreen_Back);
+        return;
+    }
+
+    if (mBubbleClickToContinue && (theKey == KeyCode::KEYCODE_SPACE || theKey == KeyCode::KEYCODE_RETURN))
+    {
+        AdvanceCrazyDaveDialog();
+        return;
+    }
+
+    Dialog::KeyDown(theKey);
 }
 
 int StoreScreen::GetItemCost(StoreItem theStoreItem)

--- a/src/Lawn/Widget/StoreScreen.cpp
+++ b/src/Lawn/Widget/StoreScreen.cpp
@@ -859,9 +859,21 @@ void StoreScreen::ButtonDepress(int theId)
     }
 }
 
-void StoreScreen::KeyChar(char theChar)
+void StoreScreen::KeyDown(KeyCode theKey)
 {
-    if (mBubbleClickToContinue && (theChar == ' ' || theChar == '\r')) AdvanceCrazyDaveDialog();
+    if (theKey == KeyCode::KEYCODE_ESCAPE)
+    {
+        ButtonDepress(StoreScreen::StoreScreen_Back);
+        return;
+    }
+
+    if (mBubbleClickToContinue && (theKey == KeyCode::KEYCODE_SPACE || theKey == KeyCode::KEYCODE_RETURN))
+    {
+        AdvanceCrazyDaveDialog();
+        return;
+    }
+
+    Dialog::KeyDown(theKey);
 }
 
 int StoreScreen::GetItemCost(StoreItem theStoreItem)

--- a/src/Lawn/Widget/StoreScreen.h
+++ b/src/Lawn/Widget/StoreScreen.h
@@ -99,7 +99,7 @@ public:
     virtual void                ButtonPress(int theId);
     /*inline*/ bool             IsPageShown(StorePages thePage);
     virtual void                ButtonDepress(int theId);
-    virtual void                KeyChar(char theChar);
+    virtual void                KeyDown(KeyCode theKey);
     static /*inline*/ int		GetItemCost(StoreItem theStoreItem);
     /*inline*/ bool             CanAffordItem(StoreItem theStoreItem);
     void                        PurchaseItem(StoreItem theStoreItem);

--- a/src/Lawn/Widget/StoreScreen.h
+++ b/src/Lawn/Widget/StoreScreen.h
@@ -99,7 +99,7 @@ public:
     void                        ButtonPress(int theId) override;
     /*inline*/ bool             IsPageShown(StorePages thePage);
     void                        ButtonDepress(int theId) override;
-    void                        KeyChar(char theChar) override;
+    void                        KeyDown(KeyCode theKey) override;
     static /*inline*/ int		GetItemCost(StoreItem theStoreItem);
     /*inline*/ bool             CanAffordItem(StoreItem theStoreItem);
     void                        PurchaseItem(StoreItem theStoreItem);

--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -749,6 +749,7 @@ void LawnApp::DoContinueDialog()
 	ContinueDialog* aDialog = new ContinueDialog(this);
 	CenterDialog(aDialog, aDialog->mWidth, aDialog->mHeight);
 	AddDialog(Dialogs::DIALOG_CONTINUE, aDialog);
+	mWidgetManager->SetFocus(aDialog);
 }
 
 void LawnApp::DoPauseDialog()

--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -1191,7 +1191,7 @@ bool LawnApp::KillDialog(int theDialogId)
 {
 	if (SexyAppBase::KillDialog(theDialogId))
 	{
-		if (mDialogMap.size() == 0)
+		if (mDialogMap.size() == 0 && mWidgetManager->mFocusWidget == nullptr)
 		{
 			if (mBoard)
 			{

--- a/src/SexyAppFramework/platform/default/Input.cpp
+++ b/src/SexyAppFramework/platform/default/Input.cpp
@@ -182,6 +182,7 @@ static KeyCode SDLKeyToKeyCode(SDL_Keycode theSDLKey)
 		case SDLK_TAB:          return KEYCODE_TAB;
 		case SDLK_CLEAR:        return KEYCODE_CLEAR;
 		case SDLK_RETURN:       return KEYCODE_RETURN;
+		case SDLK_AC_BACK:
 		case SDLK_ESCAPE:       return KEYCODE_ESCAPE;
 		case SDLK_SPACE:        return KEYCODE_SPACE;
 		case SDLK_DELETE:       return KEYCODE_DELETE;


### PR DESCRIPTION
This maps `SDLK_AC_BACK` to `KEYCODE_ESCAPE` to allow using the Android physical or virtual back button to pause the game, cancel placements, and dismiss dialogs, providing a more native UX on mobile devices.