### PR TITLE
Change base location of Mac files to be App Bundle friendly

### DIFF
--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -144,6 +144,17 @@ SexyAppBase::SexyAppBase()
 	}
 #elif defined(__EMSCRIPTEN__)
 	mResourceDir = "/";
+#elif defined(__APPLE__)
+	char* aBasePath = SDL_GetPrefPath(NULL, "PvZPortable");
+	if (aBasePath)
+	{
+		mResourceDir = aBasePath;
+		SDL_free(aBasePath);
+	}
+	else
+	{
+		mResourceDir = "";
+	}
 #else
 	char* aBasePath = SDL_GetBasePath();
 	if (aBasePath)
@@ -3215,6 +3226,15 @@ void SexyAppBase::Init()
 #elif defined(__EMSCRIPTEN__)
 	{
 		SetAppDataFolder("/saves/");
+	}
+#elif defined(__APPLE__)
+	{
+		char* aPrefPath = SDL_GetPrefPath(NULL, "PvZPortable");
+		if (aPrefPath)
+		{
+			SetAppDataFolder(aPrefPath);
+			SDL_free(aPrefPath);
+		}
 	}
 #elif !defined(__SWITCH__) && !defined(__3DS__)
 	{


### PR DESCRIPTION
I have added a signed and notarized Mac build of PvZ-Portable on [Mac Source Ports](https://www.macsourceports.com/game/pvz). 

This PR has the one change I made - I have it looking for the data in `~/Library/Application Support/PvZPortable` and changed the save data location to there as well. This keeps it to one directory, allows for App Bundle-friendly behavior, and simplifies the directory structure to make it easier for people to use it. 

I've done the change such that it does this for the Mac version but doesn't conflict with the iOS version. If there's a different way you'd like to handle this let me know. 