### PR TITLE
Fix: update board result on dialog quit action

### DIFF
--- a/src/Lawn/Widget/ContinueDialog.cpp
+++ b/src/Lawn/Widget/ContinueDialog.cpp
@@ -170,6 +170,7 @@ void ContinueDialog::ButtonDepress(int theId)
     else
     {
         mApp->KillDialog(mId);
+        mApp->mBoardResult = BoardResult::BOARDRESULT_QUIT;
         if (mApp->IsAdventureMode())
         {
             mApp->ShowGameSelector();


### PR DESCRIPTION
Set `mApp->mBoardResult` to `BoardResult::BOARDRESULT_QUIT` to avoid deleting savefile when choose `CANCEL` in continue dialog

Close #147