### PR TITLE
Change base location of Mac data to match saved data

### DIFF
--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -144,6 +144,17 @@ SexyAppBase::SexyAppBase()
 	}
 #elif defined(__EMSCRIPTEN__)
 	mResourceDir = "/";
+#elif defined(__APPLE__)
+	char* aBasePath = SDL_GetPrefPath("io.github.wszqkzqk", "PvZPortable");
+	if (aBasePath)
+	{
+		mResourceDir = aBasePath;
+		SDL_free(aBasePath);
+	}
+	else
+	{
+		mResourceDir = "";
+	}
 #else
 	char* aBasePath = SDL_GetBasePath();
 	if (aBasePath)


### PR DESCRIPTION
This modification now makes the Mac version look first in the `~/Library/Application Support/io.github.wszqkzqk/PvZPortable` directory for data, the same location as the saved game files. This keeps it to one directory and allows for App Bundle-friendly behavior.

I've done the change such that it does this for the Mac version but doesn't conflict with the iOS version. 