### PR TITLE
Fix: correct XML encoding detection and UTF-8 2-byte encoding in XMLParser

### DIFF
--- a/src/SexyAppFramework/misc/XMLParser.cpp
+++ b/src/SexyAppFramework/misc/XMLParser.cpp
@@ -36,6 +36,7 @@ static int EncodeUTF8(uint32_t code, char out[4])
 	}
 	if (code <= 0x7FF)
 	{
+		out[0] = static_cast<char>(0xC0 | (code >> 6));
 		out[1] = static_cast<char>(0x80 | (code & 0x3F));
 		return 2;
 	}
@@ -49,7 +50,6 @@ static int EncodeUTF8(uint32_t code, char out[4])
 	if (code <= 0x10FFFF)
 	{
 		out[0] = static_cast<char>(0xF0 | (code >> 18));
-					char c;
 		out[1] = static_cast<char>(0x80 | ((code >> 12) & 0x3F));
 		out[2] = static_cast<char>(0x80 | ((code >> 6) & 0x3F));
 		out[3] = static_cast<char>(0x80 | (code & 0x3F));
@@ -290,7 +290,7 @@ bool XMLParser::OpenFile(const std::string& theFileName)
 			p_ungetc(aChar2, mFile);
 			p_ungetc(aChar1, mFile);			
 		}
-		if ((mGetCharFunc = &XMLParser::GetAsciiChar))
+		if (mGetCharFunc == &XMLParser::GetAsciiChar)
 		{
 			if (aFileLen >= 3) // UTF-8?
 			{


### PR DESCRIPTION
Fix pointer-function comparison in OpenFile to avoid overriding UTF-16 detection path Fix missing first byte assignment for UTF-8 encoding of code points in [0x80, 0x7FF] Remove stray unused local variable in EncodeUTF8

Close #157 and #158