### PR TITLE
Fix: ensure Zen Garden button is marked dirty for redraw

### DIFF
--- a/src/Lawn/Widget/GameSelector.cpp
+++ b/src/Lawn/Widget/GameSelector.cpp
@@ -815,12 +815,13 @@ void GameSelector::Update()
 		mAchievementsButton->SetOffset(aNewX, aNewY);
 		mQuickPlayButton->SetOffset(aNewX, aNewY);
 
-		// @Patoke: make sure these are drawn even outside of bounds (force redraw)
+		// Make sure these are drawn even outside of bounds (force redraw)
 		mAchievementsButton->MarkDirty();
 		mOptionsButton->MarkDirty();
 		mHelpButton->MarkDirty();
 		mQuitButton->MarkDirty();
 		mStoreButton->MarkDirty();
+		mZenGardenButton->MarkDirty();
 
 		mSlideCounter--;
 	}


### PR DESCRIPTION
This pull request makes a minor update to the `GameSelector::Update()` method to ensure that the `mZenGardenButton` is properly marked for redraw, along with other UI buttons. This helps guarantee that the Zen Garden button is updated visually, even when it is outside of the usual bounds.

* UI consistency:
  * Ensured `mZenGardenButton` is marked dirty to force redraw, matching the behavior of other buttons in the `GameSelector` widget.