### PR TITLE
Fix: update AwardScreen initialization to show achievements based on parameter

### DIFF
--- a/src/Lawn/Widget/AwardScreen.cpp
+++ b/src/Lawn/Widget/AwardScreen.cpp
@@ -639,10 +639,20 @@ void AwardScreen::DrawAchievements(Graphics* g) {
 
 // GOTY @Patoke: 0x409400
 void AwardScreen::AchievementsContinuePressed() {
-	// @Patoke: implemented
 	if (mAwardType == AWARD_ACHIEVEMENTONLY) {
 		mApp->KillAwardScreen();
-		mApp->PreNewGame(GAMEMODE_ADVENTURE, false);
+		if (mApp->IsAdventureMode()) {
+			mApp->PreNewGame(mApp->mGameMode, false);
+		}
+		else if (mApp->IsSurvivalMode()) {
+			mApp->ShowChallengeScreen(ChallengePage::CHALLENGE_PAGE_SURVIVAL);
+		}
+		else if (mApp->IsPuzzleMode()) {
+			mApp->ShowChallengeScreen(ChallengePage::CHALLENGE_PAGE_PUZZLE);
+		}
+		else {
+			mApp->ShowChallengeScreen(ChallengePage::CHALLENGE_PAGE_CHALLENGE);
+		}
 	}
 	else {
 		mStartButton->mBtnNoDraw = !mShowStartButtonAfterAchievements;

--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -73,6 +73,24 @@ bool gFastMo = false;  //0x6A9EAB
 LawnApp* gLawnApp = nullptr;  //0x6A9EC0
 int gSlowMoCounter = 0;  //0x6A9EC4
 
+static bool HasUnshownAchievements(PlayerInfo* thePlayerInfo)
+{
+	if (thePlayerInfo == nullptr)
+	{
+		return false;
+	}
+
+	for (int i = 0; i < MAX_ACHIEVEMENTS; i++)
+	{
+		if (thePlayerInfo->mEarnedAchievements[i] && !thePlayerInfo->mShownAchievements[i])
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
 //0x44E8A0
 bool LawnGetCloseRequest()
 {
@@ -1582,6 +1600,10 @@ void LawnApp::CheckForGameEnd()
 		{
 			ShowAwardScreen(AwardType::AWARD_FORLEVEL, true);
 		}
+		else if (HasUnshownAchievements(mPlayerInfo))
+		{
+			ShowAwardScreen(AwardType::AWARD_ACHIEVEMENTONLY, true);
+		}
 		else
 		{
 			PreNewGame(mGameMode, false);
@@ -1596,6 +1618,10 @@ void LawnApp::CheckForGameEnd()
 			if (aUnlockedNewChallenge && HasFinishedAdventure())
 			{
 				ShowAwardScreen(AwardType::AWARD_FORLEVEL, true);
+			}
+			else if (HasUnshownAchievements(mPlayerInfo))
+			{
+				ShowAwardScreen(AwardType::AWARD_ACHIEVEMENTONLY, true);
 			}
 			else
 			{
@@ -1617,6 +1643,10 @@ void LawnApp::CheckForGameEnd()
 		{
 			ShowAwardScreen(AwardType::AWARD_FORLEVEL, true);
 		}
+		else if (HasUnshownAchievements(mPlayerInfo))
+		{
+			ShowAwardScreen(AwardType::AWARD_ACHIEVEMENTONLY, true);
+		}
 		else
 		{
 			ShowChallengeScreen(ChallengePage::CHALLENGE_PAGE_PUZZLE);
@@ -1629,6 +1659,10 @@ void LawnApp::CheckForGameEnd()
 		if (aUnlockedNewChallenge && HasFinishedAdventure())
 		{
 			ShowAwardScreen(AwardType::AWARD_FORLEVEL, true);
+		}
+		else if (HasUnshownAchievements(mPlayerInfo))
+		{
+			ShowAwardScreen(AwardType::AWARD_ACHIEVEMENTONLY, true);
 		}
 		else
 		{


### PR DESCRIPTION
This pull request improves the `AwardScreen` widget by refining achievement display, enhancing button interactivity, and fixing the initialization of achievement animations. The changes also ensure that the `AwardScreen` correctly reflects whether achievements should be shown when invoked from the main application.

**Award screen UI and interaction improvements:**

* Adjusted achievement icon and text positioning in `DrawAchievements`, and fixed the achievement description display to use the correct variable (`aAchievementDesc` instead of `aAchievementName`).
* Added initialization of `mAchievementAnimTime` to prevent uninitialized animation timing.

**Button and cursor interaction enhancements:**

* Updated cursor logic and sound feedback to include the `mContinueButton` alongside other buttons, improving user experience and consistency in both `Update` and `MouseDown` methods. [[1]](diffhunk://#diff-ab6476ed78256c1d691c41167e97618ae277b7f7c8ffd527f2c1f90c9e973263L462-R463) [[2]](diffhunk://#diff-ab6476ed78256c1d691c41167e97618ae277b7f7c8ffd527f2c1f90c9e973263L586-R587)

**Award screen invocation fix:**

* Fixed the constructor call in `LawnApp::ShowAwardScreen` to correctly pass the `theShowAchievements` parameter, ensuring the award screen displays achievements when appropriate.