### PR TITLE
Fix: address AwardScreen blank issue when mAchievementItems is empty

### DIFF
--- a/src/Lawn/Widget/AwardScreen.cpp
+++ b/src/Lawn/Widget/AwardScreen.cpp
@@ -80,6 +80,9 @@ AwardScreen::AwardScreen(LawnApp* theApp, AwardType theAwardType, bool theShowin
 				aDestY += 76;
 			}
 		}
+		else {
+			mShowingAchievements = false;
+		}
 
 		mApp->WriteCurrentUserConfig();
 	}


### PR DESCRIPTION
A softlock will occur at the end of each level if `ShowAwardScreen(AwardType::AWARD_FORLEVEL, true)` is called but the player has never earned any unshown achievements. The Next Level button will be hidden in this case.

I added a check at the end of the AwardScreen constructor (if `mAchievementItems.empty()`, `mShowingAchievements` will be reset to false)

<img width="1726" height="588" alt="image" src="https://github.com/user-attachments/assets/9ba03737-238f-4136-9e70-3b3d218db1d8" />
