### PR TITLE
Fix: implement mouse wheel input handling in ProcessDeferredMessages

### DIFF
--- a/src/SexyAppFramework/platform/default/Input.cpp
+++ b/src/SexyAppFramework/platform/default/Input.cpp
@@ -412,6 +412,16 @@ bool SexyAppBase::ProcessDeferredMessages(bool singleMessage)
 				}
 				break;
 
+			case SDL_MOUSEWHEEL:
+			{
+				mLastUserInputTick = mLastTimerTime;
+				if (event.wheel.direction == SDL_MOUSEWHEEL_FLIPPED)
+					mWidgetManager->MouseWheel(event.wheel.y);
+				else
+					mWidgetManager->MouseWheel(-event.wheel.y);
+				break;
+			}
+
 			case SDL_MOUSEMOTION:
 			{
 				if (!mMouseIn)


### PR DESCRIPTION
This pull request adds support for handling mouse wheel events in the `ProcessDeferredMessages` method, improving input responsiveness for mouse wheel actions.

**Input handling improvements:**

* Added a case for `SDL_MOUSEWHEEL` events in `ProcessDeferredMessages`, updating the last user input tick and correctly passing the wheel direction to `mWidgetManager->MouseWheel`.