### PR TITLE
Fix: prevent state transitions and concurrent slides during screen animation

### DIFF
--- a/src/Lawn/Widget/AchievementsScreen.cpp
+++ b/src/Lawn/Widget/AchievementsScreen.cpp
@@ -205,7 +205,6 @@ void AchievementsWidget::MouseDown(int x, int y, int theClickCount) {
 
 // GOTY @Patoke: 0x401890
 void AchievementsWidget::MouseUp(int x, int y, int theClickCount) {
-	(void)theClickCount;
 	Point aPos = Point(x, y);
 	if (aBackButtonRect.Contains(aPos)) {
 		mApp->mGameSelector->SlideTo(0, 0);
@@ -217,6 +216,8 @@ void AchievementsWidget::MouseUp(int x, int y, int theClickCount) {
 		mScrollDirection = mDidPressMoreButton ? -1 : 1;
 		mScrollValue = 20;
 	}
+
+	(void)theClickCount;
 }
 
 // GOTY @Patoke: 0x4019A0

--- a/src/Lawn/Widget/GameSelector.cpp
+++ b/src/Lawn/Widget/GameSelector.cpp
@@ -1311,6 +1311,9 @@ bool GameSelector::ShouldDoZenTuturialBeforeAdventure()
 // GOTY @Patoke: 0x44F5C0
 void GameSelector::ButtonDepress(int theId)
 {
+	if (mSlideCounter > 0)
+		return;
+
 	if (theId == GameSelector::GameSelector_Minigame && mMinigamesLocked)
 	{
 		mApp->LawnMessageBox(Dialogs::DIALOG_MESSAGE, "[MODE_LOCKED]", "[MINIGAME_LOCKED_MESSAGE]", "[DIALOG_BUTTON_OK]", "", Dialog::BUTTONS_FOOTER);
@@ -1506,6 +1509,9 @@ void GameSelector::AddPreviewProfiles()
 // @Patoke: implemented functions
 // GOTY @Patoke: 0x450140
 void GameSelector::SlideTo(int theX, int theY) {
+	if (mSlideCounter > 0)
+		return;
+
 	mSlideCounter = 75;
 	mDestX = theX;
 	mDestY = theY;


### PR DESCRIPTION
This pull request introduces improvements to user interaction handling in the achievements and game selector widgets, mainly by preventing unintended actions during slide animations and making minor code organization adjustments.

**Interaction handling improvements:**

* Prevents button actions in `GameSelector::ButtonDepress` and slide requests in `GameSelector::SlideTo` when a slide animation is already in progress by checking `mSlideCounter`. This helps avoid overlapping transitions and unintended behavior. [[1]](diffhunk://#diff-da3fb281a0f49bae04e21e1049232e61cfcd39485402e829847c826597d1d8bcR1314-R1316) [[2]](diffhunk://#diff-da3fb281a0f49bae04e21e1049232e61cfcd39485402e829847c826597d1d8bcR1512-R1514)

**Code organization:**

* Moves the unused `theClickCount` parameter casting to the end of `AchievementsWidget::MouseUp` for consistency and clarity. [[1]](diffhunk://#diff-b302266cab35e343dba2c3b31c4334ce1033f6d04bc49911b9a6d72ce395c4a0L208) [[2]](diffhunk://#diff-b302266cab35e343dba2c3b31c4334ce1033f6d04bc49911b9a6d72ce395c4a0R219-R220)