### PR TITLE
Fix: stabilize long-run animation and flashing counters

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -7344,7 +7344,7 @@ void Board::DrawUIBottom(Graphics* g)
 {
 	if (mBackground == BackgroundType::BACKGROUND_ZOMBIQUARIUM)
 	{
-		int aWaveTime = abs(mMainCounter / 8 % 22 - 11);
+		int aWaveTime = std::abs(static_cast<int>((mMainCounter / 8) % 22) - 11);
 		g->SetDrawMode(Graphics::DRAWMODE_ADDITIVE);
 		g->DrawImageCel(Sexy::IMAGE_WAVESIDE, 0, 40, aWaveTime);
 		g->DrawImageCel(Sexy::IMAGE_WAVECENTER, 160, 40, aWaveTime);
@@ -7530,8 +7530,10 @@ void Board::DrawFog(Graphics* g)
 			// 本格浓雾横坐标 = 列 * 80 + 浓雾偏移 - 15，纵坐标 = 行 * 85 + 20
 			float aPosX = x * 80 + mFogOffset - 15;
 			float aPosY = y * 85 + 20;
+			// 浓雾动画依赖 900 和 500 两个周期，取最小公倍数 4500 帧后局部取模，避免大数转 float 精度丢失。
+			constexpr uint32_t FOG_ANIM_PERIOD = 4500;
 			// 开始计算周期变化的颜色，aTime 为根据主计时计算的时间
-			float aTime = mMainCounter * PI * 2;
+			float aTime = static_cast<float>(mMainCounter % FOG_ANIM_PERIOD) * PI * 2;
 			// 与行、列有关的初始相位
 			float aPhaseX = 6 * PI * x / MAX_GRID_SIZE_X;
 			float aPhaseY = 6 * PI * y / (MAX_GRID_SIZE_Y + 1);

--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -7644,7 +7644,7 @@ void Board::Draw(Graphics* g)
 	if (mDrawCount && mCutScene->mPreloaded)
 	{
 		int64_t aTickCount = SDL_GetTicks();
-		int64_t aIntervalDraws = mDrawCount - mIntervalDrawCountStart;
+		int64_t aIntervalDraws = static_cast<int64_t>(mDrawCount) - static_cast<int64_t>(mIntervalDrawCountStart);
 		int64_t aInterval = aTickCount - mIntervalDrawTime;
 		if (aInterval > 10000)
 		{

--- a/src/Lawn/Board.h
+++ b/src/Lawn/Board.h
@@ -175,7 +175,7 @@ public:
 	int32_t							mPrevMouseY;
 	int32_t							mSunMoney;
 	int32_t							mNumWaves;
-	int32_t							mMainCounter;
+	uint32_t						mMainCounter;
 	int32_t							mEffectCounter;
 	int32_t							mDrawCount;
 	int32_t							mRiseFromGraveCounter;

--- a/src/Lawn/Board.h
+++ b/src/Lawn/Board.h
@@ -176,8 +176,8 @@ public:
 	int32_t							mSunMoney;
 	int32_t							mNumWaves;
 	uint32_t						mMainCounter;
-	int32_t							mEffectCounter;
-	int32_t							mDrawCount;
+	uint32_t						mEffectCounter;
+	uint32_t						mDrawCount;
 	int32_t							mRiseFromGraveCounter;
 	int32_t							mOutOfMoneyCounter;
 	int32_t							mCurrentWave;
@@ -230,7 +230,7 @@ public:
 	int32_t							mMaxSunPlants;
 	int64_t							mStartDrawTime;
 	int64_t							mIntervalDrawTime;
-	int32_t							mIntervalDrawCountStart;
+	uint32_t						mIntervalDrawCountStart;
 	float							mMinFPS;
 	int32_t							mPreloadTime;
 	intptr_t						mGameID;

--- a/src/Lawn/Challenge.cpp
+++ b/src/Lawn/Challenge.cpp
@@ -2338,8 +2338,11 @@ void Challenge::DrawBeghouled(Graphics* g)
 			float aPixelX = mBoard->GridToPixelX(mChallengeGridX, mChallengeGridY) + 80;
 			float aPixelY = mBoard->GridToPixelY(mChallengeGridX, mChallengeGridY) + 100;
 
+			// Rotation speed coefficient is 2*PI*0.001, which means one full rotation every 1000 frames. Modulus is to avoid large angle float precision cliffs.
+			constexpr uint32_t BEGHOULED_TWIST_ROTATION_PERIOD = 1000;
+			float aRotation = -static_cast<float>(mBoard->mMainCounter % BEGHOULED_TWIST_ROTATION_PERIOD) * (2 * PI * 0.001f);
 			SexyTransform2D aTransform;
-			TodScaleRotateTransformMatrix(aTransform, aPixelX, aPixelY, -mBoard->mMainCounter * 2 * PI * 0.001f, 1, 1);
+			TodScaleRotateTransformMatrix(aTransform, aPixelX, aPixelY, aRotation, 1, 1);
 
 			Image* aImageOverlay = Sexy::IMAGE_BEGHOULED_TWIST_OVERLAY;
 			Rect aSrcRect = Rect(0, 0, aImageOverlay->mWidth, aImageOverlay->mHeight);

--- a/src/Lawn/Challenge.cpp
+++ b/src/Lawn/Challenge.cpp
@@ -3046,9 +3046,9 @@ void Challenge::DrawRain(Graphics* g)
 
 	aBoardOffsetX = mBoard->mX / 100 * -100;
 
-	int aTime = mBoard->mEffectCounter;
-	int aTimeOffsetXEst = TodAnimateCurve(0, 100, aTime % 100, 0, -100, CURVE_LINEAR);
-	int aTimeOffsetYEst = TodAnimateCurve(0, 20, aTime % 20, -100, 0, CURVE_LINEAR);
+	const uint32_t aTime = mBoard->mEffectCounter;
+	int aTimeOffsetXEst = TodAnimateCurve(0, 100, static_cast<int>(aTime % 100u), 0, -100, CURVE_LINEAR);
+	int aTimeOffsetYEst = TodAnimateCurve(0, 20, static_cast<int>(aTime % 20u), -100, 0, CURVE_LINEAR);
 
 	// 绘制远景的雨
 	for (int aHorCnt = 9; aHorCnt > 0; aHorCnt--)
@@ -3061,9 +3061,8 @@ void Challenge::DrawRain(Graphics* g)
 		}
 	}
 
-	aTime = mBoard->mEffectCounter;
-	float aTimeOffsetXCls = TodAnimateCurve(0, 161, aTime % 161, 0, -100, CURVE_LINEAR);
-	float aTimeOffsetYCls = TodAnimateCurve(0, 33, aTime % 33, -100, 0, CURVE_LINEAR);
+	float aTimeOffsetXCls = TodAnimateCurve(0, 161, static_cast<int>(aTime % 161u), 0, -100, CURVE_LINEAR);
+	float aTimeOffsetYCls = TodAnimateCurve(0, 33, static_cast<int>(aTime % 33u), -100, 0, CURVE_LINEAR);
 	// 绘制近景的雨
 	for (int aHorCnt = 0; aHorCnt < 9; aHorCnt++)
 	{

--- a/src/Lawn/GridItem.cpp
+++ b/src/Lawn/GridItem.cpp
@@ -268,8 +268,10 @@ void GridItem::DrawCrater(Graphics* g)
             aCelCol = 1;
         }
 
+        // 弹坑水波摆动每 200 帧循环一次，局部取模可避免超长运行后的浮点抖动。
+        constexpr uint32_t CRATER_ANIM_PERIOD = 200;
         float aPos = mGridY * PI + mGridX * PI * 0.25f;
-        float aTime = mBoard->mMainCounter * PI * 2.0f / 200.0f;
+        float aTime = static_cast<float>(mBoard->mMainCounter % CRATER_ANIM_PERIOD) * (PI * 2.0f / static_cast<float>(CRATER_ANIM_PERIOD));
         aYPos += sin(aPos + aTime) * 2.0f;
     }
     else if (mBoard->StageHasRoof())

--- a/src/Lawn/Plant.cpp
+++ b/src/Lawn/Plant.cpp
@@ -3561,18 +3561,10 @@ float PlantDrawHeightOffset(Board* theBoard, Plant* thePlant, SeedType theSeedTy
 
     if (doFloating)
     {
-        int aCounter;
-        if (theBoard)
-        {
-            aCounter = theBoard->mMainCounter;
-        }
-        else
-        {
-            aCounter = gLawnApp->mAppCounter;
-        }
+        uint32_t aCounter = theBoard ? theBoard->mMainCounter : gLawnApp->mAppCounter;
 
         float aPos = theRow * PI + theCol * 0.25f * PI;
-        float aTime = aCounter * 2.0f * PI / 200.0f;
+        float aTime = static_cast<float>(aCounter % 200) * (2.0f * PI / 200.0f);
         float aFloatingHeight = sin(aPos + aTime) * 2.0f;
         aHeightOffset += aFloatingHeight;
     }
@@ -4014,17 +4006,9 @@ void Plant::Draw(Graphics* g)
 
         if (Plant::IsFlying(mSeedType))
         {
-            int aCounter;
-            if (IsOnBoard())
-            {
-                aCounter = mBoard->mMainCounter;
-            }
-            else
-            {
-                aCounter = mApp->mAppCounter;
-            }
+            uint32_t aCounter = IsOnBoard() ? mBoard->mMainCounter : mApp->mAppCounter;
 
-            float aTime = (mRow * 97 + mPlantCol * 61 + aCounter) * 0.03f;
+            float aTime = static_cast<float>(fmod((mRow * 97.0 + mPlantCol * 61.0 + static_cast<double>(aCounter)) * 0.03, 2.0 * PI));
             float aWave = sin(aTime) * 2.0f;
             aOffsetY += aWave;
         }

--- a/src/Lawn/System/PoolEffect.cpp
+++ b/src/Lawn/System/PoolEffect.cpp
@@ -36,6 +36,7 @@ void PoolEffect::PoolEffectInitialize()
     TodHesitationBracket aHesitation("PoolEffectInitialize");
 
     mApp = gLawnApp;
+    mPoolCounter = 0;
 
     mCausticImage = new MemoryImage(gSexyAppBase);
     mCausticImage->mWidth = CAUSTIC_IMAGE_WIDTH;
@@ -91,16 +92,16 @@ void PoolEffect::UpdateWaterEffect()
     int idx = 0;
     for (int y = 0; y < CAUSTIC_IMAGE_HEIGHT; y++)
     {
-        int timeV1 = (256 - y) << 17;
-        int timeV0 = y << 17;
+        unsigned int timeV1 = (256 - y) << 17;
+        unsigned int timeV0 = y << 17;
 
         for (int x = 0; x < CAUSTIC_IMAGE_WIDTH; x++)
         {
             uint32_t* pix = &mCausticImage->mBits[idx];
 
-            int timeU = x << 17;
-            int timePool0 = mPoolCounter << 16;
-            int timePool1 = ((mPoolCounter & 65535) + 1) << 16;
+            unsigned int timeU = x << 17;
+            unsigned int timePool0 = mPoolCounter << 16;
+            unsigned int timePool1 = ((mPoolCounter & 65535u) + 1u) << 16;
             int a1 = static_cast<unsigned char>(BilinearLookupFixedPoint(timeU - timePool1 / 6, timeV1 + timePool0 / 8)); //scroll speed
             int a0 = static_cast<unsigned char>(BilinearLookupFixedPoint(timeU + timePool0 / 10, timeV0)); //scroll speed
             unsigned char a = static_cast<unsigned char>((a0 + a1) / 2);
@@ -155,7 +156,8 @@ void PoolEffect::PoolEffectDraw(Sexy::Graphics* g, bool theIsNight)
             aOffsetArray[2][x][y][1] = y / 50.0f; //5
             if (x != 0 && x != 15 && y != 0 && y != 5)
             {
-                float aPoolPhase = mPoolCounter * 1 * PI; //speed, * 2 is default
+                constexpr unsigned int POOL_PHASE_PERIOD = 316800u; // LCM of all sin wave effective periods (1600, 300, 1800, 220, 3200/3, 200, 720, 640, 88)
+                float aPoolPhase = (mPoolCounter % POOL_PHASE_PERIOD) * PI; //speed, * 2 is default
                 float aWaveTime1 = aPoolPhase / 800.0;
                 float aWaveTime2 = aPoolPhase / 150.0;
                 float aWaveTime3 = aPoolPhase / 900.0;
@@ -260,5 +262,5 @@ void PoolEffect::PoolEffectDraw(Sexy::Graphics* g, bool theIsNight)
 
 void PoolEffect::PoolEffectUpdate()
 {
-    ++mPoolCounter; //wonder if this stops after 4.5 years.
+    ++mPoolCounter;
 }

--- a/src/Lawn/System/PoolEffect.h
+++ b/src/Lawn/System/PoolEffect.h
@@ -40,7 +40,7 @@ public:
 	unsigned char*		mCausticGrayscaleImage;
 	Sexy::MemoryImage*	mCausticImage;
 	LawnApp*			mApp;
-	int					mPoolCounter;
+	unsigned int		mPoolCounter;
 
 public:
 	void				PoolEffectInitialize();

--- a/src/Lawn/System/SaveGame.cpp
+++ b/src/Lawn/System/SaveGame.cpp
@@ -1608,7 +1608,7 @@ static void SyncBoardBasePortable(PortableSaveContext& theContext, Board* theBoa
 			case BOARD_FIELD_PREV_MOUSE_Y: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPrevMouseY); }); break;
 			case BOARD_FIELD_SUN_MONEY: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mSunMoney); }); break;
 			case BOARD_FIELD_NUM_WAVES: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mNumWaves); }); break;
-			case BOARD_FIELD_MAIN_COUNTER: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mMainCounter); }); break;
+			case BOARD_FIELD_MAIN_COUNTER: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mMainCounter); }); break;
 			case BOARD_FIELD_EFFECT_COUNTER: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mEffectCounter); }); break;
 			case BOARD_FIELD_DRAW_COUNT: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mDrawCount); }); break;
 			case BOARD_FIELD_RISE_FROM_GRAVE_COUNTER: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mRiseFromGraveCounter); }); break;
@@ -1718,7 +1718,7 @@ static void SyncBoardBasePortable(PortableSaveContext& theContext, Board* theBoa
 		AppendFieldWithSync(aBlob, BOARD_FIELD_PREV_MOUSE_Y, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPrevMouseY); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_SUN_MONEY, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mSunMoney); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_NUM_WAVES, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mNumWaves); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_MAIN_COUNTER, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mMainCounter); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_MAIN_COUNTER, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mMainCounter); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_EFFECT_COUNTER, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mEffectCounter); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_DRAW_COUNT, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mDrawCount); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_RISE_FROM_GRAVE_COUNTER, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mRiseFromGraveCounter); });

--- a/src/Lawn/System/SaveGame.cpp
+++ b/src/Lawn/System/SaveGame.cpp
@@ -1609,8 +1609,8 @@ static void SyncBoardBasePortable(PortableSaveContext& theContext, Board* theBoa
 			case BOARD_FIELD_SUN_MONEY: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mSunMoney); }); break;
 			case BOARD_FIELD_NUM_WAVES: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mNumWaves); }); break;
 			case BOARD_FIELD_MAIN_COUNTER: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mMainCounter); }); break;
-			case BOARD_FIELD_EFFECT_COUNTER: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mEffectCounter); }); break;
-			case BOARD_FIELD_DRAW_COUNT: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mDrawCount); }); break;
+			case BOARD_FIELD_EFFECT_COUNTER: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mEffectCounter); }); break;
+			case BOARD_FIELD_DRAW_COUNT: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mDrawCount); }); break;
 			case BOARD_FIELD_RISE_FROM_GRAVE_COUNTER: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mRiseFromGraveCounter); }); break;
 			case BOARD_FIELD_OUT_OF_MONEY_COUNTER: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mOutOfMoneyCounter); }); break;
 			case BOARD_FIELD_CURRENT_WAVE: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mCurrentWave); }); break;
@@ -1663,7 +1663,7 @@ static void SyncBoardBasePortable(PortableSaveContext& theContext, Board* theBoa
 			case BOARD_FIELD_MAX_SUN_PLANTS: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mMaxSunPlants); }); break;
 			case BOARD_FIELD_START_DRAW_TIME: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt64(theBoard->mStartDrawTime); }); break;
 			case BOARD_FIELD_INTERVAL_DRAW_TIME: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt64(theBoard->mIntervalDrawTime); }); break;
-			case BOARD_FIELD_INTERVAL_DRAW_COUNT_START: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mIntervalDrawCountStart); }); break;
+			case BOARD_FIELD_INTERVAL_DRAW_COUNT_START: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mIntervalDrawCountStart); }); break;
 			case BOARD_FIELD_MIN_FPS: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncFloat(theBoard->mMinFPS); }); break;
 			case BOARD_FIELD_PRELOAD_TIME: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPreloadTime); }); break;
 			case BOARD_FIELD_GAME_ID: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ int64_t aGameId = static_cast<int64_t>(theBoard->mGameID); c.SyncInt64(aGameId); if (c.mReading) theBoard->mGameID = static_cast<intptr_t>(aGameId); }); break;
@@ -1719,8 +1719,8 @@ static void SyncBoardBasePortable(PortableSaveContext& theContext, Board* theBoa
 		AppendFieldWithSync(aBlob, BOARD_FIELD_SUN_MONEY, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mSunMoney); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_NUM_WAVES, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mNumWaves); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_MAIN_COUNTER, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mMainCounter); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_EFFECT_COUNTER, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mEffectCounter); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_DRAW_COUNT, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mDrawCount); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_EFFECT_COUNTER, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mEffectCounter); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_DRAW_COUNT, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mDrawCount); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_RISE_FROM_GRAVE_COUNTER, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mRiseFromGraveCounter); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_OUT_OF_MONEY_COUNTER, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mOutOfMoneyCounter); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_CURRENT_WAVE, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mCurrentWave); });
@@ -1773,7 +1773,7 @@ static void SyncBoardBasePortable(PortableSaveContext& theContext, Board* theBoa
 		AppendFieldWithSync(aBlob, BOARD_FIELD_MAX_SUN_PLANTS, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mMaxSunPlants); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_START_DRAW_TIME, [&](PortableSaveContext& c){ c.SyncInt64(theBoard->mStartDrawTime); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_INTERVAL_DRAW_TIME, [&](PortableSaveContext& c){ c.SyncInt64(theBoard->mIntervalDrawTime); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_INTERVAL_DRAW_COUNT_START, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mIntervalDrawCountStart); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_INTERVAL_DRAW_COUNT_START, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mIntervalDrawCountStart); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_MIN_FPS, [&](PortableSaveContext& c){ c.SyncFloat(theBoard->mMinFPS); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_PRELOAD_TIME, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPreloadTime); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_GAME_ID, [&](PortableSaveContext& c){ int64_t aGameId = static_cast<int64_t>(theBoard->mGameID); c.SyncInt64(aGameId); if (c.mReading) theBoard->mGameID = static_cast<intptr_t>(aGameId); });

--- a/src/LawnApp.h
+++ b/src/LawnApp.h
@@ -106,7 +106,7 @@ public:
 	PlayerInfo*						mPlayerInfo;
 	LevelStats*						mLastLevelStats;
 	bool							mCloseRequest;
-	int								mAppCounter;
+	uint32_t						mAppCounter;
 	Music*							mMusic;
 	ReanimationID					mCrazyDaveReanimID;
 	CrazyDaveState					mCrazyDaveState;

--- a/src/Sexy.TodLib/TodCommon.cpp
+++ b/src/Sexy.TodLib/TodCommon.cpp
@@ -1008,9 +1008,9 @@ void SexyMatrix3Multiply(SexyMatrix3& m, const SexyMatrix3& l, const SexyMatrix3
 }
 
 // GOTY @Patoke: 0x51D2C0
-Color GetFlashingColor(int theCounter, int theFlashTime)
+Color GetFlashingColor(uint32_t theCounter, int theFlashTime)
 {
-	int aTimeAge = theCounter % theFlashTime;
+	int aTimeAge = static_cast<int>(theCounter % static_cast<uint32_t>(theFlashTime));
 	int aTimeInf = theFlashTime / 2;
 	//int aTimeDel = abs(aTimeInf - aTimeAge) / aTimeInf;
 	// @Patoke: order wasn't like in binaries

--- a/src/Sexy.TodLib/TodCommon.h
+++ b/src/Sexy.TodLib/TodCommon.h
@@ -168,7 +168,7 @@ inline float			FloatLerp(float theStart, float theEnd, float theFactor)	{ return
 inline int				FloatRoundToInt(float theFloatValue)						{ return theFloatValue > 0 ? theFloatValue + 0.5f : theFloatValue - 0.5f; }
 inline bool				FloatApproxEqual(float theFloatVal1, float theFloatVal2)	{ return fabs(theFloatVal1 - theFloatVal2) < FLT_EPSILON; }
 
-Color					GetFlashingColor(int theCounter, int theFlashTime);
+Color					GetFlashingColor(uint32_t theCounter, int theFlashTime);
 /*inline*/ int			ColorComponentMultiply(int theColor1, int theColor2);
 Color					ColorsMultiply(const Color& theColor1, const Color& theColor2);
 Color					ColorAdd(const Color& theColor1, const Color& theColor2);


### PR DESCRIPTION
* Switch mMainCounter and mAppCounter to uint32_t for defined wrap-around sync
* BOARD_FIELD_MAIN_COUNTER via SyncUInt32 in save/load path
* Clamp periodic animation phases before float math (fog, crater, beghouled, floating plants)
* Wrap flying-plant phase with fmod(..., 2*PI) to prevent long-run drift
* Update GetFlashingColor counter type to uint32_t to remove signed narrowing risks