### PR TITLE
Change counter fields to uint32_t for consistency in Board and PlayerInfo

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -152,6 +152,7 @@ Board::Board(LawnApp* theApp)
 	mMushroomAndCoffeeBeansOnly = true; // @Patoke: added construct
 	mMushroomsUsed = false; // @Patoke: added construct
 	mLevelCoinsCollected = 0;
+	mGargantuarsKillsByCornCob = 0;
 	mCoinsCollected = 0;
 	mDiamondsCollected = 0;
 	mPottedPlantsCollected = 0;

--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -5152,8 +5152,8 @@ void Board::SurvivalSaveScore()
 	if (!mApp->IsSurvivalMode())
 		return;
 
-	int aFlagsCompleted = GetSurvivalFlagsCompleted();
-	int& aFlagsRecord = mApp->mPlayerInfo->mChallengeRecords[mApp->GetCurrentChallengeIndex()];
+	uint32_t aFlagsCompleted = GetSurvivalFlagsCompleted();
+	uint32_t& aFlagsRecord = mApp->mPlayerInfo->mChallengeRecords[mApp->GetCurrentChallengeIndex()];
 	if (aFlagsCompleted > aFlagsRecord)
 	{
 		aFlagsRecord = aFlagsCompleted;
@@ -5166,8 +5166,8 @@ void Board::PuzzleSaveStreak()
 	if (!mApp->IsEndlessIZombie(mApp->mGameMode) && !mApp->IsEndlessScaryPotter(mApp->mGameMode))
 		return;
 
-	int aStreak = mChallenge->mSurvivalStage + 1;
-	int& aRecord = mApp->mPlayerInfo->mChallengeRecords[mApp->GetCurrentChallengeIndex()];
+	uint32_t aStreak = mChallenge->mSurvivalStage + 1;
+	uint32_t& aRecord = mApp->mPlayerInfo->mChallengeRecords[mApp->GetCurrentChallengeIndex()];
 	if (aStreak > aRecord)
 	{
 		aRecord = aStreak;

--- a/src/Lawn/Board.h
+++ b/src/Lawn/Board.h
@@ -242,7 +242,7 @@ public:
 	bool							mMushroomAndCoffeeBeansOnly;							//+GOTY @Patoke: 0x5790
 	bool							mMushroomsUsed;											//+GOTY @Patoke: 0x5791
 	uint32_t						mLevelCoinsCollected;									//+GOTY @Patoke: 0x5788
-	int32_t							mGargantuarsKillsByCornCob;								//+GOTY @Patoke: 0x578C
+	uint32_t						mGargantuarsKillsByCornCob;								//+GOTY @Patoke: 0x578C
 	uint32_t						mCoinsCollected;										//+GOTY @Patoke: 0x57C8
 	uint32_t						mDiamondsCollected;										//+GOTY @Patoke: 0x57CC
 	uint32_t						mPottedPlantsCollected;

--- a/src/Lawn/Board.h
+++ b/src/Lawn/Board.h
@@ -225,8 +225,8 @@ public:
 	bool							mSukhbirMode;
 	BoardResult						mPrevBoardResult;
 	int32_t							mTriggeredLawnMowers;
-	int32_t							mPlayTimeActiveLevel;
-	int32_t							mPlayTimeInactiveLevel;
+	uint32_t						mPlayTimeActiveLevel;
+	uint32_t						mPlayTimeInactiveLevel;
 	int32_t							mMaxSunPlants;
 	int64_t							mStartDrawTime;
 	int64_t							mIntervalDrawTime;
@@ -234,19 +234,19 @@ public:
 	float							mMinFPS;
 	int32_t							mPreloadTime;
 	intptr_t						mGameID;
-	int32_t							mGravesCleared;
-	int32_t							mPlantsEaten;
-	int32_t							mPlantsShoveled;
+	uint32_t						mGravesCleared;
+	uint32_t						mPlantsEaten;
+	uint32_t						mPlantsShoveled;
 	bool							mPeaShooterUsed;										//+GOTY @Patoke: 0x5784
 	bool							mCatapultPlantsUsed;									//+GOTY @Patoke: 0x5785
 	bool							mMushroomAndCoffeeBeansOnly;							//+GOTY @Patoke: 0x5790
 	bool							mMushroomsUsed;											//+GOTY @Patoke: 0x5791
-	int32_t							mLevelCoinsCollected;									//+GOTY @Patoke: 0x5788
+	uint32_t						mLevelCoinsCollected;									//+GOTY @Patoke: 0x5788
 	int32_t							mGargantuarsKillsByCornCob;								//+GOTY @Patoke: 0x578C
-	int32_t							mCoinsCollected;										//+GOTY @Patoke: 0x57C8
-	int32_t							mDiamondsCollected;										//+GOTY @Patoke: 0x57CC
-	int32_t							mPottedPlantsCollected;
-	int32_t							mChocolateCollected;
+	uint32_t						mCoinsCollected;										//+GOTY @Patoke: 0x57C8
+	uint32_t						mDiamondsCollected;										//+GOTY @Patoke: 0x57CC
+	uint32_t						mPottedPlantsCollected;
+	uint32_t						mChocolateCollected;
 
 public:
 	Board(LawnApp* theApp);

--- a/src/Lawn/System/PlayerInfo.h
+++ b/src/Lawn/System/PlayerInfo.h
@@ -72,11 +72,11 @@ public:
     uint32_t            mId;                                //+0x20
     int32_t             mLevel;                             //+0x24
     int32_t             mCoins;                             //+0x28
-    int32_t             mFinishedAdventure;                 //+0x2C
-    int32_t             mChallengeRecords[100];             //+0x30
+    uint32_t            mFinishedAdventure;                 //+0x2C
+    uint32_t            mChallengeRecords[100];             //+0x30
     uint32_t            mPurchases[80];                     //+0x1C0
-    int32_t             mPlayTimeActivePlayer;              //+0x300
-    int32_t             mPlayTimeInactivePlayer;            //+0x304
+    uint32_t            mPlayTimeActivePlayer;              //+0x300
+    uint32_t            mPlayTimeInactivePlayer;            //+0x304
     int32_t             mHasUsedCheatKeys;                  //+0x308
     int32_t             mHasWokenStinky;                    //+0x30C
     int32_t             mDidntPurchasePacketUpgrade;        //+0x310

--- a/src/Lawn/System/SaveGame.cpp
+++ b/src/Lawn/System/SaveGame.cpp
@@ -1675,7 +1675,7 @@ static void SyncBoardBasePortable(PortableSaveContext& theContext, Board* theBoa
 			case BOARD_FIELD_MUSHROOM_AND_COFFEE_BEANS_ONLY: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncBool(theBoard->mMushroomAndCoffeeBeansOnly); }); break;
 			case BOARD_FIELD_MUSHROOMS_USED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncBool(theBoard->mMushroomsUsed); }); break;
 			case BOARD_FIELD_LEVEL_COINS_COLLECTED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mLevelCoinsCollected); }); break;
-			case BOARD_FIELD_GARGANTUARS_KILLS_BY_CORN_COB: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mGargantuarsKillsByCornCob); }); break;
+			case BOARD_FIELD_GARGANTUARS_KILLS_BY_CORN_COB: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mGargantuarsKillsByCornCob); }); break;
 			case BOARD_FIELD_COINS_COLLECTED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mCoinsCollected); }); break;
 			case BOARD_FIELD_DIAMONDS_COLLECTED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mDiamondsCollected); }); break;
 			case BOARD_FIELD_POTTED_PLANTS_COLLECTED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mPottedPlantsCollected); }); break;
@@ -1785,7 +1785,7 @@ static void SyncBoardBasePortable(PortableSaveContext& theContext, Board* theBoa
 		AppendFieldWithSync(aBlob, BOARD_FIELD_MUSHROOM_AND_COFFEE_BEANS_ONLY, [&](PortableSaveContext& c){ c.SyncBool(theBoard->mMushroomAndCoffeeBeansOnly); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_MUSHROOMS_USED, [&](PortableSaveContext& c){ c.SyncBool(theBoard->mMushroomsUsed); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_LEVEL_COINS_COLLECTED, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mLevelCoinsCollected); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_GARGANTUARS_KILLS_BY_CORN_COB, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mGargantuarsKillsByCornCob); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_GARGANTUARS_KILLS_BY_CORN_COB, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mGargantuarsKillsByCornCob); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_COINS_COLLECTED, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mCoinsCollected); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_DIAMONDS_COLLECTED, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mDiamondsCollected); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_POTTED_PLANTS_COLLECTED, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mPottedPlantsCollected); });

--- a/src/Lawn/System/SaveGame.cpp
+++ b/src/Lawn/System/SaveGame.cpp
@@ -1658,8 +1658,8 @@ static void SyncBoardBasePortable(PortableSaveContext& theContext, Board* theBoa
 			case BOARD_FIELD_SUKHBIR_MODE: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncBool(theBoard->mSukhbirMode); }); break;
 			case BOARD_FIELD_PREV_BOARD_RESULT: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ SyncEnum32(c, theBoard->mPrevBoardResult); }); break;
 			case BOARD_FIELD_TRIGGERED_LAWN_MOWERS: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mTriggeredLawnMowers); }); break;
-			case BOARD_FIELD_PLAY_TIME_ACTIVE_LEVEL: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPlayTimeActiveLevel); }); break;
-			case BOARD_FIELD_PLAY_TIME_INACTIVE_LEVEL: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPlayTimeInactiveLevel); }); break;
+			case BOARD_FIELD_PLAY_TIME_ACTIVE_LEVEL: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mPlayTimeActiveLevel); }); break;
+			case BOARD_FIELD_PLAY_TIME_INACTIVE_LEVEL: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mPlayTimeInactiveLevel); }); break;
 			case BOARD_FIELD_MAX_SUN_PLANTS: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mMaxSunPlants); }); break;
 			case BOARD_FIELD_START_DRAW_TIME: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt64(theBoard->mStartDrawTime); }); break;
 			case BOARD_FIELD_INTERVAL_DRAW_TIME: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt64(theBoard->mIntervalDrawTime); }); break;
@@ -1667,19 +1667,19 @@ static void SyncBoardBasePortable(PortableSaveContext& theContext, Board* theBoa
 			case BOARD_FIELD_MIN_FPS: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncFloat(theBoard->mMinFPS); }); break;
 			case BOARD_FIELD_PRELOAD_TIME: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPreloadTime); }); break;
 			case BOARD_FIELD_GAME_ID: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ int64_t aGameId = static_cast<int64_t>(theBoard->mGameID); c.SyncInt64(aGameId); if (c.mReading) theBoard->mGameID = static_cast<intptr_t>(aGameId); }); break;
-			case BOARD_FIELD_GRAVES_CLEARED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mGravesCleared); }); break;
-			case BOARD_FIELD_PLANTS_EATEN: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPlantsEaten); }); break;
-			case BOARD_FIELD_PLANTS_SHOVELED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPlantsShoveled); }); break;
+			case BOARD_FIELD_GRAVES_CLEARED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mGravesCleared); }); break;
+			case BOARD_FIELD_PLANTS_EATEN: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mPlantsEaten); }); break;
+			case BOARD_FIELD_PLANTS_SHOVELED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mPlantsShoveled); }); break;
 			case BOARD_FIELD_PEA_SHOOTER_USED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncBool(theBoard->mPeaShooterUsed); }); break;
 			case BOARD_FIELD_CATAPULT_PLANTS_USED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncBool(theBoard->mCatapultPlantsUsed); }); break;
 			case BOARD_FIELD_MUSHROOM_AND_COFFEE_BEANS_ONLY: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncBool(theBoard->mMushroomAndCoffeeBeansOnly); }); break;
 			case BOARD_FIELD_MUSHROOMS_USED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncBool(theBoard->mMushroomsUsed); }); break;
-			case BOARD_FIELD_LEVEL_COINS_COLLECTED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mLevelCoinsCollected); }); break;
+			case BOARD_FIELD_LEVEL_COINS_COLLECTED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mLevelCoinsCollected); }); break;
 			case BOARD_FIELD_GARGANTUARS_KILLS_BY_CORN_COB: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mGargantuarsKillsByCornCob); }); break;
-			case BOARD_FIELD_COINS_COLLECTED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mCoinsCollected); }); break;
-			case BOARD_FIELD_DIAMONDS_COLLECTED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mDiamondsCollected); }); break;
-			case BOARD_FIELD_POTTED_PLANTS_COLLECTED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPottedPlantsCollected); }); break;
-			case BOARD_FIELD_CHOCOLATE_COLLECTED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mChocolateCollected); }); break;
+			case BOARD_FIELD_COINS_COLLECTED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mCoinsCollected); }); break;
+			case BOARD_FIELD_DIAMONDS_COLLECTED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mDiamondsCollected); }); break;
+			case BOARD_FIELD_POTTED_PLANTS_COLLECTED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mPottedPlantsCollected); }); break;
+			case BOARD_FIELD_CHOCOLATE_COLLECTED: ApplyFieldWithSync(aFieldData, aFieldSize, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mChocolateCollected); }); break;
 			default: break;
 			}
 		}
@@ -1768,8 +1768,8 @@ static void SyncBoardBasePortable(PortableSaveContext& theContext, Board* theBoa
 		AppendFieldWithSync(aBlob, BOARD_FIELD_SUKHBIR_MODE, [&](PortableSaveContext& c){ c.SyncBool(theBoard->mSukhbirMode); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_PREV_BOARD_RESULT, [&](PortableSaveContext& c){ SyncEnum32(c, theBoard->mPrevBoardResult); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_TRIGGERED_LAWN_MOWERS, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mTriggeredLawnMowers); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_PLAY_TIME_ACTIVE_LEVEL, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPlayTimeActiveLevel); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_PLAY_TIME_INACTIVE_LEVEL, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPlayTimeInactiveLevel); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_PLAY_TIME_ACTIVE_LEVEL, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mPlayTimeActiveLevel); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_PLAY_TIME_INACTIVE_LEVEL, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mPlayTimeInactiveLevel); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_MAX_SUN_PLANTS, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mMaxSunPlants); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_START_DRAW_TIME, [&](PortableSaveContext& c){ c.SyncInt64(theBoard->mStartDrawTime); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_INTERVAL_DRAW_TIME, [&](PortableSaveContext& c){ c.SyncInt64(theBoard->mIntervalDrawTime); });
@@ -1777,19 +1777,19 @@ static void SyncBoardBasePortable(PortableSaveContext& theContext, Board* theBoa
 		AppendFieldWithSync(aBlob, BOARD_FIELD_MIN_FPS, [&](PortableSaveContext& c){ c.SyncFloat(theBoard->mMinFPS); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_PRELOAD_TIME, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPreloadTime); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_GAME_ID, [&](PortableSaveContext& c){ int64_t aGameId = static_cast<int64_t>(theBoard->mGameID); c.SyncInt64(aGameId); if (c.mReading) theBoard->mGameID = static_cast<intptr_t>(aGameId); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_GRAVES_CLEARED, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mGravesCleared); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_PLANTS_EATEN, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPlantsEaten); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_PLANTS_SHOVELED, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPlantsShoveled); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_GRAVES_CLEARED, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mGravesCleared); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_PLANTS_EATEN, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mPlantsEaten); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_PLANTS_SHOVELED, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mPlantsShoveled); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_PEA_SHOOTER_USED, [&](PortableSaveContext& c){ c.SyncBool(theBoard->mPeaShooterUsed); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_CATAPULT_PLANTS_USED, [&](PortableSaveContext& c){ c.SyncBool(theBoard->mCatapultPlantsUsed); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_MUSHROOM_AND_COFFEE_BEANS_ONLY, [&](PortableSaveContext& c){ c.SyncBool(theBoard->mMushroomAndCoffeeBeansOnly); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_MUSHROOMS_USED, [&](PortableSaveContext& c){ c.SyncBool(theBoard->mMushroomsUsed); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_LEVEL_COINS_COLLECTED, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mLevelCoinsCollected); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_LEVEL_COINS_COLLECTED, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mLevelCoinsCollected); });
 		AppendFieldWithSync(aBlob, BOARD_FIELD_GARGANTUARS_KILLS_BY_CORN_COB, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mGargantuarsKillsByCornCob); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_COINS_COLLECTED, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mCoinsCollected); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_DIAMONDS_COLLECTED, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mDiamondsCollected); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_POTTED_PLANTS_COLLECTED, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mPottedPlantsCollected); });
-		AppendFieldWithSync(aBlob, BOARD_FIELD_CHOCOLATE_COLLECTED, [&](PortableSaveContext& c){ c.SyncInt32(theBoard->mChocolateCollected); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_COINS_COLLECTED, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mCoinsCollected); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_DIAMONDS_COLLECTED, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mDiamondsCollected); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_POTTED_PLANTS_COLLECTED, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mPottedPlantsCollected); });
+		AppendFieldWithSync(aBlob, BOARD_FIELD_CHOCOLATE_COLLECTED, [&](PortableSaveContext& c){ c.SyncUInt32(theBoard->mChocolateCollected); });
 		WriteTLVBlob(theContext, aBlob);
 	}
 }

--- a/src/Lawn/Widget/ChallengeScreen.cpp
+++ b/src/Lawn/Widget/ChallengeScreen.cpp
@@ -495,7 +495,7 @@ void ChallengeScreen::DrawButton(Graphics* g, int theChallengeIndex)
 			// ============================================================================================
 			// ▲ 绘制关卡锁定或关卡完成的贴图以及关卡最高记录的文本等
 			// ============================================================================================
-			int aRecord = mApp->mPlayerInfo->mChallengeRecords[theChallengeIndex];
+			uint32_t aRecord = mApp->mPlayerInfo->mChallengeRecords[theChallengeIndex];
 			if (theChallengeIndex == mUnlockChallengeIndex)
 			{
 				Image* aLockImage = Sexy::IMAGE_LOCK;


### PR DESCRIPTION
This pull request refactors several variables and data structures related to gameplay statistics from `int32_t` to `uint32_t` for improved type safety and to prevent negative values where only non-negative values make sense. It also updates save/load logic and related usages to match these type changes.

**Type Safety and Data Structure Updates**
* Changed various gameplay statistic fields in `Board` and `PlayerInfo` (such as `mPlayTimeActiveLevel`, `mGravesCleared`, `mLevelCoinsCollected`, `mChallengeRecords`, etc.) from `int32_t` to `uint32_t` to ensure only non-negative values are stored. (`src/Lawn/Board.h`, `src/Lawn/System/PlayerInfo.h`) [[1]](diffhunk://#diff-ffa13631f5b3b876f9c59ca2b76619355df54d53c9891bdce09d88e68d70af98L228-R249) [[2]](diffhunk://#diff-49c904b1d46683ace480df5e69311fdac9808a8b014fa00b8f978350e8f01369L75-R79)
* Updated the initialization of `mGargantuarsKillsByCornCob` in the `Board` constructor to match the new type. (`src/Lawn/Board.cpp`)

**Save/Load System Adjustments**
* Modified save and load logic to use `SyncUInt32` instead of `SyncInt32` for all affected fields, ensuring consistency with the new unsigned types. (`src/Lawn/System/SaveGame.cpp`) [[1]](diffhunk://#diff-98829c68ecacdd27d0bb4f3fb7e6a074ba8ccb8aebb2c7d8334a86382c607725L1661-R1682) [[2]](diffhunk://#diff-98829c68ecacdd27d0bb4f3fb7e6a074ba8ccb8aebb2c7d8334a86382c607725L1771-R1792)

**Gameplay Logic Consistency**
* Updated all usages of challenge records, flags, and streaks to use `uint32_t` instead of `int`, ensuring correct value ranges throughout the codebase. (`src/Lawn/Board.cpp`, `src/Lawn/Widget/ChallengeScreen.cpp`) [[1]](diffhunk://#diff-f28a1c8555f4582838a756e3433b9042d5edeaa8bb0e7aead4efec26636c2b06L5162-R5164) [[2]](diffhunk://#diff-f28a1c8555f4582838a756e3433b9042d5edeaa8bb0e7aead4efec26636c2b06L5176-R5178) [[3]](diffhunk://#diff-99327f2d4d0341170039f88e3aee1d65740cc3159373c32b00fcb5ce44f5196bL498-R498)

These changes collectively improve code safety and prevent potential bugs caused by negative values in statistics that should only ever be zero or positive.