### PR TITLE
Fix: correct particle freeze conditions for Grave Buster and Pool Sparkly in cutscene

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -1283,10 +1283,11 @@ void Board::FreezeEffectsForCutscene(bool theFreeze)
 	{
 		if (aParticle->mEffectType == ParticleEffect::PARTICLE_GRAVE_BUSTER)
 		{
-			if (aParticle->mEffectType == ParticleEffect::PARTICLE_POOL_SPARKLY && mIceTrapCounter == 0)
-			{
-				aParticle->mDontUpdate = theFreeze;
-			}
+			aParticle->mDontUpdate = theFreeze;
+		}
+		else if (aParticle->mEffectType == ParticleEffect::PARTICLE_POOL_SPARKLY && mIceTrapCounter == 0)
+		{
+			aParticle->mDontUpdate = theFreeze;
 		}
 	}
 


### PR DESCRIPTION
Separate the logic for PARTICLE_GRAVE_BUSTER and PARTICLE_POOL_SPARKLY in Board::FreezeEffectsForCutscene to fix incorrect nesting of conditions.

Close #166