### PR TITLE
Fix: enable texture repeat for pool caustic effect

### DIFF
--- a/src/Lawn/System/PoolEffect.cpp
+++ b/src/Lawn/System/PoolEffect.cpp
@@ -44,6 +44,7 @@ void PoolEffect::PoolEffectInitialize()
     mCausticImage->mBits = new uint32_t[CAUSTIC_IMAGE_WIDTH * CAUSTIC_IMAGE_HEIGHT + 1];
     mCausticImage->mHasTrans = true;
     mCausticImage->mHasAlpha = true;
+    mCausticImage->mRenderFlags |= RenderImageFlag_Repeat;
     memset(mCausticImage->mBits, 0xFF, CAUSTIC_IMAGE_WIDTH * CAUSTIC_IMAGE_HEIGHT * 4); //4
     mCausticImage->mBits[CAUSTIC_IMAGE_WIDTH * CAUSTIC_IMAGE_HEIGHT] = MEMORYCHECK_ID;
 
@@ -151,6 +152,8 @@ void PoolEffect::PoolEffectDraw(Sexy::Graphics* g, bool theIsNight)
     {
         for (int y = 0; y <= 5; y++) //handles the caustic effect
         {
+            aOffsetArray[2][x][y][0] = x / 15.0f;
+            aOffsetArray[2][x][y][1] = y / 5.0f;
             if (x != 0 && x != 15 && y != 0 && y != 5)
             {
                 constexpr unsigned int POOL_PHASE_PERIOD = 316800u; // LCM of all sin wave effective periods (1600, 300, 1800, 220, 3200/3, 200, 720, 640, 88)
@@ -177,8 +180,6 @@ void PoolEffect::PoolEffectDraw(Sexy::Graphics* g, bool theIsNight)
                 aOffsetArray[0][x][y][1] = 0.0f;
                 aOffsetArray[1][x][y][0] = 0.0f;
                 aOffsetArray[1][x][y][1] = 0.0f;
-                aOffsetArray[2][x][y][0] = 0.0f;
-                aOffsetArray[2][x][y][1] = 0.0f;
             }
         }
     }

--- a/src/SexyAppFramework/graphics/GLInterface.cpp
+++ b/src/SexyAppFramework/graphics/GLInterface.cpp
@@ -84,7 +84,7 @@ static int gNumVertices;
 static GLenum gVertexMode;
 static GLuint gProgram;
 static GLuint gVbo;
-static GLint gUfViewProjMtx, gUfTexture, gUfUseTexture, gUfUvBounds;
+static GLint gUfViewProjMtx, gUfTexture, gUfUseTexture, gUfUvBounds, gUfClampUvEnabled;
 
 static void GfxBegin(GLenum vertexMode)
 {
@@ -190,9 +190,12 @@ V2F vec2 v_uv;
 	uniform sampler2D u_texture;
 	uniform int u_useTexture;
 	uniform vec4 u_uvBounds;
+	uniform int u_clampUvEnabled;
 	void main() {
-		if (u_useTexture != 0)
-			FRAG_OUT = TEX2D(u_texture, clamp(v_uv, u_uvBounds.xy, u_uvBounds.zw)) * v_color;
+		if (u_useTexture != 0) {
+			vec2 uv = (u_clampUvEnabled != 0) ? clamp(v_uv, u_uvBounds.xy, u_uvBounds.zw) : v_uv;
+			FRAG_OUT = TEX2D(u_texture, uv) * v_color;
+		}
 		else
 			FRAG_OUT = v_color;
 	}
@@ -466,8 +469,9 @@ static void CopyImageToTexturePalette8(MemoryImage *img, int offx, int offy,
 static void CopyImageToTexture(MemoryImage *img, int offx, int offy,
 	int texW, int texH, PixelFormat fmt, bool create)
 {
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	GLint wrap = (img->mRenderFlags & RenderImageFlag_Repeat) ? GL_REPEAT : GL_CLAMP_TO_EDGE;
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrap);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrap);
 
 	int w = std::min(texW, img->GetWidth()  - offx);
 	int h = std::min(texH, img->GetHeight() - offy);
@@ -729,12 +733,13 @@ static void SetLinearFilter(bool linear)
 
 static constexpr float kDefaultUvBounds[4] = { 0.f, 0.f, 1.f, 1.f };
 
-static void GfxBindTexture(GLuint tex, const float *uvBounds = kDefaultUvBounds)
+static void GfxBindTexture(GLuint tex, const float *uvBounds = kDefaultUvBounds, bool clampUv = true)
 {
 	glBindTexture(GL_TEXTURE_2D, tex);
 	int f = gLinearFilter ? GL_LINEAR : GL_NEAREST;
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, f);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, f);
+	glUniform1i(gUfClampUvEnabled, clampUv ? 1 : 0);
 	glUniform4fv(gUfUvBounds, 1, uvBounds);
 }
 
@@ -963,7 +968,7 @@ void TextureData::BltTransformed(const SexyMatrix3 &theTrans, const Rect& theSrc
 }
 
 void TextureData::BltTriangles(const TriVertex theVertices[][3], int theNumTriangles,
-                               unsigned int theColor, float tx, float ty)
+                               unsigned int theColor, float tx, float ty, bool clampUv)
 {
 	if (mMaxTotalU <= 1.0 && mMaxTotalV <= 1.0)
 	{
@@ -980,7 +985,7 @@ void TextureData::BltTriangles(const TriVertex theVertices[][3], int theNumTrian
 			std::max(mMaxTotalV - halfV, midV)
 		};
 		glActiveTexture(GL_TEXTURE0);
-		GfxBindTexture(piece.mTexture, uvb);
+		GfxBindTexture(piece.mTexture, uvb, clampUv);
 		glUniform1i(gUfUseTexture, 1);
 
 		GfxBegin(GL_TRIANGLES);
@@ -1041,7 +1046,7 @@ void TextureData::BltTriangles(const TriVertex theVertices[][3], int theNumTrian
 				DoPolyTextureClip(vl);
 				if (vl.size() >= 3)
 				{
-					GfxBindTexture(piece.mTexture, uvb);
+					GfxBindTexture(piece.mTexture, uvb, clampUv);
 					GfxBegin(GL_TRIANGLE_FAN);
 					GfxAddVertices(vl);
 					GfxEnd();
@@ -1158,6 +1163,7 @@ int GLInterface::Init(bool IsWindowed)
 		gUfTexture     = glGetUniformLocation(gProgram, "u_texture");
 		gUfUseTexture  = glGetUniformLocation(gProgram, "u_useTexture");
 		gUfUvBounds    = glGetUniformLocation(gProgram, "u_uvBounds");
+		gUfClampUvEnabled = glGetUniformLocation(gProgram, "u_clampUvEnabled");
 
 		glGenBuffers(1, &gVbo);
 		glBindBuffer(GL_ARRAY_BUFFER, gVbo);
@@ -1184,6 +1190,7 @@ int GLInterface::Init(bool IsWindowed)
 	MakeOrthoMatrix(0, (float)mWidth, (float)mHeight, 0, -10, 10, ortho);
 	glUniformMatrix4fv(gUfViewProjMtx, 1, GL_FALSE, ortho);
 	glUniform1i(gUfTexture, 0);
+	glUniform1i(gUfClampUvEnabled, 1);
 
 	glEnable(GL_BLEND);
 	glDisable(GL_DITHER);
@@ -1531,7 +1538,8 @@ void GLInterface::DrawTrianglesTex(const TriVertex theVertices[][3], int theNumT
 	SetLinearFilter(blend);
 
 	uint32_t c = theColor.ToGLColor();
-	((TextureData*)mem->mRenderData)->BltTriangles(theVertices, theNumTriangles, c, tx, ty);
+	bool clampUv = (mem->mRenderFlags & RenderImageFlag_Repeat) == 0;
+	((TextureData*)mem->mRenderData)->BltTriangles(theVertices, theNumTriangles, c, tx, ty, clampUv);
 }
 
 void GLInterface::DrawTrianglesTexStrip(const TriVertex theVertices[], int theNumTriangles,

--- a/src/SexyAppFramework/graphics/GLInterface.h
+++ b/src/SexyAppFramework/graphics/GLInterface.h
@@ -51,7 +51,8 @@ enum RenderImageFlags
 	RenderImageFlag_Use64By64Subdivisions	=			0x0002,		// good to use with image strips so the entire texture isn't pulled in when drawing just a piece
 	RenderImageFlag_UseA4R4G4B4				=			0x0004,		// images with not too many color gradients work well in this format
 	RenderImageFlag_UseA8R8G8B8				=			0x0008,		// non-alpha images will be stored as R5G6B5 by default so use this option if you want a 32-bit non-alpha image
-	RenderImageFlag_TextureMask				=			0x000F		// mask for flags that affect texture format/layout (excludes transient flags like sanding)
+	RenderImageFlag_Repeat					=			0x0010,		// use GL_REPEAT sampling for this texture
+	RenderImageFlag_TextureMask				=			0x001F		// mask for flags that affect texture state/layout (excludes transient flags like sanding)
 };
 
 struct TextureDataPiece
@@ -171,7 +172,7 @@ public:
 
 	void Blt(float theX, float theY, const Rect& theSrcRect, const Color& theColor);
 	void BltTransformed(const SexyMatrix3 &theTrans, const Rect& theSrcRect, const Color& theColor, const Rect *theClipRect = nullptr, float theX = 0, float theY = 0, bool center = false);	
-	void BltTriangles(const TriVertex theVertices[][3], int theNumTriangles, unsigned int theColor, float tx = 0, float ty = 0);
+	void BltTriangles(const TriVertex theVertices[][3], int theNumTriangles, unsigned int theColor, float tx = 0, float ty = 0, bool clampUv = true);
 };
 
 class GLInterface : public NativeDisplay

--- a/src/SexyAppFramework/platform/3ds/graphics/GLInterface.cpp
+++ b/src/SexyAppFramework/platform/3ds/graphics/GLInterface.cpp
@@ -538,7 +538,8 @@ static void CopyImageToTexture(C3D_Tex *theTex, MemoryImage *theImage, int offx,
 {
 	GPU_TEXTURE_FILTER_PARAM filter = (gLinearFilter) ? GPU_LINEAR : GPU_NEAREST;
 	C3D_TexSetFilter(theTex, filter, filter);
-	C3D_TexSetWrap(theTex, GPU_CLAMP_TO_EDGE, GPU_CLAMP_TO_EDGE);
+	auto wrap = (theImage->mRenderFlags & RenderImageFlag_Repeat) ? GPU_REPEAT : GPU_CLAMP_TO_EDGE;
+	C3D_TexSetWrap(theTex, wrap, wrap);
 
 	int aWidth = std::min(texWidth,(theImage->GetWidth()-offx));
 	int aHeight = std::min(texHeight,(theImage->GetHeight()-offy));

--- a/src/SexyAppFramework/platform/3ds/graphics/GLInterface.h
+++ b/src/SexyAppFramework/platform/3ds/graphics/GLInterface.h
@@ -51,7 +51,8 @@ enum RenderImageFlags
 	RenderImageFlag_Use64By64Subdivisions	=			0x0002,		// good to use with image strips so the entire texture isn't pulled in when drawing just a piece
 	RenderImageFlag_UseA4R4G4B4				=			0x0004,		// images with not too many color gradients work well in this format
 	RenderImageFlag_UseA8R8G8B8				=			0x0008,		// non-alpha images will be stored as R5G6B5 by default so use this option if you want a 32-bit non-alpha image
-	RenderImageFlag_TextureMask				=			0x000F		// mask for flags that affect texture format/layout (excludes transient flags like sanding)
+	RenderImageFlag_Repeat					=			0x0010,		// use repeat sampling for this texture
+	RenderImageFlag_TextureMask				=			0x001F		// mask for flags that affect texture state/layout (excludes transient flags like sanding)
 };
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This pull request adds support for repeat texture sampling (GL_REPEAT) on images by introducing a new `RenderImageFlag_Repeat` flag. It updates the rendering pipeline to use this flag for both OpenGL and 3DS platforms, allowing textures to be sampled with repeating UV coordinates when requested. Additionally, it refines how texture coordinate clamping is handled in the shader and related rendering code, making the behavior more flexible and controllable per-image.

**Texture sampling improvements:**

* Added `RenderImageFlag_Repeat` to `RenderImageFlags` in both OpenGL and 3DS headers, enabling per-image control of texture wrapping mode. [[1]](diffhunk://#diff-d9282684f190466f2e663e4bfef07fbae731886de85db9b8eb389d8f89259199L54-R55) [[2]](diffhunk://#diff-1069dde2b3cb86471c12e0c69575f5eca54be5057fb7ffec976b6bca8710ba20L54-R55)
* Updated texture upload and binding code to use GL_REPEAT or GPU_REPEAT when the repeat flag is set, instead of always using clamp-to-edge. [[1]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L469-R474) [[2]](diffhunk://#diff-9f7b8ad3fef9029f4505bac8d13466568370f92ec680f60f15e2c773b3c9b6caL541-R542)
* Modified the OpenGL shader and pipeline to introduce a new `u_clampUv` uniform, controlling whether UV coordinates are clamped or allowed to repeat, and updated all relevant code paths to set this uniform appropriately. [[1]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L87-R87) [[2]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787R193-R198) [[3]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L732-R742) [[4]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L966-R971) [[5]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L983-R988) [[6]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L1044-R1049) [[7]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787R1166) [[8]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787R1193) [[9]](diffhunk://#diff-c627de2df21c18254a6cd6e7b6da53aefb6a2ab5406d7dce2da234182efa3787L1534-R1542) [[10]](diffhunk://#diff-d9282684f190466f2e663e4bfef07fbae731886de85db9b8eb389d8f89259199L174-R175)

**Pool effect rendering:**

* Set the `RenderImageFlag_Repeat` flag for the caustic image in the pool effect, ensuring correct texture sampling for water caustics.
* Adjusted the calculation and assignment of UV offsets for the caustic effect, cleaning up redundant code and ensuring correct mapping. [[1]](diffhunk://#diff-decab156aa3acc4c16a99f3ea76b24ede1f349c49cd180f6cd521de8dd8abe0eR155-R160) [[2]](diffhunk://#diff-decab156aa3acc4c16a99f3ea76b24ede1f349c49cd180f6cd521de8dd8abe0eL180-L181)