### PR TITLE
Fix: correct shop pagestring display and coinbank

### DIFF
--- a/src/Lawn/Widget/StoreScreen.cpp
+++ b/src/Lawn/Widget/StoreScreen.cpp
@@ -504,7 +504,7 @@ void StoreScreen::Draw(Graphics* g)
     g->SetColor(Color(180, 255, 90));
     g->SetFont(Sexy::FONT_CONTINUUMBOLD14);
     std::string aCoinLabel = mApp->GetMoneyString(mApp->mPlayerInfo->mCoins);
-    g->DrawString(aCoinLabel, STORESCREEN_COINBANK_X + 111 - Sexy::FONT_CONTINUUMBOLD14->StringWidth(aCoinLabel), STORESCREEN_COINBANK_Y + 24);
+    g->DrawString(aCoinLabel, STORESCREEN_COINBANK_X + 116 - Sexy::FONT_CONTINUUMBOLD14->StringWidth(aCoinLabel), STORESCREEN_COINBANK_Y + 24);
 
     if (!mPrevButton->mDisabled)
     {

--- a/src/Lawn/Widget/StoreScreen.cpp
+++ b/src/Lawn/Widget/StoreScreen.cpp
@@ -517,8 +517,8 @@ void StoreScreen::Draw(Graphics* g)
             }
         }
 
-        std::string aPageString = TodReplaceNumberString(TodReplaceNumberString("[STORE_PAGE]", "{PAGE}", mPage), "{NUM_PAGES}", aNumPages);
-        TodDrawString(g, aPageString, STORESCREEN_PAGESTRING_X, STORESCREEN_COINBANK_Y, Sexy::FONT_BRIANNETOD12, Color(80, 80, 80), DS_ALIGN_CENTER);
+        std::string aPageString = TodReplaceNumberString(TodReplaceNumberString("[STORE_PAGE]", "{PAGE}", mPage + 1), "{NUM_PAGES}", aNumPages);
+        TodDrawString(g, aPageString, STORESCREEN_PAGESTRING_X, STORESCREEN_PAGESTRING_Y, Sexy::FONT_BRIANNETOD12, Color(80, 80, 80), DS_ALIGN_CENTER);
     }
 }
 


### PR DESCRIPTION
- replace STORESCREEN_COINBANK_Y with STORESCREEN_PAGESTRING_Y to correct the position.
- add an offset number for mPage to make sure it begins at 1
- replace coinbank Y offset ```111``` with ```116```
the number comes from ```Board.cpp``` line 7402

<img width="935" height="557" alt="image" src="https://github.com/user-attachments/assets/04266280-52d9-47f8-b18c-096a6eae3718" />

<img width="781" height="283" alt="image" src="https://github.com/user-attachments/assets/f2e38171-0e21-44c7-a6c0-072acccb4a50" />
