### PR TITLE
Fix: correct flag wave countdown condition in UpdateZombieSpawning

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -5474,7 +5474,7 @@ void Board::UpdateZombieSpawning()
 			mZombieHealthToNextWave = 0;
 			mZombieCountDown = ZOMBIE_COUNTDOWN_BEFORE_REPICK + 1;
 		}
-		else if (IsFlagWave(mCurrentWave) && (mApp->IsWallnutBowlingLevel() || mApp->mGameMode == GameMode::GAMEMODE_CHALLENGE_LAST_STAND))
+		else if (IsFlagWave(mCurrentWave) && !(mApp->IsWallnutBowlingLevel() || mApp->mGameMode == GameMode::GAMEMODE_CHALLENGE_LAST_STAND))
 		{
 			mZombieHealthToNextWave = 0;
 			mZombieCountDown = ZOMBIE_COUNTDOWN_BEFORE_FLAG;


### PR DESCRIPTION
The condition for flag waves incorrectly included Wallnut Bowling and Last Stand instead of excluding them, causing Survival Endless wave 9/19 huge wave warning to trigger prematurely when zombie health drops below the threshold, instead of waiting for full clearance or the timeout.

Close #220