### PR TITLE
Fix: prevent interaction with menu buttons during reward acquisition

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -4680,6 +4680,10 @@ void Board::ClearCursor()
 
 bool Board::CanInteractWithBoardButtons()
 {
+	// during the process of obtaining a reward, should not interaction with the menu.
+	if (mBoardFadeOutCounter >= 0)
+		return false;
+
 	if (mPaused || mApp->GetDialogCount() > 0)
 		return false;
 


### PR DESCRIPTION
During award pickup, FadeOutLevel sets mBoardFadeOutCounter >= 0, which already clears MouseHitTest so seed packets cannot be selected. Menu and other board chrome still used CanInteractWithBoardButtons(), which did not check the fadeout counter, so the menu stayed clickable.

Return false from CanInteractWithBoardButtons() while mBoardFadeOutCounter >= 0. so the menu  follow the same interaction rules as the seed bank for the rest of the level-end sequence.