### PR TITLE
Fix winter melon splash on shielded zombies, balloon pool spawning, and blover wind-up

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -2577,7 +2577,7 @@ bool Board::RowCanHaveZombieType(int theRow, ZombieType theZombieType)
 	{
 		return false;  // 无草皮之地关卡，无草皮的行在前 5 波不刷出僵尸
 	}
-	if (mPlantRow[theRow] == PlantRowType::PLANTROW_POOL && !Zombie::ZombieTypeCanGoInPool(theZombieType))
+	if (mPlantRow[theRow] == PlantRowType::PLANTROW_POOL && !Zombie::ZombieTypeCanGoInPool(theZombieType) && theZombieType != ZombieType::ZOMBIE_BALLOON)
 	{
 		return false;  // 水路不会刷出不能进入泳池的僵尸
 	}

--- a/src/Lawn/Plant.cpp
+++ b/src/Lawn/Plant.cpp
@@ -1612,11 +1612,6 @@ void Plant::UpdateBlover()
         aBodyReanim->SetFramesForLayer("anim_loop");
         aBodyReanim->mLoopType = ReanimLoopType::REANIM_LOOP;
     }
-
-    if (mState != PlantState::STATE_DOINGSPECIAL && mStateCountdown == 0)
-    {
-        DoSpecial();
-    }
 }
 
 void Plant::UpdateFlowerPot()

--- a/src/Lawn/Projectile.cpp
+++ b/src/Lawn/Projectile.cpp
@@ -385,12 +385,12 @@ void Projectile::CheckForHighGround()
 
 bool Projectile::IsSplashDamage(Zombie* theZombie)
 {
-	if (mProjectileType && theZombie && theZombie->IsFireResistant())
+	if (mProjectileType == ProjectileType::PROJECTILE_FIREBALL && theZombie && theZombie->IsFireResistant())
 		return false;
 
-	return 
-		mProjectileType == ProjectileType::PROJECTILE_MELON || 
-		mProjectileType == ProjectileType::PROJECTILE_WINTERMELON || 
+	return
+		mProjectileType == ProjectileType::PROJECTILE_MELON ||
+		mProjectileType == ProjectileType::PROJECTILE_WINTERMELON ||
 		mProjectileType == ProjectileType::PROJECTILE_FIREBALL;
 }
 


### PR DESCRIPTION
This PR fixes three gameplay bugs reported in #225:

1. **Winter melon / melon splash missing on shielded zombies** (`Projectile.cpp`)
   - `IsSplashDamage()` used `mProjectileType && theZombie->IsFireResistant()`, which implicitly converted any non-zero projectile type to `true`. This caused melon and winter-melon projectiles to incorrectly skip splash damage when hitting fire-resistant zombies (Zamboni, Catapult, Screen Door, Ladder).
   - Fixed by restricting the early-return to `PROJECTILE_FIREBALL` only, matching the intended behavior and the pattern used in `IsZombieHitBySplash()`.

2. **Balloon zombies never spawn in pool lanes** (`Board.cpp`)
   - `RowCanHaveZombieType()` rejected any zombie type not in `ZombieTypeCanGoInPool()` for pool rows. Balloon zombies are flying units and were never in that list, so they got zero spawn weight in pool lanes.
   - Fixed by adding a `ZOMBIE_BALLOON` exception, allowing them to be assigned to pool rows during wave generation (they still die instantly if their balloon is popped over water, handled by existing `IsFlying()` logic).

3. **Blover has no wind-up animation** (`Plant.cpp`)
   - `UpdateBlover()` contained an unconditional `if (mStateCountdown == 0) DoSpecial()` check. Since `mStateCountdown` defaults to `0`, this triggered `DoSpecial()` on the first frame, bypassing the intended `mDoSpecialCountdown = 50` (0.5s) wind-up.
   - Removed the erroneous block. Blover now waits for the countdown to expire before activating, restoring the wind-up animation. The instant-activation-on-eaten behavior is still preserved by the independent check in `Zombie::EatPlant()`.

Close #225