### PR TITLE
Fix: enable floating plants in Zombiquarium background

### DIFF
--- a/src/Lawn/Plant.cpp
+++ b/src/Lawn/Plant.cpp
@@ -3553,6 +3553,10 @@ float PlantDrawHeightOffset(Board* theBoard, Plant* thePlant, SeedType theSeedTy
     {
         doFloating = true;
     }
+    else if (theBoard->mBackground == BackgroundType::BACKGROUND_ZOMBIQUARIUM)
+    {
+        doFloating = true;
+    }
 
     if (doFloating)
     {


### PR DESCRIPTION
Plants now correctly float in Zombiquarium lanes, matching visual behavior seen in other aquatic backgrounds like pool levels. This ensures consistent rendering and improves immersion in Zombiquarium gameplay.

Close #235