### PR TITLE
Fix: use mBoard->mLevel instead of mPlayerInfo->mLevel for adventure special-level checks

### DIFF
--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -2198,7 +2198,7 @@ bool LawnApp::IsWallnutBowlingLevel()
 	if (mGameMode == GameMode::GAMEMODE_CHALLENGE_WALLNUT_BOWLING || mGameMode == GameMode::GAMEMODE_CHALLENGE_WALLNUT_BOWLING_2)
 		return true;
 
-	return IsAdventureMode() && mPlayerInfo->mLevel == 5;
+	return IsAdventureMode() && mBoard->mLevel == 5;
 }
 
 bool LawnApp::IsSlotMachineLevel()
@@ -2214,12 +2214,12 @@ bool LawnApp::IsWhackAZombieLevel()
 	if (mGameMode == GameMode::GAMEMODE_CHALLENGE_WHACK_A_ZOMBIE)
 		return true;
 
-	return IsAdventureMode() && mPlayerInfo->mLevel == 15;
+	return IsAdventureMode() && mBoard->mLevel == 15;
 }
 
 bool LawnApp::IsLittleTroubleLevel()
 {
-	return (mBoard && (mGameMode == GameMode::GAMEMODE_CHALLENGE_LITTLE_TROUBLE || (mGameMode == GameMode::GAMEMODE_ADVENTURE && mPlayerInfo->mLevel == 25)));
+	return (mBoard && (mGameMode == GameMode::GAMEMODE_CHALLENGE_LITTLE_TROUBLE || (mGameMode == GameMode::GAMEMODE_ADVENTURE && mBoard->mLevel == 25)));
 }
 
 bool LawnApp::IsScaryPotterLevel()
@@ -2227,7 +2227,7 @@ bool LawnApp::IsScaryPotterLevel()
 	if (mGameMode >= GameMode::GAMEMODE_SCARY_POTTER_1 && mGameMode <= GameMode::GAMEMODE_SCARY_POTTER_ENDLESS)
 		return true;
 
-	return IsAdventureMode() && mPlayerInfo->mLevel == 35;
+	return IsAdventureMode() && mBoard && mBoard->mLevel == 35;
 }
 
 bool LawnApp::IsStormyNightLevel()
@@ -2238,7 +2238,7 @@ bool LawnApp::IsStormyNightLevel()
 	if (mGameMode == GameMode::GAMEMODE_CHALLENGE_STORMY_NIGHT)
 		return true;
 
-	return IsAdventureMode() && mPlayerInfo->mLevel == 40;
+	return IsAdventureMode() && mBoard->mLevel == 40;
 }
 
 bool LawnApp::IsBungeeBlitzLevel()
@@ -2249,7 +2249,7 @@ bool LawnApp::IsBungeeBlitzLevel()
 	if (mGameMode == GameMode::GAMEMODE_CHALLENGE_BUNGEE_BLITZ)
 		return true;
 
-	return IsAdventureMode() && mPlayerInfo->mLevel == 45;
+	return IsAdventureMode() && mBoard->mLevel == 45;
 }
 
 bool LawnApp::IsMiniBossLevel()
@@ -2257,10 +2257,7 @@ bool LawnApp::IsMiniBossLevel()
 	if (mBoard == nullptr)
 		return false;
 
-	return
-		(IsAdventureMode() && mPlayerInfo->mLevel == 10) ||
-		(IsAdventureMode() && mPlayerInfo->mLevel == 20) ||
-		(IsAdventureMode() && mPlayerInfo->mLevel == 30);
+	return IsAdventureMode() && (mBoard->mLevel == 10 || mBoard->mLevel == 20 || mBoard->mLevel == 30);
 }
 
 bool LawnApp::IsFinalBossLevel()
@@ -2271,7 +2268,7 @@ bool LawnApp::IsFinalBossLevel()
 	if (mGameMode == GameMode::GAMEMODE_CHALLENGE_FINAL_BOSS)
 		return true;
 
-	return IsAdventureMode() && mPlayerInfo->mLevel == 50;
+	return IsAdventureMode() && mBoard->mLevel == 50;
 }
 
 bool LawnApp::IsChallengeWithoutSeedBank()


### PR DESCRIPTION
In UpdatePlayerProfileForFinishingLevel(), SetLevel() is called before achievement checks, so mPlayerInfo->mLevel has already been incremented when IsWhackAZombieLevel() and similar functions are evaluated. This caused the "No Fungus Among Us" achievement to be incorrectly awarded after completing 2-5 (Whack-A-Zombie).

Use mBoard->mLevel, which reflects the level that was actually played, for all adventure-mode special-level checks. The mBoard null guard is already present (or added where missing) in each affected function.

Close #246