### PR TITLE
Fix: move Whack-a-Zombie hammer cursor initialization to StartLevel

### DIFF
--- a/src/Lawn/Challenge.cpp
+++ b/src/Lawn/Challenge.cpp
@@ -431,6 +431,14 @@ void Challenge::StartLevel()
 		mBoard->mCursorObject->mCursorType = CURSOR_TYPE_HAMMER;
 		mBoard->mZombieCountDown = 200;
 		mBoard->mZombieCountDownStart = mBoard->mZombieCountDown;
+
+		ReanimatorEnsureDefinitionLoaded(ReanimationType::REANIM_HAMMER, true);
+		mApp->RemoveReanimation(mBoard->mCursorObject->mReanimCursorID);
+		Reanimation* aHammerReanim = mApp->AddReanimation(-25.0f, 16.0f, 0, ReanimationType::REANIM_HAMMER);
+		aHammerReanim->mIsAttachment = true;
+		aHammerReanim->PlayReanim("anim_whack_zombie", ReanimLoopType::REANIM_PLAY_ONCE_AND_HOLD, 0, 24.0f);
+		aHammerReanim->mAnimTime = 1.0f;
+		mBoard->mCursorObject->mReanimCursorID = mApp->ReanimationGetID(aHammerReanim);
 	}
 	if (mApp->IsStormyNightLevel())
 	{

--- a/src/Lawn/CursorObject.cpp
+++ b/src/Lawn/CursorObject.cpp
@@ -41,17 +41,6 @@ CursorObject::CursorObject()
     mCobCannonPlantID = PlantID::PLANTID_NULL;
     mGlovePlantID = PlantID::PLANTID_NULL;
     mReanimCursorID = ReanimationID::REANIMATIONID_NULL;
-    
-    if (mApp->IsWhackAZombieLevel())
-    {
-        ReanimatorEnsureDefinitionLoaded(ReanimationType::REANIM_HAMMER, true);
-        Reanimation* aHammerReanim = mApp->AddReanimation(-25.0f, 16.0f, 0, ReanimationType::REANIM_HAMMER);
-        aHammerReanim->mIsAttachment = true;
-        aHammerReanim->PlayReanim("anim_whack_zombie", ReanimLoopType::REANIM_PLAY_ONCE_AND_HOLD, 0, 24.0f);
-        aHammerReanim->mAnimTime = 1.0f;
-        mReanimCursorID = mApp->ReanimationGetID(aHammerReanim);
-    }
-
     mWidth = 80;
     mHeight = 80;
 }
@@ -84,6 +73,7 @@ void CursorObject::Update()
 void CursorObject::Die()
 {
     mApp->RemoveReanimation(mReanimCursorID);
+    mReanimCursorID = ReanimationID::REANIMATIONID_NULL;
 }
 
 void CursorObject::Draw(Graphics* g)

--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -2198,7 +2198,7 @@ bool LawnApp::IsWallnutBowlingLevel()
 	if (mGameMode == GameMode::GAMEMODE_CHALLENGE_WALLNUT_BOWLING || mGameMode == GameMode::GAMEMODE_CHALLENGE_WALLNUT_BOWLING_2)
 		return true;
 
-	return IsAdventureMode() && mPlayerInfo->mLevel == 5;
+	return IsAdventureMode() && mBoard->mLevel == 5;
 }
 
 bool LawnApp::IsSlotMachineLevel()
@@ -2214,12 +2214,12 @@ bool LawnApp::IsWhackAZombieLevel()
 	if (mGameMode == GameMode::GAMEMODE_CHALLENGE_WHACK_A_ZOMBIE)
 		return true;
 
-	return IsAdventureMode() && mPlayerInfo->mLevel == 15;
+	return IsAdventureMode() && mBoard->mLevel == 15;
 }
 
 bool LawnApp::IsLittleTroubleLevel()
 {
-	return (mBoard && (mGameMode == GameMode::GAMEMODE_CHALLENGE_LITTLE_TROUBLE || (mGameMode == GameMode::GAMEMODE_ADVENTURE && mPlayerInfo->mLevel == 25)));
+	return (mBoard && (mGameMode == GameMode::GAMEMODE_CHALLENGE_LITTLE_TROUBLE || (mGameMode == GameMode::GAMEMODE_ADVENTURE && mBoard->mLevel == 25)));
 }
 
 bool LawnApp::IsScaryPotterLevel()
@@ -2227,7 +2227,7 @@ bool LawnApp::IsScaryPotterLevel()
 	if (mGameMode >= GameMode::GAMEMODE_SCARY_POTTER_1 && mGameMode <= GameMode::GAMEMODE_SCARY_POTTER_ENDLESS)
 		return true;
 
-	return IsAdventureMode() && mPlayerInfo->mLevel == 35;
+	return IsAdventureMode() && mBoard && mBoard->mLevel == 35;
 }
 
 bool LawnApp::IsStormyNightLevel()
@@ -2238,7 +2238,7 @@ bool LawnApp::IsStormyNightLevel()
 	if (mGameMode == GameMode::GAMEMODE_CHALLENGE_STORMY_NIGHT)
 		return true;
 
-	return IsAdventureMode() && mPlayerInfo->mLevel == 40;
+	return IsAdventureMode() && mBoard->mLevel == 40;
 }
 
 bool LawnApp::IsBungeeBlitzLevel()
@@ -2249,7 +2249,7 @@ bool LawnApp::IsBungeeBlitzLevel()
 	if (mGameMode == GameMode::GAMEMODE_CHALLENGE_BUNGEE_BLITZ)
 		return true;
 
-	return IsAdventureMode() && mPlayerInfo->mLevel == 45;
+	return IsAdventureMode() && mBoard->mLevel == 45;
 }
 
 bool LawnApp::IsMiniBossLevel()
@@ -2257,10 +2257,7 @@ bool LawnApp::IsMiniBossLevel()
 	if (mBoard == nullptr)
 		return false;
 
-	return
-		(IsAdventureMode() && mPlayerInfo->mLevel == 10) ||
-		(IsAdventureMode() && mPlayerInfo->mLevel == 20) ||
-		(IsAdventureMode() && mPlayerInfo->mLevel == 30);
+	return IsAdventureMode() && (mBoard->mLevel == 10 || mBoard->mLevel == 20 || mBoard->mLevel == 30);
 }
 
 bool LawnApp::IsFinalBossLevel()
@@ -2271,7 +2268,7 @@ bool LawnApp::IsFinalBossLevel()
 	if (mGameMode == GameMode::GAMEMODE_CHALLENGE_FINAL_BOSS)
 		return true;
 
-	return IsAdventureMode() && mPlayerInfo->mLevel == 50;
+	return IsAdventureMode() && mBoard->mLevel == 50;
 }
 
 bool LawnApp::IsChallengeWithoutSeedBank()


### PR DESCRIPTION
- Move ReanimatorEnsureDefinitionLoaded and Reanimation setup from CursorObject constructor to Challenge::StartLevel.
- This ensures the hammer animation is only loaded and initialized when entering the specific "Whack-a-Zombie" challenge mode.
- Add missing mReanimCursorID reset to REANIMATIONID_NULL in CursorObject::Die() to prevent stale references.
- Removes the conditional check for IsWhackAZombieLevel from the constructor, centralizing level-specific logic in Challenge.