### PR TITLE
Fix: correct intro camera pan direction in CutScene

### DIFF
--- a/src/Lawn/CutScene.cpp
+++ b/src/Lawn/CutScene.cpp
@@ -2289,7 +2289,7 @@ void CutScene::DrawUpsell(Graphics* g)
 
 void CutScene::UpdateIntro()
 {
-	mBoard->Move(TodAnimateCurve(TimeIntro_PanRightStart, TimeIntro_PanRightEnd, mCutsceneTime, -100, 100, TodCurves::CURVE_LINEAR), 0);
+	mBoard->Move(-TodAnimateCurve(TimeIntro_PanRightStart, TimeIntro_PanRightEnd, mCutsceneTime, -100, 100, TodCurves::CURVE_LINEAR), 0);
 
 	if (mCutsceneTime == 10)
 	{


### PR DESCRIPTION
The camera movement in the intro sequence was moving in the wrong direction due to a sign error in the coordinate calculation. Added a negative sign to the TodAnimateCurve result to ensure the camera pans correctly from left to right during the intro.

Close #255