### PR TITLE
Fix: correct Dancing Zombie phase and summon behavior

### DIFF
--- a/src/ConstEnums.h
+++ b/src/ConstEnums.h
@@ -1285,9 +1285,9 @@ enum ZombiePhase : int32_t
     PHASE_DANCER_DANCING_LEFT,
     PHASE_DANCER_WALK_TO_RAISE,
     PHASE_DANCER_RAISE_LEFT_1,
-    PHASE_DANCER_RAISE_RIGHT_1,
+    PHASE_DANCER_RAISE_RIGHT_1, // deprecated: not used for the disco dancer zombie
     PHASE_DANCER_RAISE_LEFT_2,
-    PHASE_DANCER_RAISE_RIGHT_2,
+    PHASE_DANCER_RAISE_RIGHT_2, // deprecated: not used for the disco dancer zombie
     PHASE_DANCER_RISING,
     PHASE_DOLPHIN_WALKING,
     PHASE_DOLPHIN_INTO_POOL,

--- a/src/Lawn/Zombie.cpp
+++ b/src/Lawn/Zombie.cpp
@@ -2892,9 +2892,7 @@ void Zombie::UpdateZombieBackupDancer()
             break;
 
         case ZombiePhase::PHASE_DANCER_RAISE_LEFT_1:
-        case ZombiePhase::PHASE_DANCER_RAISE_RIGHT_1:
         case ZombiePhase::PHASE_DANCER_RAISE_LEFT_2:
-        case ZombiePhase::PHASE_DANCER_RAISE_RIGHT_2:
             mZombiePhase = aDancerPhase;
             PlayZombieReanim("anim_armraise", ReanimLoopType::REANIM_LOOP, 10, 18.0f);
             break;
@@ -2913,7 +2911,7 @@ void Zombie::UpdateZombieDancer()
     if (mSummonCounter > 0)
     {
         mSummonCounter--;
-        if (mSummonCounter == 1) // @Patoke: checking 0 instead of 1
+        if (mSummonCounter == 0)
         {
             if (GetDancerFrame() == 12 && mHasHead && mPosX < 700.0f)
             {
@@ -2979,9 +2977,7 @@ void Zombie::UpdateZombieDancer()
                 break;
 
             case ZombiePhase::PHASE_DANCER_RAISE_LEFT_1:
-            case ZombiePhase::PHASE_DANCER_RAISE_RIGHT_1:
             case ZombiePhase::PHASE_DANCER_RAISE_LEFT_2:
-            case ZombiePhase::PHASE_DANCER_RAISE_RIGHT_2:
                 mZombiePhase = aDancerPhase;
                 PlayZombieReanim("anim_armraise", ReanimLoopType::REANIM_LOOP, 10, 18.0f);
                 break;
@@ -3858,11 +3854,9 @@ bool Zombie::ZombieNotWalking()
         mZombieHeight == ZombieHeight::HEIGHT_ZOMBIQUARIUM ||
         mZombieType == ZombieType::ZOMBIE_BUNGEE || 
         mZombieType == ZombieType::ZOMBIE_BOSS ||
-        mZombiePhase == ZombiePhase::PHASE_DANCER_RAISE_LEFT_1 || 
+        mZombiePhase == ZombiePhase::PHASE_DANCER_RAISE_LEFT_1 ||
         mZombiePhase == ZombiePhase::PHASE_DANCER_WALK_TO_RAISE ||
-        mZombiePhase == ZombiePhase::PHASE_DANCER_RAISE_RIGHT_1 || 
-        mZombiePhase == ZombiePhase::PHASE_DANCER_RAISE_LEFT_2 ||
-        mZombiePhase == ZombiePhase::PHASE_DANCER_RAISE_RIGHT_2)
+        mZombiePhase == ZombiePhase::PHASE_DANCER_RAISE_LEFT_2)
     {
         return true;
     }
@@ -5221,8 +5215,7 @@ void Zombie::UpdateReanim()
     {
         anOpposite = false;
 
-        if (mZombiePhase == ZombiePhase::PHASE_DANCER_DANCING_IN || mZombiePhase == ZombiePhase::PHASE_DANCER_RAISE_RIGHT_1 || 
-            mZombiePhase == ZombiePhase::PHASE_DANCER_RAISE_RIGHT_2)
+        if (mZombiePhase == ZombiePhase::PHASE_DANCER_DANCING_IN)
         {
             if (!mIsEating)
             {
@@ -6080,9 +6073,8 @@ ZombiePhase Zombie::GetDancerPhase()
     return
         aFrame <= 11 ? ZombiePhase::PHASE_DANCER_DANCING_LEFT :
         aFrame <= 12 ? ZombiePhase::PHASE_DANCER_WALK_TO_RAISE :
-        aFrame <= 15 ? ZombiePhase::PHASE_DANCER_RAISE_RIGHT_1 :
         aFrame <= 18 ? ZombiePhase::PHASE_DANCER_RAISE_LEFT_1 :
-        aFrame <= 21 ? ZombiePhase::PHASE_DANCER_RAISE_RIGHT_2 : ZombiePhase::PHASE_DANCER_RAISE_LEFT_2;
+                       ZombiePhase::PHASE_DANCER_RAISE_LEFT_2;
 }
 
 void Zombie::DrawIceTrap(Graphics* g, const ZombieDrawPosition& theDrawPos, bool theFront)


### PR DESCRIPTION
When observing the Dancing Zombie in-game, two issues were noticed:

1. During the dancing cycle, the zombie would visibly turn back and
   forth between phases rather than consistently facing one direction
   as expected in the GOTY version.
2. Backup dancer summons felt less responsive, with noticeable delays
   before re-summoning when backup dancers were defeated.

Fixed the phase mapping and summon counter retry logic to address
these discrepancies. Cleaned up unreachable phase references.
Deprecated enum values are preserved in ConstEnums.h for compatibility.
