### PR TITLE
Feat: suppress right-click context menu on canvas for WASM builds 

### DIFF
--- a/wasm/shell.html
+++ b/wasm/shell.html
@@ -232,6 +232,10 @@ var Module = {
     print: function(text) { console.log(text); },
     printErr: function(text) { console.warn(text); }
 };
+
+Module.canvas.addEventListener('contextmenu', function(e) {
+    e.preventDefault();
+});
 </script>
 {{{ SCRIPT }}}
 <script>


### PR DESCRIPTION
In this PR, the right-click context menu for WASM builds has been disabled to improve the user's right-click experience.

Patch: https://github.com/malash/PvZ-Portable/commit/d0c58922309e58aed06974f39bd1974fb3a9a9e9.diff