### PR TITLE
Fix: apply Dancer Zombie scale in DrawSeedType

### DIFF
--- a/src/Lawn/Plant.cpp
+++ b/src/Lawn/Plant.cpp
@@ -4137,6 +4137,13 @@ void Plant::DrawSeedType(Graphics* g, SeedType theSeedType, SeedType theImitater
     if (Challenge::IsZombieSeedType(aSeedType))
     {
         ZombieType aZombieType = Challenge::IZombieSeedTypeToZombieType(aSeedType);
+        if (aZombieType == ZombieType::ZOMBIE_DANCER)
+        {
+            aSeedG.mScaleX *= 0.8f;
+            aSeedG.mScaleY *= 0.8f;
+            aOffsetX = 20.0f;
+            aOffsetY = 42.0f;
+        }
         gLawnApp->mReanimatorCache->DrawCachedZombie(&aSeedG, thePosX + aOffsetX, thePosY + aOffsetY, aZombieType);
     }
     else

--- a/src/Lawn/SeedPacket.cpp
+++ b/src/Lawn/SeedPacket.cpp
@@ -455,9 +455,9 @@ void DrawSeedPacket(Graphics* g, float x, float y, SeedType theSeedType, SeedTyp
 		break;
 
 	case SeedType::SEED_ZOMBIE_DANCER:
-		aScale = 0.3f;
-		aOffsetX = 1.0f;
-		aOffsetY = 2.0f;
+		aScale = 0.375f;
+		aOffsetX = -19.0f;
+		aOffsetY = -40.0f;
 		break;
 
 	case SeedType::SEED_ZOMBIE_POLEVAULTER:

--- a/src/Lawn/Zombie.cpp
+++ b/src/Lawn/Zombie.cpp
@@ -597,11 +597,9 @@ void Zombie::ZombieInitialize(int theRow, ZombieType theType, bool theVariant, Z
     }
 
     case ZombieType::ZOMBIE_DANCER:
-        // @Patoke: add scaling for new assets
         mScaleZombie = 0.8f;
         if (!IsOnBoard())
         {
-            // @Patoke: oops
             PlayZombieReanim("anim_armraise", ReanimLoopType::REANIM_LOOP, 0, 12.0f);
         }
         else
@@ -616,7 +614,6 @@ void Zombie::ZombieInitialize(int theRow, ZombieType theType, bool theVariant, Z
         break;
 
     case ZombieType::ZOMBIE_BACKUP_DANCER:
-        // @Patoke: add scaling for new assets
         mScaleZombie = 0.8f;
         if (!IsOnBoard())
         {
@@ -3452,14 +3449,12 @@ void Zombie::DropHead(unsigned int theDamageFlags)
     {
         if (mZombieType == ZombieType::ZOMBIE_DANCER)
         {
-            // @Patoke: added new assets
             ReanimShowPrefix("Zombie_disco_chops", RENDER_GROUP_HIDDEN);
             ReanimShowPrefix("Zombie_disco_glasses", RENDER_GROUP_HIDDEN);
             aParticle->OverrideImage(nullptr, IMAGE_ZOMBIEDANCERHEAD);
         }
         else if (mZombieType == ZombieType::ZOMBIE_BACKUP_DANCER)
         {
-            // @Patoke: added new assets
             ReanimShowPrefix("Zombie_disco_chops", RENDER_GROUP_HIDDEN);
             ReanimShowPrefix("Zombie_backup_stash", RENDER_GROUP_HIDDEN);
             aParticle->OverrideImage(nullptr, IMAGE_ZOMBIEBACKUPDANCERHEAD);


### PR DESCRIPTION
The on-board Dancer Zombie uses mScaleZombie=0.8f, but DrawSeedType did not account for this, causing the IZombie cursor preview to appear larger than the placed zombie. Add scale and position compensation in DrawSeedType and adjust the seed packet offsets. Clean up misleading comments.