### PR TITLE
Fix: correct KillDialog mResult sentinel from -1 to 0x7FFFFFFF

### DIFF
--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -775,7 +775,7 @@ bool SexyAppBase::KillDialog(int theDialogId, bool removeWidget, bool deleteWidg
 
 		// set the result to something else so DoMainLoop knows that the dialog is gone 
 		// in case nobody else sets mResult		
-		if (aDialog->mResult == -1) 
+		if (aDialog->mResult == 0x7FFFFFFF)
 			aDialog->mResult = 0;
 		
 		DialogList::iterator aListItr = std::find(mDialogList.begin(),mDialogList.end(),aDialog);


### PR DESCRIPTION
The Dialog constructor initializes mResult to 0x7FFFFFFF, which WaitForResult uses as its blocking sentinel. KillDialog was checking mResult == -1 (a value never set) before clearing it to 0, so it never unblocked WaitForResult.

On native this went unnoticed because ProcessSafeDeleteList frees the dialog, and subsequent heap allocations eventually overwrite the stale mResult, breaking the loop by accident. On Emscripten the allocator leaves the value intact, causing WaitForResult to spin indefinitely — the dialog visually closes but the caller never resumes.

Close #270