### PR TITLE
Fix: wrong render layer in PARTICLE_VASE_

### DIFF
--- a/src/Lawn/Challenge.cpp
+++ b/src/Lawn/Challenge.cpp
@@ -4163,7 +4163,7 @@ void Challenge::ScaryPotterOpenPot(GridItem* theScaryPot)
 		theScaryPot->mGridItemState == GRIDITEM_STATE_SCARY_POT_LEAF ? PARTICLE_VASE_SHATTER_LEAF :
 		theScaryPot->mGridItemState == GRIDITEM_STATE_SCARY_POT_ZOMBIE ? PARTICLE_VASE_SHATTER_ZOMBIE :
 		PARTICLE_VASE_SHATTER;
-	mApp->AddTodParticle(aXPos + 20, aYPos, RENDER_LAYER_TOP, anEffect);
+	mApp->AddTodParticle(aXPos + 20, aYPos, RENDER_LAYER_PARTICLE, anEffect);
 }
 
 void Challenge::ScaryPotterJackExplode(int thePosX, int thePosY)


### PR DESCRIPTION
Change RENDER_LAYER_TOP to RENDER_LAYER_PARTICLE.
make sure the particle under the zombies.

<img width="1588" height="623" alt="image" src="https://github.com/user-attachments/assets/bed1a629-a839-4ec2-9860-f895fa09033b" />

<img width="1290" height="796" alt="image" src="https://github.com/user-attachments/assets/eeecbce3-cc54-4f29-8673-e0889f38a6bb" />

 dont know corretly enum. but this good.