### PR TITLE
Fix: correct zombie velocity of dolphin-riders and plain zombies

### DIFF
--- a/src/Lawn/Zombie.cpp
+++ b/src/Lawn/Zombie.cpp
@@ -1122,10 +1122,6 @@ void Zombie::PickRandomSpeed()
     {
         mVelX = 0.3f;
     }
-    else if (mZombiePhase == ZombiePhase::PHASE_DOLPHIN_WALKING_IN_POOL)
-    {
-        mVelX = 0.3f;
-    }
     else if (mZombiePhase == ZombiePhase::PHASE_DIGGER_WALKING)
     {
         if (mApp->IsIZombieLevel())
@@ -1170,7 +1166,7 @@ void Zombie::PickRandomSpeed()
     }
     else
     {
-        mVelX = RandRangeFloat(0.23f, 0.32f);
+        mVelX = RandRangeFloat(0.23f, 0.37f);
         if (mVelX < 0.3f)
         {
             mAnimTicksPerFrame = 12;


### PR DESCRIPTION
I found two mistakes in the mVelX of PHASE_DOLPHIN_WALKING_IN_POOL and the default branch.

---

## 1. PHASE_DOLPHIN_WALKING_IN_POOL 

After dophin flied over a plant, the vel should become a random float **between 0.23 and 0.37**, not an exact num **0.3**.

The following images show the vel of dolphin during the process of rushing(0.89-0.91), flying over a wall-nut(0.5) and walking in the water(should be 0.23-0.37), using CE to get data from **the original game**.

<img width="782" height="307" alt="original game engine" src="https://github.com/user-attachments/assets/6dd078d7-7d10-4251-99ae-7e7be9e88ada" />

However, in **Pvz Portable**, the vel when walking in the water is exactly 0.3. (see typ: 14)

<img width="238" height="242" alt="pvz portable" src="https://github.com/user-attachments/assets/2bd6117a-4a6a-4d4a-a787-5f2012c9c5fe" />

This mistake is probably caused by confusion with SNORKEL_WALKING_IN_POOL. After removing the if logic, PHASE_DOLPHIN_WALKING_IN_POOL will enter the default branch, providing the correct data.

---

## 2. the default branch

Plain zombies' velocity should be a random float between 0.23 and **0.37**, not between 0.23 and **0.32**.

I used CE to monitor vels of zombies in VBE, and 4 of 14 are above 0.32.

<img width="626" height="371" alt="original game engine" src="https://github.com/user-attachments/assets/3d3ff98b-afb8-41a3-9230-68ce08b1e1db" />

Data provided by Pvz Wiki can also prove this. The column [僵尸速度](https://wiki.pvz1.com/doku.php?id=%E6%94%BB%E7%95%A5:%E5%83%B5%E5%B0%B8%E9%80%9F%E5%BA%A6) says `普通僵尸、路障僵尸、铁桶僵尸、铁门僵尸（双手摆动），速度参数0.23~0.37。` What's more, [僵尸图鉴](https://wiki.pvz1.com/doku.php?id=%E6%95%99%E7%A8%8B:%E5%83%B5%E5%B0%B8%E5%9B%BE%E9%89%B4) records 格均耗时 as 459 to 735, and we found 459/735 perfectly equal to 0.23/0.37.

**However**, the same operation in Pvz Portable generates no zombie with the mVelX bigger than 0.32, which is obviously a mistake. 

<img width="260" height="607" alt="pvz portable" src="https://github.com/user-attachments/assets/b8feeeef-1e28-4102-8723-12fb617c1e67" />

---

These are the 2 main bugs found. Looking forward to ur reply and have a nice day  :)

    ~~Yours, sincerely~~

    ~~Li Hua~~
