### PR TITLE
Feat: disable LIMBO_PAGE by default, enable explicitly in Arch testing PKGBUILD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,7 +442,7 @@ jobs:
     - name: Build PvZ-Portable for WebAssembly
       run: |
         mkdir build-wasm
-        emcmake cmake -G Ninja -B build-wasm -DCMAKE_BUILD_TYPE=Release -DLIMBO_PAGE=OFF
+        emcmake cmake -G Ninja -B build-wasm -DCMAKE_BUILD_TYPE=Release
         cmake --build build-wasm -j$(nproc)
 
     - name: Upload Artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ else()
 endif()
 
 option(PVZ_DEBUG "Enable _PVZ_DEBUG macro to enable cheats, hidden features, etc." ${PVZ_DEBUG_DEFAULT})
-option(LIMBO_PAGE "Enable limbo page to access hidden levels" ON)
+option(LIMBO_PAGE "Enable limbo page to access hidden levels" OFF)
 option(CONSOLE "Show console on Windows" ${WIN_CONSOLE_DEFAULT})
 option(DO_FIX_BUGS "Define DO_FIX_BUGS macro (Community fixes for original game bugs of 1.2.0.1073 GOTY Edition)" OFF)
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ You can customize the game features by adding options to the first `cmake` comma
 | Option | Default | Description |
 | :--- | :--- | :--- |
 | `PVZ_DEBUG` | `OFF`<br>(`ON` if `CMAKE_BUILD_TYPE` is `Debug`) | Enable **cheat keys**, debug displays and other debug features. |
-| `LIMBO_PAGE` | `ON` | Enable access to the limbo page which contains hidden levels. |
+| `LIMBO_PAGE` | `OFF` | Enable access to the limbo page which contains hidden levels. |
 | `DO_FIX_BUGS` | `OFF` | Apply community fixes for "bugs" of official 1.2.0.1073 GOTY Edition.[^1] However, these "bugs" are usually **considered "features"** by many players. |
 | `CONSOLE` | `OFF`<br>(`ON` if `CMAKE_BUILD_TYPE` is `Debug`) | Show a console window (Windows only). |
 | `BUILD_STATIC` | `OFF` | Link statically to create a standalone executable (Windows with MinGW-based toolchains only). Use a vcpkg `-static` triplet for MSVC instead. |

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -45,6 +45,7 @@ pkgver() {
 build() {
     cmake -B build -S "${pkgname}" \
         -DCMAKE_BUILD_TYPE='Release' \
+        -DLIMBO_PAGE=ON \
         -DCMAKE_INSTALL_PREFIX='/usr'
     cmake --build build
 }


### PR DESCRIPTION
Aligned with the original version by default