### PR TITLE
Fix: duration of STATE_SQUASH_LOOK should be 45 instead of 30

### DIFF
--- a/src/Lawn/Plant.cpp
+++ b/src/Lawn/Plant.cpp
@@ -1499,7 +1499,7 @@ void Plant::UpdateSquash()
         {
             PlayBodyReanim("anim_jumpup", ReanimLoopType::REANIM_PLAY_ONCE_AND_HOLD, 20, 24.0f);
             mState = PlantState::STATE_SQUASH_PRE_LAUNCH;
-            mStateCountdown = 30;
+            mStateCountdown = 45;
         }
     }
     else if (mState == PlantState::STATE_SQUASH_PRE_LAUNCH)


### PR DESCRIPTION
# Duration of STATE_SQUASH_LOOK should be 45 instead of 30

## Proof 1:

After the fix:

| State| Duration | Kill |
|------|----------------|--------------------------------------------------|
| `STATE_SQUASH_LOOK` | 80 | 0 ~ 80 |
| `STATE_SQUASH_PRE_LAUNCH` | **45** | 80 ~ **125** |
| `STATE_SQUASH_RISING` | 50 | 125 ~ 175 |
| `STATE_SQUASH_FALLING` | 10 | 175 ~ 180 |

Squash spends 180 frames instead of 165 frames to kill a zombie, and that time is measured 182 in PvZ Wiki or PvZ Tool.


## Proof 2:

<img width="931" height="160" alt="cc5093ab360c83b2f6ff10dccd387c44" src="https://github.com/user-attachments/assets/d2e493de-a7c1-4eaa-bc12-196937698df9" />

State 4 corresponds to the cd of 45 frames.

---

Looking forward to ur reply~