### PR TITLE
Fix: correct Imitater tooltip string key from NOT_RECOMMEND_FOR_LEVEL to NOT_RECOMMENDED_FOR_LEVEL

### DIFF
--- a/src/Lawn/Widget/ImitaterDialog.cpp
+++ b/src/Lawn/Widget/ImitaterDialog.cpp
@@ -136,7 +136,7 @@ void ImitaterDialog::ShowToolTip()
 			}
 			else
 			{
-				mToolTip->SetWarningText("[NOT_RECOMMEND_FOR_LEVEL]");
+				mToolTip->SetWarningText("[NOT_RECOMMENDED_FOR_LEVEL]");
 			}
 		}
 		else


### PR DESCRIPTION
Close #288