### PR TITLE
Fix: ensure Jalapeno-headed zombie dies with loot when burned

### DIFF
--- a/src/Lawn/Zombie.cpp
+++ b/src/Lawn/Zombie.cpp
@@ -2376,6 +2376,7 @@ void Zombie::UpdateZombieJalapenoHead()
             }
         }
 #endif
+        DieNoLoot();
     }
 }
 


### PR DESCRIPTION
Testing has confirmed that self-destructing zombies do not drop loot, so call `DieNoLoot()` instead of `DieWithLoot()` here.

Close #295