### PR TITLE
Feat: toggle fullscreen with Alt+Enter

### DIFF
--- a/src/SexyAppFramework/platform/default/Input.cpp
+++ b/src/SexyAppFramework/platform/default/Input.cpp
@@ -482,6 +482,16 @@ bool SexyAppBase::ProcessDeferredMessages(bool singleMessage)
 			case SDL_KEYDOWN:
 			{
 				mLastUserInputTick = mLastTimerTime;
+
+				if (mAllowAltEnter &&
+					event.key.repeat == 0 &&
+					(event.key.keysym.sym == SDLK_RETURN || event.key.keysym.sym == SDLK_KP_ENTER) &&
+					(event.key.keysym.mod & KMOD_ALT))
+				{
+					SwitchScreenMode(!mIsWindowed);
+					break;
+				}
+
 				mWidgetManager->KeyDown(SDLKeyToKeyCode(event.key.keysym.sym));
 
 				char aSynthesizedChar = 0;


### PR DESCRIPTION
Use the existing mAllowAltEnter guard and SwitchScreenMode() to toggle fullscreen on Alt+Enter key press. The shortcut is ignored on mobile platforms where fullscreen is forced.

Close #305