### PR TITLE
Fix: Revise the description of the "Roll Some Heads" achievement to match the original version

### DIFF
--- a/src/Lawn/Widget/AchievementsScreen.cpp
+++ b/src/Lawn/Widget/AchievementsScreen.cpp
@@ -50,7 +50,7 @@ AchievementItem gAchievementList[MAX_ACHIEVEMENTS] = {
 	{ "Explodonator", "Take out 10 full-sized zombies with a single Cherry Bomb." },
 	{ "Morticulturalist", "Collect all 49 plants (including plants from Crazy Dave's shop)." },
 	{ "Don't Pea in the Pool", "Complete a daytime pool level without using pea shooters of any kind." },
-	{ "Roll Some Heads", "Bowl over 5 zombies with the same wall-nut." },
+	{ "Roll Some Heads", "Bowl over 5 zombies with a single Wall-Nut." },
 	{ "Grounded", "Defeat a normal roof level without using any catapult plants." },
 	{ "Zombologist", "Discover the Yeti zombie." },
 	{ "Penny Pincher", "Pick up 30 coins in a row on a single level without letting any disappear." },


### PR DESCRIPTION
In PR, fixed the inconsistent description of the "Roll Some Heads" achievement to bring this project more in line with the original version.


Comparison

Before the Fix:
<img width="1002" height="790" alt="屏幕截图 2026-06-20 171422" src="https://github.com/user-attachments/assets/a70a45cf-892b-49bb-b8cc-59ba17d95b7f" />


After the Fix:
<img width="1002" height="790" alt="屏幕截图 2026-06-20 171734" src="https://github.com/user-attachments/assets/8a9f1e54-2688-4249-8b7a-ffb2fc6e0ad4" />


Original Version:
<img width="802" height="633" alt="屏幕截图 2026-06-20 171406" src="https://github.com/user-attachments/assets/11eeac51-b635-4efe-834d-61b2362955ac" />