### PR TITLE
Fix: award Morticulturalist when all shop plants are owned

### DIFF
--- a/src/Lawn/Widget/AchievementsScreen.cpp
+++ b/src/Lawn/Widget/AchievementsScreen.cpp
@@ -277,8 +277,8 @@ void ReportAchievement::AchievementInitForPlayer(LawnApp* theApp) {
 	}
 
 	bool aGiveAchievement = true;
-	for (int i = STORE_ITEM_PLANT_GATLINGPEA; i <= STORE_ITEM_PLANT_IMITATER; i++) {
-		if (theApp->HasSeedType(SeedType(i)))
+	for (int aSeedType = SeedType::SEED_GATLINGPEA; aSeedType <= SeedType::SEED_IMITATER; aSeedType++) {
+		if (!theApp->HasSeedType(SeedType(aSeedType)))
 			aGiveAchievement = false;
 	}
 

--- a/src/Lawn/Widget/StoreScreen.cpp
+++ b/src/Lawn/Widget/StoreScreen.cpp
@@ -1042,11 +1042,13 @@ void StoreScreen::PurchaseItem(StoreItem theStoreItem)
                 mApp->mSeedChooserScreen->UpdateAfterPurchase();
             }
 
-            // @Patoke: implemented
-            bool aGiveAchievement = true;
-            for (int i = STORE_ITEM_PLANT_GATLINGPEA; i <= STORE_ITEM_PLANT_IMITATER; i++) {
-                if (mApp->HasSeedType(SeedType(i)))
-                    aGiveAchievement = false;
+            // Only give the achievement if the player bought a plant and has all plants purchased
+            bool aGiveAchievement = theStoreItem >= STORE_ITEM_PLANT_GATLINGPEA && theStoreItem <= STORE_ITEM_PLANT_IMITATER;
+            if (aGiveAchievement) {
+                for (int aSeedType = SeedType::SEED_GATLINGPEA; aSeedType <= SeedType::SEED_IMITATER; aSeedType++) {
+                    if (!mApp->HasSeedType(SeedType(aSeedType)))
+                        aGiveAchievement = false;
+                }
             }
 
             if (aGiveAchievement) {


### PR DESCRIPTION
The check looped store-item indices 0..8 cast to SeedType (Peashooter.. Puffshroom, not the 9 shop plants at seed types 40..48) and cleared the grant flag when a plant was owned rather than missing, so the achievement could never be earned. Iterate the real shop-plant seed range and flip the condition in both AchievementInitForPlayer and the store handler, and only run the latter on a shop-plant purchase, matching the original game.