### PR TITLE
fix: Use correct translation key for restart button

### DIFF
--- a/src/Lawn/Widget/NewOptionsDialog.cpp
+++ b/src/Lawn/Widget/NewOptionsDialog.cpp
@@ -43,7 +43,7 @@ NewOptionsDialog::NewOptionsDialog(LawnApp* theApp, bool theFromGameSelector) :
     mFromGameSelector = theFromGameSelector;
     SetColor(Dialog::COLOR_BUTTON_TEXT, Color(255, 255, 100));
     mAlmanacButton = MakeButton(NewOptionsDialog::NewOptionsDialog_Almanac, this, "[VIEW_ALMANAC_BUTTON]");
-    mRestartButton = MakeButton(NewOptionsDialog::NewOptionsDialog_Restart, this, "[RESTART_LEVEL]");
+    mRestartButton = MakeButton(NewOptionsDialog::NewOptionsDialog_Restart, this, "[RESTART_BUTTON]");
     mBackToMainButton = MakeButton(NewOptionsDialog::NewOptionsDialog_MainMenu, this, "[MAIN_MENU_BUTTON]");
 
     mBackToGameButton = MakeNewButton(


### PR DESCRIPTION
Currently, the restart button in the options menu uses RESTART_LEVEL, which corresponds to this in LawnStrings.txt:
`Are you sure that you want to restart the level?`
This is incorrect. The correct string would be RESTART_BUTTON, which corresponds to just `Restart`.
This PR fixes this issue, which solves this visual bug:
<img width="796" height="869" alt="image" src="https://github.com/user-attachments/assets/580fbe27-5896-488f-a179-094603945251" />
