### PR TITLE
Fix: clean up latent UB and modernize string handling

### DIFF
--- a/src/Lawn/CursorObject.cpp
+++ b/src/Lawn/CursorObject.cpp
@@ -43,6 +43,7 @@ CursorObject::CursorObject()
     mReanimCursorID = ReanimationID::REANIMATIONID_NULL;
     mWidth = 80;
     mHeight = 80;
+    mHammerDownCounter = 0;
 }
 
 void CursorObject::Update()

--- a/src/Lawn/MessageWidget.cpp
+++ b/src/Lawn/MessageWidget.cpp
@@ -34,11 +34,13 @@ MessageWidget::MessageWidget(LawnApp* theApp)
 {
 	mApp = theApp;
 	mDuration = 0;
+	mDisplayTime = 0;
 	mLabel[0] = '\0';
 	mMessageStyle = MessageStyle::MESSAGE_STYLE_OFF;
 	mLabelNext[0] = '\0';
 	mMessageStyleNext = MessageStyle::MESSAGE_STYLE_OFF;
 	mSlideOffTime = 100;
+	mReanimType = ReanimationType::REANIM_NONE;
 	memset(mTextReanimID, static_cast<int>(ReanimationID::REANIMATIONID_NULL), MAX_MESSAGE_LENGTH);
 }
 

--- a/src/Lawn/System/SaveGame.cpp
+++ b/src/Lawn/System/SaveGame.cpp
@@ -2590,7 +2590,7 @@ static bool LawnLoadGameV4(Board* theBoard, const std::string& theFilePath)
 		return false;
 	if (aHeader.mVersion != SAVE_FILE_V4_VERSION)
 		return false;
-	if (aHeader.mPayloadSize + sizeof(SaveFileHeaderV4) > static_cast<uint32_t>(aBuffer.GetDataLen()))
+	if (aHeader.mPayloadSize > static_cast<uint32_t>(aBuffer.GetDataLen()) - sizeof(SaveFileHeaderV4))
 		return false;
 
 	unsigned char* aPayload = (unsigned char*)aBuffer.GetDataPtr() + sizeof(SaveFileHeaderV4);

--- a/src/Sexy.TodLib/Definition.cpp
+++ b/src/Sexy.TodLib/Definition.cpp
@@ -423,7 +423,6 @@ inline bool DefReadFromCacheString(void*& theReadPtr, const char** theString)
 {
     int aLen;
     SMemR(theReadPtr, &aLen, sizeof(int));
-    TOD_ASSERT(aLen >= 0 && aLen <= 100000);
     if (aLen == 0)
         *theString = "";
     else
@@ -440,9 +439,8 @@ inline bool DefReadFromCacheImage(void*& theReadPtr, Image** theImage)
 {
     int aLen;
     SMemR(theReadPtr, &aLen, sizeof(int));  // 读取贴图标签字符数组的长度
-    char* aImageName = (char*)alloca(aLen + 1);  // 在栈上分配贴图标签字符数组的内存空间
-    SMemR(theReadPtr, aImageName, aLen);  // 读取贴图标签字符数组
-    aImageName[aLen] = '\0';
+    std::string aImageName(aLen, '\0');
+    SMemR(theReadPtr, aImageName.data(), aLen);  // 读取贴图标签字符数组
 
     *theImage = nullptr;
     return aImageName[0] == '\0' || DefinitionLoadImage(theImage, aImageName);
@@ -452,10 +450,9 @@ inline bool DefReadFromCacheFont(void*& theReadPtr, _Font** theFont)
 {
     int aLen;
     SMemR(theReadPtr, &aLen, sizeof(int));  // 读取字体标签字符数组的长度
-    char* aFontName = (char*)alloca(aLen + 1);  // 在栈上分配字体标签字符数组的内存空间
-    SMemR(theReadPtr, aFontName, aLen);  // 读取字体标签字符数组
-    aFontName[aLen] = '\0';
-    
+    std::string aFontName(aLen, '\0');
+    SMemR(theReadPtr, aFontName.data(), aLen);  // 读取字体标签字符数组
+
     *theFont = nullptr;
     return aFontName[0] == '\0' || DefinitionLoadFont(theFont, aFontName);
 }

--- a/src/SexyAppFramework/misc/ResourceManager.cpp
+++ b/src/SexyAppFramework/misc/ResourceManager.cpp
@@ -866,13 +866,13 @@ bool ResourceManager::DoLoadFont(FontRes* theRes)
 
 		if (!theRes->mTags.empty())
 		{
-			char aBuf[1024];
-			strcpy(aBuf,theRes->mTags.c_str());
-			const char *aPtr = strtok(aBuf,", \r\n\t");
-			while (aPtr != nullptr)
+			const char* aDelim = ", \r\n\t";
+			size_t aPos = theRes->mTags.find_first_not_of(aDelim);
+			while (aPos != std::string::npos)
 			{
-				anImageFont->AddTag(aPtr);
-				aPtr = strtok(nullptr,", \r\n\t");
+				size_t aEnd = theRes->mTags.find_first_of(aDelim, aPos);
+				anImageFont->AddTag(theRes->mTags.substr(aPos, aEnd - aPos));
+				aPos = theRes->mTags.find_first_not_of(aDelim, aEnd);
 			}
 			anImageFont->Prepare();
 		}


### PR DESCRIPTION
- Definition: replace non-standard alloca with std::string in the image/font cache loaders, and drop a debug-only length assert in the string loader that never fires on trusted cache data.
- ResourceManager: tokenize font tags directly from the std::string instead of strcpy/strtok into a fixed-size buffer.
- SaveGame: express the V4 payload bounds check in subtraction form to avoid unsigned wrap on 32-bit targets.
- MessageWidget/CursorObject: initialize mReanimType, mDisplayTime and mHammerDownCounter in their constructors to avoid reading or serializing uninitialized memory.