### PR TITLE
Fix: match original title-case labels on default dialog buttons

### DIFF
--- a/src/Lawn/Widget/LawnDialog.cpp
+++ b/src/Lawn/Widget/LawnDialog.cpp
@@ -54,13 +54,13 @@ LawnDialog::LawnDialog(LawnApp* theApp, int theId, bool isModal, const std::stri
     // @Patoke: these dialogs had the wrong local name
     if (theButtonMode == 1)
     {
-        mLawnYesButton = MakeButton(1000, this, "[DIALOG_BUTTON_YES]");
-        mLawnNoButton = MakeButton(1001, this, "[DIALOG_BUTTON_NO]");
+        mLawnYesButton = MakeButton(1000, this, "Yes");
+        mLawnNoButton = MakeButton(1001, this, "No");
     }
     else if (theButtonMode == 2)
     {
-        mLawnYesButton = MakeButton(1000, this, "[DIALOG_BUTTON_OK]");
-        mLawnNoButton = MakeButton(1001, this, "[DIALOG_BUTTON_CANCEL]");
+        mLawnYesButton = MakeButton(1000, this, "Ok");
+        mLawnNoButton = MakeButton(1001, this, "Cancel");
     }
     else if (theButtonMode == 3)
     {

--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -1098,16 +1098,7 @@ void LawnApp::FinishTimesUpDialog()
 // GOTY @Patoke: 0x5282E0
 void LawnApp::DoConfirmSellDialog(const std::string& theMessage)
 {
-	Dialog* aConfirmDialog = DoDialog(Dialogs::DIALOG_ZEN_SELL, true, "[ZEN_SELL_HEADER]", theMessage, "", Dialog::BUTTONS_YES_NO);
-	aConfirmDialog->mYesButton->mLabel = TodStringTranslate("[DIALOG_BUTTON_YES]");
-	aConfirmDialog->mNoButton->mLabel = TodStringTranslate("[DIALOG_BUTTON_NO]");
-}
-
-void LawnApp::DoConfirmPurchaseDialog(const std::string& theMessage)
-{
-	LawnDialog* aComfirmDialog = (LawnDialog*)DoDialog(Dialogs::DIALOG_STORE_PURCHASE, true, "买下这个物品？", theMessage, "", Dialog::BUTTONS_YES_NO);
-	aComfirmDialog->mLawnYesButton->mLabel = TodStringTranslate("[DIALOG_BUTTON_YES]");
-	aComfirmDialog->mLawnNoButton->mLabel = TodStringTranslate("[DIALOG_BUTTON_NO]");
+	DoDialog(Dialogs::DIALOG_ZEN_SELL, true, "[ZEN_SELL_HEADER]", theMessage, "", Dialog::BUTTONS_YES_NO);
 }
 
 Dialog* LawnApp::NewDialog(int theDialogId, bool isModal, const std::string& theDialogHeader, const std::string& theDialogLines, const std::string& theDialogFooter, int theButtonMode)

--- a/src/LawnApp.h
+++ b/src/LawnApp.h
@@ -176,7 +176,6 @@ public:
 	void							FinishNameError(int theId);
 	void							FinishRestartConfirmDialog();
 	void							DoConfirmSellDialog(const std::string& theMessage);
-	void							DoConfirmPurchaseDialog(const std::string& theMessage);
 	void							FinishTimesUpDialog();
 	void							KillBoard();
 	void							MakeNewBoard();


### PR DESCRIPTION
Close #106