### PR TITLE
Fix: fix dialog button casing and localize hardcoded strings across versions

### DIFF
--- a/src/Lawn/Widget/AchievementsScreen.cpp
+++ b/src/Lawn/Widget/AchievementsScreen.cpp
@@ -41,7 +41,7 @@
 
 Rect aBackButtonRect = { 120, 35, 130, 80 };
 
-AchievementItem gAchievementList[MAX_ACHIEVEMENTS] = {
+constinit const AchievementItem gAchievementList[MAX_ACHIEVEMENTS] = {
 	{ "Home Lawn Security", "Complete Adventure Mode." },
 	{ "Nobel Peas Prize", "Get the golden sunflower trophy." },
 	{ "Better Off Dead", "Get to a streak of 10 in I, Zombie Endless" },

--- a/src/Lawn/Widget/AchievementsScreen.h
+++ b/src/Lawn/Widget/AchievementsScreen.h
@@ -25,6 +25,7 @@
 
 #include "../../ConstEnums.h"
 #include "widget/Widget.h"
+#include <string_view>
 
 class LawnApp;
 
@@ -57,11 +58,11 @@ enum AchievementId {
 // todo @Patoke: add these
 class AchievementItem {
 public:
-    std::string name;
-    std::string description;
+    std::string_view name;
+    std::string_view description;
 };
 
-extern AchievementItem gAchievementList[MAX_ACHIEVEMENTS];
+extern const AchievementItem gAchievementList[MAX_ACHIEVEMENTS];
 
 class AchievementsWidget : public Widget {
 public:

--- a/src/Lawn/Widget/AlmanacDialog.cpp
+++ b/src/Lawn/Widget/AlmanacDialog.cpp
@@ -37,7 +37,7 @@
 
 bool gZombieDefeated[NUM_ZOMBIE_TYPES] = { false };
 
-AlmanacDialog::AlmanacDialog(LawnApp* theApp) : LawnDialog(theApp, DIALOG_ALMANAC, true, "Almanac", "", "", BUTTONS_NONE)
+AlmanacDialog::AlmanacDialog(LawnApp* theApp) : LawnDialog(theApp, DIALOG_ALMANAC, true, theApp->GetString("ALMANAC_HEADER", "Almanac"), "", "", BUTTONS_NONE)
 {
 	mApp = (LawnApp*)gSexyAppBase;
 	mOpenPage = ALMANAC_PAGE_INDEX;

--- a/src/Lawn/Widget/AwardScreen.cpp
+++ b/src/Lawn/Widget/AwardScreen.cpp
@@ -631,8 +631,8 @@ void AwardScreen::DrawAchievements(Graphics* g) {
 	TodDrawString(g, mApp->GetString("ACHIEVEMENTS_TITLE", "ACHIEVEMENTS"), BOARD_WIDTH / 2, 58, FONT_HOUSEOFTERROR28, Color(220, 220, 220), DS_ALIGN_CENTER);
 
 	for (size_t i = 0; i < mAchievementItems.size(); i++) {
-		std::string aAchievementName = gAchievementList[mAchievementItems[i].mId].name;
-		std::string aAchievementDesc = gAchievementList[mAchievementItems[i].mId].description;
+		std::string aAchievementName = std::string(gAchievementList[mAchievementItems[i].mId].name);
+		std::string aAchievementDesc = std::string(gAchievementList[mAchievementItems[i].mId].description);
 		aAchievementName.append(" Earned!");
 
 		Rect aSrcRect = Rect(70 * (mAchievementItems[i].mId % 7), 70 * (mAchievementItems[i].mId / 7), 70, 70);

--- a/src/Lawn/Widget/AwardScreen.cpp
+++ b/src/Lawn/Widget/AwardScreen.cpp
@@ -628,7 +628,7 @@ void AwardScreen::DrawAchievements(Graphics* g) {
 
 	g->DrawImage(IMAGE_CHALLENGE_BACKGROUND, 0, 0);
 
-	TodDrawString(g, "ACHIEVEMENTS", BOARD_WIDTH / 2, 58, FONT_HOUSEOFTERROR28, Color(220, 220, 220), DS_ALIGN_CENTER);
+	TodDrawString(g, mApp->GetString("ACHIEVEMENTS_TITLE", "ACHIEVEMENTS"), BOARD_WIDTH / 2, 58, FONT_HOUSEOFTERROR28, Color(220, 220, 220), DS_ALIGN_CENTER);
 
 	for (size_t i = 0; i < mAchievementItems.size(); i++) {
 		std::string aAchievementName = gAchievementList[mAchievementItems[i].mId].name;

--- a/src/Lawn/Widget/ChallengeScreen.cpp
+++ b/src/Lawn/Widget/ChallengeScreen.cpp
@@ -143,7 +143,7 @@ ChallengeScreen::ChallengeScreen(LawnApp* theApp, ChallengePage thePage)
 		aPageButton->mDoFinger = true;
 		mPageButton[aPageIdx] = aPageButton;
 		if (aPageIdx == CHALLENGE_PAGE_LIMBO)
-			aPageButton->mLabel = TodStringTranslate("Limbo Page");
+			aPageButton->mLabel = mApp->GetString("LIMBO_PAGE_BUTTON", "Limbo Page");
 		else
 			aPageButton->mLabel = TodReplaceNumberString("[PAGE_X]", "{PAGE}", aPageIdx);
 		aPageButton->mButtonImage = Sexy::IMAGE_BLANK;

--- a/src/Lawn/Widget/ContinueDialog.cpp
+++ b/src/Lawn/Widget/ContinueDialog.cpp
@@ -34,20 +34,22 @@ ContinueDialog::ContinueDialog(LawnApp* theApp) : LawnDialog(
 	theApp, 
 	Dialogs::DIALOG_CONTINUE, 
 	true, 
-	"CONTINUE GAME?", 
+	theApp->GetString("CONTINUE_GAME_HEADER", "CONTINUE GAME?"), 
 	"", 
 	"[DIALOG_BUTTON_CANCEL]", 
 	Dialog::BUTTONS_FOOTER)
 {
     if (theApp->IsAdventureMode())
     {
-        mDialogLines = TodStringTranslate("Do you want to continue your current game or restart the level?");
+        mDialogLines = mApp->GetString("CONTINUE_GAME_OR_RESTART",
+            "Do you want to continue your current game or restart the level?");
         mContinueButton = MakeButton(ContinueDialog::ContinueDialog_Continue, this, "[CONTINUE_BUTTON]");
         mNewGameButton = MakeButton(ContinueDialog::ContinueDialog_NewGame, this, "[RESTART_LEVEL]");
     }
     else
     {
-        mDialogLines = TodStringTranslate("Do you want to continue your current game or start a new game?");
+        mDialogLines = mApp->GetString("CONTINUE_GAME",
+            "Do you want to continue your current game or start a new game?");
         mContinueButton = MakeButton(ContinueDialog::ContinueDialog_Continue, this, "[CONTINUE_BUTTON]");
         mNewGameButton = MakeButton(ContinueDialog::ContinueDialog_NewGame, this, "[NEW_GAME_BUTTON]");
     }
@@ -167,8 +169,8 @@ void ContinueDialog::ButtonDepress(int theId)
             LawnDialog* aDialog = (LawnDialog*)mApp->DoDialog(
                 Dialogs::DIALOG_RESTARTCONFIRM, 
                 true, 
-                "New Game?", 
-                "Are you sure that you want to start a new game?", 
+                mApp->GetString("NEW_GAME_HEADER", "New Game?"), 
+                mApp->GetString("NEW_GAME", "Are you sure that you want to start a new game?"), 
                 "", 
                 Dialog::BUTTONS_OK_CANCEL
             );

--- a/src/Lawn/Widget/LawnDialog.cpp
+++ b/src/Lawn/Widget/LawnDialog.cpp
@@ -54,13 +54,13 @@ LawnDialog::LawnDialog(LawnApp* theApp, int theId, bool isModal, const std::stri
     // @Patoke: these dialogs had the wrong local name
     if (theButtonMode == 1)
     {
-        mLawnYesButton = MakeButton(1000, this, "[DIALOG_BUTTON_YES]");
-        mLawnNoButton = MakeButton(1001, this, "[DIALOG_BUTTON_NO]");
+        mLawnYesButton = MakeButton(1000, this, mApp->GetString("BUTTON_YES", "Yes"));
+        mLawnNoButton = MakeButton(1001, this, mApp->GetString("BUTTON_NO", "No"));
     }
     else if (theButtonMode == 2)
     {
-        mLawnYesButton = MakeButton(1000, this, "[DIALOG_BUTTON_OK]");
-        mLawnNoButton = MakeButton(1001, this, "[DIALOG_BUTTON_CANCEL]");
+        mLawnYesButton = MakeButton(1000, this, mApp->GetString("BUTTON_OK", "Ok"));
+        mLawnNoButton = MakeButton(1001, this, mApp->GetString("BUTTON_CANCEL", "Cancel"));
     }
     else if (theButtonMode == 3)
     {

--- a/src/Lawn/Widget/NewOptionsDialog.cpp
+++ b/src/Lawn/Widget/NewOptionsDialog.cpp
@@ -376,7 +376,7 @@ void NewOptionsDialog::ButtonDepress(int theId)
             }
 
             LawnDialog* aDialog = (LawnDialog*)mApp->DoDialog(Dialogs::DIALOG_CONFIRM_RESTART, true, aDialogTitle, aDialogMessage, "", Dialog::BUTTONS_YES_NO);
-            aDialog->mLawnYesButton->mLabel = TodStringTranslate("[RESTART_BUTTON]");
+            aDialog->mLawnYesButton->mLabel = mApp->GetString("RESTART_LABEL", "RESTART");
             aDialog->mLawnNoButton->mLabel = TodStringTranslate("[DIALOG_BUTTON_CANCEL]");
             
             if (aDialog->WaitForResult(true) == Dialog::ID_YES)

--- a/src/Lawn/Widget/NewOptionsDialog.cpp
+++ b/src/Lawn/Widget/NewOptionsDialog.cpp
@@ -203,10 +203,10 @@ void NewOptionsDialog::Draw(Sexy::Graphics* g)
     float aFontScale = static_cast<float>(mApp->GetDouble("OPTION_DLG_LABEL_FONT_SCALE", 1.0));
     if (aFontScale != 1.0f)
         g->SetScale(aFontScale, aFontScale, 0.0f, 0.0f);
-    TodDrawString(g, "Music", aSliderLabelsX, 140 + aMusicOffset, FONT_DWARVENTODCRAFT18, aTextColor, DrawStringJustification::DS_ALIGN_RIGHT);
-    TodDrawString(g, "Sound FX", aSliderLabelsX, 167 + aSfxOffset, FONT_DWARVENTODCRAFT18, aTextColor, DrawStringJustification::DS_ALIGN_RIGHT);
-    TodDrawString(g, "3D Acceleration", aCheckboxLabelsX, 197 + a3DAccelOffset, FONT_DWARVENTODCRAFT18, aTextColor, DrawStringJustification::DS_ALIGN_RIGHT);
-    TodDrawString(g, "Full Screen", aCheckboxLabelsX, 229 + aFullScreenOffset, FONT_DWARVENTODCRAFT18, aTextColor, DrawStringJustification::DS_ALIGN_RIGHT);
+    TodDrawString(g, mApp->GetString("OPTIONS_MUSIC_LABEL", "Music"), aSliderLabelsX, 140 + aMusicOffset, FONT_DWARVENTODCRAFT18, aTextColor, DrawStringJustification::DS_ALIGN_RIGHT);
+    TodDrawString(g, mApp->GetString("OPTIONS_SOUNDFX", "Sound FX"), aSliderLabelsX, 167 + aSfxOffset, FONT_DWARVENTODCRAFT18, aTextColor, DrawStringJustification::DS_ALIGN_RIGHT);
+    TodDrawString(g, mApp->GetString("OPTIONS_3D_ACCELERATION", "3D Acceleration"), aCheckboxLabelsX, 197 + a3DAccelOffset, FONT_DWARVENTODCRAFT18, aTextColor, DrawStringJustification::DS_ALIGN_RIGHT);
+    TodDrawString(g, mApp->GetString("OPTIONS_FULL_SCREEN", "Full Screen"), aCheckboxLabelsX, 229 + aFullScreenOffset, FONT_DWARVENTODCRAFT18, aTextColor, DrawStringJustification::DS_ALIGN_RIGHT);
     if (aFontScale != 1.0f)
         g->SetScale(1.0f, 1.0f, 0.0f, 0.0f);
 }
@@ -241,10 +241,11 @@ void NewOptionsDialog::CheckboxChecked(int theId, bool checked)
             mApp->DoDialog(
                 Dialogs::DIALOG_COLORDEPTH_EXP, 
                 true, 
-                "No Windowed Mode", 
-                "Windowed mode is only available if your desktop was running in either\n"
+                mApp->GetString("NO_WINDOWED_MODE", "No Windowed Mode"),
+                mApp->GetString("INVALID_WINDOWS_MODE",
+                    "Windowed mode is only available if your desktop was running in either\n"
                     "16 bit or 32 bit color mode when you started the game.\n\n"
-                    "If you'd like to run in Windowed mode then you need to quit the game and switch your desktop to 16 or 32 bit color mode.", 
+                    "If you'd like to run in Windowed mode then you need to quit the game and switch your desktop to 16 or 32 bit color mode."),
                 "[DIALOG_BUTTON_OK]", 
                 Dialog::BUTTONS_FOOTER
             );
@@ -262,12 +263,13 @@ void NewOptionsDialog::CheckboxChecked(int theId, bool checked)
                 mApp->DoDialog(
                     Dialogs::DIALOG_INFO,
                     true,
-                    "Not Supported",
-                    "Hardware Acceleration cannot be enabled on this computer.\n\n"
+                    mApp->GetString("NOT_SUPPORTED", "Not Supported"),
+                    mApp->GetString("HARDWARE_ACCELERATION_NOT_SUPPORTED",
+                        "Hardware Acceleration cannot be enabled on this computer.\n\n"
                         "Your video card does not\n"
                         "meet the minimum requirements\n"
-                        "for this game.",
-                    "[DIALOG_BUTTON_OK]",
+                        "for this game."),
+                    "[DIALOG_BUTTON_OK]", 
                     Dialog::BUTTONS_FOOTER
                 );
             }
@@ -276,10 +278,11 @@ void NewOptionsDialog::CheckboxChecked(int theId, bool checked)
                 mApp->DoDialog(
                     Dialogs::DIALOG_INFO,
                     true,
-                    "Warning",
-                    "Your video card may not fully support this feature.\n\n"
-                        "If you experience slower performance, please disable Hardware Acceleration.\n",
-                    "[DIALOG_BUTTON_OK]",
+                    mApp->GetString("DIALOG_WARNING", "Warning"),
+                    mApp->GetString("SLOW_PERFORMANCE",
+                        "Your video card may not fully support this feature.\n\n"
+                        "If you experience slower performance, please disable Hardware Acceleration."),
+                    "[DIALOG_BUTTON_OK]", 
                     Dialog::BUTTONS_FOOTER
                 );
             }

--- a/src/Lawn/Widget/NewUserDialog.cpp
+++ b/src/Lawn/Widget/NewUserDialog.cpp
@@ -30,8 +30,8 @@ NewUserDialog::NewUserDialog(LawnApp* theApp, bool isRename) : LawnDialog(
 	isRename ? Dialogs::DIALOG_RENAMEUSER : Dialogs::DIALOG_CREATEUSER, 
 	true, 
 	// @Patoke: these locals don't exist
-	isRename ? "RENAME USER" : "NEW USER", 
-	"Please enter your name:", 
+	isRename ? theApp->GetString("RENAME_USER", "RENAME USER") : theApp->GetString("NEW_USER", "NEW USER"), 
+	theApp->GetString("PLEASE_ENTER_NAME", "Please enter your name:"), 
 	"[DIALOG_BUTTON_OK]", 
 	Dialog::BUTTONS_OK_CANCEL)
 {

--- a/src/Lawn/Widget/StoreScreen.cpp
+++ b/src/Lawn/Widget/StoreScreen.cpp
@@ -67,7 +67,7 @@ void StoreScreenOverlay::Draw(Graphics* g)
     mParent->DrawOverlay(g);
 }
 
-StoreScreen::StoreScreen(LawnApp* theApp) : Dialog(nullptr, nullptr, DIALOG_STORE, true, "Store", "", "", BUTTONS_NONE)
+StoreScreen::StoreScreen(LawnApp* theApp) : Dialog(nullptr, nullptr, DIALOG_STORE, true, theApp->GetString("STORE", "Store"), "", "", BUTTONS_NONE)
 {
 	mApp = theApp;
     mClip = false;
@@ -933,8 +933,9 @@ void StoreScreen::PurchaseItem(StoreItem theStoreItem)
     {
         // @Patoke: fix locals
         Dialog* aDialog = mApp->DoDialog(DIALOG_NOT_ENOUGH_MONEY, true,
-            "Not enough money", 
-            "You can't afford this item yet. Earn more coins by killing zombies!", 
+            mApp->GetString("NOT_ENOUGH_MONEY", "Not enough money"),
+            mApp->GetString("CANNOT_AFFORD_ITEM",
+                "You can't afford this item yet. Earn more coins by killing zombies!"),
             "[DIALOG_BUTTON_OK]", BUTTONS_FOOTER);
         mWaitForDialog = true;
         aDialog->WaitForResult(true);
@@ -945,8 +946,8 @@ void StoreScreen::PurchaseItem(StoreItem theStoreItem)
         LawnDialog* aComfirmDialog = (LawnDialog*)mApp->DoDialog(
             DIALOG_STORE_PURCHASE, 
             true, 
-            "Buy this item?", 
-            "Are you sure you want to buy this item?", 
+            mApp->GetString("BUY_ITEM_HEADER", "Buy this item?"),
+            mApp->GetString("BUY_ITEM", "Are you sure you want to buy this item?"),
             "", 
             BUTTONS_YES_NO
         );
@@ -963,8 +964,10 @@ void StoreScreen::PurchaseItem(StoreItem theStoreItem)
             if (theStoreItem == STORE_ITEM_PACKET_UPGRADE)
             {
                 ++mApp->mPlayerInfo->mPurchases[theStoreItem];
-                std::string aDialogLines = StrFormat("Now you can choose to take %d seeds with you per level!", 6 + mApp->mPlayerInfo->mPurchases[theStoreItem]);
-                Dialog* aDialog = mApp->DoDialog(DIALOG_UPGRADED, true, "More slots!", aDialogLines, "[DIALOG_BUTTON_OK]", BUTTONS_FOOTER);
+                std::string aDialogLines = StrFormat(
+                    mApp->GetString("NOW_YOU_CAN_CHOOSE_X_SEEDS", "Now you can choose to take %d seeds with you per level!").c_str(),
+                    6 + mApp->mPlayerInfo->mPurchases[theStoreItem]);
+                Dialog* aDialog = mApp->DoDialog(DIALOG_UPGRADED, true, mApp->GetString("MORE_SLOTS", "More slots!"), aDialogLines, "[DIALOG_BUTTON_OK]", BUTTONS_FOOTER);
 
                 mWaitForDialog = true;
                 aDialog->WaitForResult(true);

--- a/src/Lawn/Widget/UserDialog.cpp
+++ b/src/Lawn/Widget/UserDialog.cpp
@@ -37,7 +37,7 @@ static int gUserListWidgetColors[][3] = {
 };
 
 // @Patoke: these dialogs don't have localizations
-UserDialog::UserDialog(LawnApp* theApp) : LawnDialog(theApp, Dialogs::DIALOG_USERDIALOG, true, "WHO ARE YOU?", "", "", Dialog::BUTTONS_OK_CANCEL)
+UserDialog::UserDialog(LawnApp* theApp) : LawnDialog(theApp, Dialogs::DIALOG_USERDIALOG, true, theApp->GetString("WHO_ARE_YOU", "WHO ARE YOU?"), "", "", Dialog::BUTTONS_OK_CANCEL)
 {
 	mVerticalCenterText = false;
 	mUserList = new ListWidget(0, FONT_BRIANNETOD16, this);
@@ -46,8 +46,8 @@ UserDialog::UserDialog(LawnApp* theApp) : LawnDialog(theApp, Dialogs::DIALOG_USE
     mUserList->mJustify = ListWidget::JUSTIFY_CENTER;
     mUserList->mItemHeight = 24;
     
-    mRenameButton = MakeButton(UserDialog::UserDialog_RenameUser, this, "Rename");
-    mDeleteButton = MakeButton(UserDialog::UserDialog_DeleteUser, this, "Delete");
+    mRenameButton = MakeButton(UserDialog::UserDialog_RenameUser, this, mApp->GetString("RENAME_BUTTON", "Rename"));
+    mDeleteButton = MakeButton(UserDialog::UserDialog_DeleteUser, this, mApp->GetString("DELETE_BUTTON", "Delete"));
 
     mNumUsers = 0;
     if (theApp->mPlayerInfo)
@@ -70,7 +70,7 @@ UserDialog::UserDialog(LawnApp* theApp) : LawnDialog(theApp, Dialogs::DIALOG_USE
 
     if (mNumUsers < 8)
     {
-        mUserList->AddLine(TodStringTranslate("(Create a New User)"), false);
+        mUserList->AddLine(mApp->GetString("CREATE_NEW_USER", "(Create a New User)"), false);
     }
 
     mTallBottom = true;
@@ -140,7 +140,7 @@ void UserDialog::FinishDeleteUser()
     mNumUsers--;
     if (mNumUsers == 7)
     {
-        mUserList->AddLine(TodStringTranslate("(Create a New User)"), false);
+        mUserList->AddLine(mApp->GetString("CREATE_NEW_USER", "(Create a New User)"), false);
     }
 }
 

--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -694,8 +694,9 @@ void LawnApp::DoConfirmBackToMain()
 	LawnDialog* aDialog = (LawnDialog*)DoDialog(
 		Dialogs::DIALOG_CONFIRM_BACK_TO_MAIN, 
 		true, 
-		"Leave Game?"/*"[LEAVE_GAME]"*/,
-		"Do you want to return\nto the main menu?\n\nYour game will be saved."/*"[LEAVE_GAME_HEADER]"*/, 
+		GetString("LEAVE_GAME_HEADER", "Leave Game?"),
+		GetString("LEAVE_GAME",
+			"Do you want to return\nto the main menu?\n\nYour game will be saved."), 
 		"", 
 		Dialog::BUTTONS_YES_NO
 	);
@@ -760,9 +761,9 @@ void LawnApp::DoPauseDialog()
 	LawnDialog* aDialog = (LawnDialog*)DoDialog(
 		Dialogs::DIALOG_PAUSED,
 		true,
-		"GAME PAUSED"/*"[RESUME_GAME]"*/,
-		"Click to resume game", 
-		"Resume Game"/*"[GAME_PAUSED]"*/, 
+		GetString("GAME_PAUSED", "GAME PAUSED"),
+		GetString("CLICK_TO_RESUME", "Click to resume game"),
+		GetString("RESUME_GAME", "Resume Game"), 
 		Dialog::BUTTONS_FOOTER
 	);
 
@@ -875,8 +876,9 @@ void LawnApp::FinishCreateUserDialog(bool isYes)
 		DoDialog(
 			Dialogs::DIALOG_CREATEUSERERROR,
 			true,
-			"Enter Your Name",
-			"Please enter your name to create a new user profile for storing high score data and game progress",
+			GetString("ENTER_YOUR_NAME", "Enter Your Name"),
+			GetString("USER_ERROR_MESSAGE",
+				"Please enter your name to create a new user profile for storing high score data and game progress."),
 			"[DIALOG_BUTTON_OK]",
 			Dialog::BUTTONS_FOOTER
 		);
@@ -886,8 +888,9 @@ void LawnApp::FinishCreateUserDialog(bool isYes)
 		DoDialog(
 			Dialogs::DIALOG_CREATEUSERERROR,
 			true,
-			"Enter Your Name"/*"[ENTER_YOUR_NAME]"*/,
-			"Please enter your name to create a new user profile for storing high score data and game progress"/*"[ENTER_NEW_USER]"*/,
+			GetString("ENTER_YOUR_NAME", "Enter Your Name"),
+			GetString("USER_ERROR_MESSAGE",
+				"Please enter your name to create a new user profile for storing high score data and game progress."),
 			"[DIALOG_BUTTON_OK]",
 			Dialog::BUTTONS_FOOTER
 		);
@@ -904,8 +907,9 @@ void LawnApp::FinishCreateUserDialog(bool isYes)
 			DoDialog(
 				Dialogs::DIALOG_CREATEUSERERROR,
 				true,
-				"Name Conflict"/*"[NAME_CONFLICT]"*/,
-				"The name you entered is already being used.  Please enter a unique player name"/*"[ENTER_UNIQUE_PLAYER_NAME]"*/,
+				GetString("NAME_CONFLICT", "Name Conflict"),
+				GetString("ENTER_UNIQUE_PLAYER_NAME",
+					"The name you entered is already being used.  Please enter a unique player name."),
 				"[DIALOG_BUTTON_OK]",
 				Dialog::BUTTONS_FOOTER
 			);
@@ -934,10 +938,10 @@ void LawnApp::DoConfirmDeleteUserDialog(const std::string& theName)
 	DoDialog(
 		Dialogs::DIALOG_CONFIRMDELETEUSER, 
 		true, 
-		"Are You Sure"/*"[ARE_YOU_SURE]"*/, 
-		// StrFormat(TodStringTranslate("[DELETE_USER_WARNING]").c_str(), theName)
-		// @Patoke: didn't access this as 'const char*'
-		StrFormat("This will permanently remove '%s' from the player roster!"/**/, theName.c_str()),
+		GetString("ARE_YOU_SURE", "Are You Sure?"), 
+		StrFormat(
+			GetString("DELETE_USER_WARNING", "This will permanently remove '%s' from the player roster!").c_str(),
+			theName.c_str()),
 		"", 
 		Dialog::BUTTONS_YES_NO
 	);
@@ -1022,8 +1026,9 @@ void LawnApp::FinishRenameUserDialog(bool isYes)
 		DoDialog(
 			Dialogs::DIALOG_RENAMEUSERERROR,
 			true,
-			"Name Conflict"/*"[NAME_CONFLICT]"*/,
-			"The name you entered is already being used.  Please enter a unique player name"/*"[ENTER_UNIQUE_PLAYER_NAME]"*/,
+			GetString("NAME_CONFLICT", "Name Conflict"),
+			GetString("ENTER_UNIQUE_PLAYER_NAME",
+				"The name you entered is already being used.  Please enter a unique player name."),
 			"[DIALOG_BUTTON_OK]",
 			Dialog::BUTTONS_FOOTER
 		);
@@ -1836,12 +1841,12 @@ void LawnApp::URLOpenFailed(const std::string& theURL)
 	KillDialog(Dialogs::DIALOG_OPENURL_WAIT);
 	CopyToClipboard(theURL);
 
-	std::string aString = 
-		"Please open the following URL in your browser\n\n" + 
-		theURL + 
-		"\n\nFor your convenience, this URL has already been copied to your clipboard.";
+	std::string aString =
+		StrFormat(
+			GetString("OPEN_URL", "Please open the following URL in your browser\n\n%s\n\nFor your convenience, this URL has already been copied to your clipboard.").c_str(),
+			theURL.c_str());
 
-	DoDialog(Dialogs::DIALOG_OPENURL_WAIT, true, "Open Browser", "[DIALOG_BUTTON_OK]", aString, Dialog::BUTTONS_FOOTER);
+	DoDialog(Dialogs::DIALOG_OPENURL_WAIT, true, GetString("OPEN_BROWSER", "Open Browser"), "[DIALOG_BUTTON_OK]", aString, Dialog::BUTTONS_FOOTER);
 }
 
 void LawnApp::URLOpenSucceeded(const std::string& theURL)
@@ -1855,8 +1860,8 @@ bool LawnApp::OpenURL(const std::string& theURL, bool shutdownOnOpen)
 	DoDialog(
 		Dialogs::DIALOG_OPENURL_WAIT, 
 		true, 
-		"Opening Browser", 
-		"Opening Browser", 
+		GetString("OPENING_BROWSER", "Opening Browser"),
+		GetString("OPENING_BROWSER", "Opening Browser"),
 		"", 
 		Dialog::BUTTONS_NONE
 	);
@@ -3044,7 +3049,7 @@ void LawnApp::DrawCrazyDave(Graphics* g)
 		TodDrawStringWrapped(g, aBubbleText, aRect, FONT_BRIANNETOD16, Color::Black, aWrapEnum);
 		if (clickToContinue)
 		{
-			TodDrawString(g, "click to continue", aPosX + 139, aPosY + 140, FONT_PICO129, Color::Black, DrawStringJustification::DS_ALIGN_CENTER);
+			TodDrawString(g, GetString("CLICK_TO_CONTINUE", "click to continue"), aPosX + 139, aPosY + 140, FONT_PICO129, Color::Black, DrawStringJustification::DS_ALIGN_CENTER);
 		}
 	}
 

--- a/src/Sexy.TodLib/TodStringFile.cpp
+++ b/src/Sexy.TodLib/TodStringFile.cpp
@@ -160,7 +160,7 @@ void TodStringListLoad(const char* theFileName)
 
 std::string TodStringListFind(const std::string& theName)
 {
-	std::map<std::string, std::string>::iterator anItr = gSexyAppBase->mStringProperties.find(theName);
+	auto anItr = gSexyAppBase->mStringProperties.find(theName);
 	if (anItr != gSexyAppBase->mStringProperties.end())
 	{
 		return anItr->second;

--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -3065,9 +3065,9 @@ double SexyAppBase::GetDouble(const std::string& theId, double theDefault)
 		return theDefault;
 }
 
-std::string SexyAppBase::GetString(const std::string& theId)
+std::string SexyAppBase::GetString(std::string_view theId)
 {
-	std::map<std::string, std::string>::iterator anItr = mStringProperties.find(theId);
+	auto anItr = mStringProperties.find(theId);
 	DBG_ASSERTE(anItr != mStringProperties.end());
 	
 	if (anItr != mStringProperties.end())	
@@ -3076,14 +3076,14 @@ std::string SexyAppBase::GetString(const std::string& theId)
 		return "";
 }
 
-std::string SexyAppBase::GetString(const std::string& theId, const std::string& theDefault)
+std::string SexyAppBase::GetString(std::string_view theId, std::string_view theDefault)
 {
-	std::map<std::string, std::string>::iterator anItr = mStringProperties.find(theId);
+	auto anItr = mStringProperties.find(theId);
 	
 	if (anItr != mStringProperties.end())	
 		return anItr->second;
 	else
-		return theDefault;	
+		return std::string(theDefault);	
 }
 
 std::vector<std::string> SexyAppBase::GetStringVector(const std::string& theId)
@@ -3099,7 +3099,7 @@ std::vector<std::string> SexyAppBase::GetStringVector(const std::string& theId)
 
 void SexyAppBase::SetString(const std::string& theId, const std::string& theValue)
 {
-	std::pair<std::map<std::string, std::string>::iterator, bool> aPair = mStringProperties.insert(std::map<std::string, std::string>::value_type(theId, theValue));
+	auto aPair = mStringProperties.emplace(theId, theValue);
 	if (!aPair.second) // Found it, change value
 		aPair.first->second = theValue;
 }

--- a/src/SexyAppFramework/SexyAppBase.h
+++ b/src/SexyAppFramework/SexyAppBase.h
@@ -34,6 +34,7 @@
 #include <mutex>
 #include <thread>
 #include <set>
+#include <string_view>
 #include "graphics/SharedImage.h"
 #include "misc/Ratio.h"
 #include <atomic>
@@ -340,7 +341,7 @@ public:
 	bool					mEnableWindowAspect;
 	Ratio					mWindowAspect;
 
-	std::map<std::string, std::string>	mStringProperties;
+	std::map<std::string, std::string, std::less<>>	mStringProperties;
 	StringBoolMap			mBoolProperties;
 	StringIntMap			mIntProperties;
 	StringDoubleMap			mDoubleProperties;
@@ -537,8 +538,8 @@ public:
 	int						GetInteger(const std::string& theId, int theDefault);
 	double					GetDouble(const std::string& theId);
 	double					GetDouble(const std::string& theId, double theDefault);
-	std::string				GetString(const std::string& theId);
-	std::string				GetString(const std::string& theId, const std::string& theDefault);
+	std::string				GetString(std::string_view theId);
+	std::string				GetString(std::string_view theId, std::string_view theDefault);
 
 	std::vector<std::string>	GetStringVector(const std::string& theId);
 


### PR DESCRIPTION
- Fix OK/Cancel/Yes/No dialog button casing to match the original.
- Localize hardcoded English dialog strings so 1.2.0.1096 and non-English editions show localized text, while 1.2.0.1073 shows the exact original literals.

Close #106