### PR TITLE
Fix: correct trophy count font size

### DIFF
--- a/src/Lawn/Widget/ChallengeScreen.cpp
+++ b/src/Lawn/Widget/ChallengeScreen.cpp
@@ -558,7 +558,7 @@ void ChallengeScreen::Draw(Graphics* g)
 	if (aTrophiesTotal > 0)
 	{
 		std::string aTrophyString = StrFormat("%d/%d", aTrophiesGot, aTrophiesTotal);
-		TodDrawString(g, aTrophyString, 739, 73, Sexy::FONT_DWARVENTODCRAFT12, Color(255, 240, 0), DS_ALIGN_CENTER);
+		TodDrawString(g, aTrophyString, 739, 73, Sexy::FONT_DWARVENTODCRAFT15, Color(255, 240, 0), DS_ALIGN_CENTER);
 	}
 	TodDrawImageScaledF(g, Sexy::IMAGE_TROPHY, 718, 26, 0.5f, 0.5f);
 


### PR DESCRIPTION
replace FONT_DWARVENTODCRAFT12 with FONT_DWARVENTODCRAFT15

<img width="527" height="247" alt="image" src="https://github.com/user-attachments/assets/18ee4982-7cb2-46b1-8bca-b095fbd4b9f2" />
