### PR TITLE
Fix: handle UTF-8 by code point in MessageWidget and ChallengeScreen

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -1988,7 +1988,7 @@ void Board::FadeOutLevel()
 	mApp->SetCursor(CURSOR_POINTER);
 }
 
-void Board::DisplayAdvice(const std::string& theAdvice, MessageStyle theMessageStyle, AdviceType theHelpIndex)
+void Board::DisplayAdvice(std::string_view theAdvice, MessageStyle theMessageStyle, AdviceType theHelpIndex)
 {
 	if (theHelpIndex != AdviceType::ADVICE_NONE)
 	{
@@ -2002,7 +2002,7 @@ void Board::DisplayAdvice(const std::string& theAdvice, MessageStyle theMessageS
 	mHelpIndex = theHelpIndex;
 }
 
-void Board::DisplayAdviceAgain(const std::string& theAdvice, MessageStyle theMessageStyle, AdviceType theHelpIndex)
+void Board::DisplayAdviceAgain(std::string_view theAdvice, MessageStyle theMessageStyle, AdviceType theHelpIndex)
 {
 	if (theHelpIndex != AdviceType::ADVICE_NONE)
 	{

--- a/src/Lawn/Board.h
+++ b/src/Lawn/Board.h
@@ -262,7 +262,7 @@ public:
 	/*inline*/ void					SaveGame(const std::string& theFileName);
 	bool							LoadGame(const std::string& theFileName);
 	void							InitLevel();
-	void							DisplayAdvice(const std::string& theAdvice, MessageStyle theMessageStyle, AdviceType theHelpIndex);
+	void							DisplayAdvice(std::string_view theAdvice, MessageStyle theMessageStyle, AdviceType theHelpIndex);
 	void							StartLevel();
 	Plant*							AddPlant(int theGridX, int theGridY, SeedType theSeedType, SeedType theImitaterType = SeedType::SEED_NONE);
 	Projectile*						AddProjectile(int theX, int theY, int theRenderOrder, int theRow, ProjectileType theProjectileType);
@@ -467,7 +467,7 @@ public:
 	void							PuzzleSaveStreak();
 	/*inline*/ void					ClearAdviceImmediately();
 	/*inline*/ bool					IsFinalScaryPotterStage();
-	/*inline*/ void					DisplayAdviceAgain(const std::string& theAdvice, MessageStyle theMessageStyle, AdviceType theHelpIndex);
+	/*inline*/ void					DisplayAdviceAgain(std::string_view theAdvice, MessageStyle theMessageStyle, AdviceType theHelpIndex);
 	GridItem*						GetSquirrelAt(int theGridX, int theGridY);
 	GridItem*						GetZenToolAt(int theGridX, int theGridY);
 	bool							IsPlantInGoldWateringCanRange(int theMouseX, int theMouseY, Plant* thePlant);

--- a/src/Lawn/MessageWidget.cpp
+++ b/src/Lawn/MessageWidget.cpp
@@ -41,6 +41,7 @@ MessageWidget::MessageWidget(LawnApp* theApp)
 	mMessageStyleNext = MessageStyle::MESSAGE_STYLE_OFF;
 	mSlideOffTime = 100;
 	mReanimType = ReanimationType::REANIM_NONE;
+	mTextReanimCount = 0;
 	memset(mTextReanimID, static_cast<int>(ReanimationID::REANIMATIONID_NULL), MAX_MESSAGE_LENGTH);
 }
 
@@ -175,24 +176,33 @@ void MessageWidget::LayoutReanimText()
 	aCurLine = 0;
 	float aCurPosY = 0.0f;
 	float aCurPosX = -aLineWidth[0] * 0.5f;
-	// 以下遍历字幕中的所有文本，分别在适当的位置创建每一个文字的动画
-	for (int aPos = 0; aPos < aLabelLen; aPos++)
+	// Iterate by code point so each reanimated glyph corresponds to one UTF-8 character.
+	int aCharIdx = 0;
+	size_t aBytePos = 0;
+	while (aBytePos < (size_t)aLabelLen)
 	{
-		// 创建文字的动画
+		const size_t aCharStart = aBytePos;
+		char32_t aChar = 0;
+		if (!UTF8DecodeNext(mLabel, aBytePos, aChar))
+			break;
+
 		Reanimation* aReanimText = mApp->AddReanimation(aCurPosX, aCurPosY, 0, mReanimType);
 		aReanimText->mIsAttachment = true;
 		aReanimText->PlayReanim("anim_enter", ReanimLoopType::REANIM_PLAY_ONCE_AND_HOLD, 0.0f, 0.0f);
-		mTextReanimID[aPos] = mApp->ReanimationGetID(aReanimText);
+		mTextReanimID[aCharIdx] = mApp->ReanimationGetID(aReanimText);
+		mTextReanimByteOffset[aCharIdx] = aCharStart;
 
-		aCurPosX += aFont->CharWidth(mLabel[aPos]);  // 坐标调整至下一个文字的位置
-		if (mLabel[aPos] == '\n')  // 换行处理
+		aCurPosX += aFont->CharWidth(aChar);
+		if (aChar == U'\n')
 		{
 			aCurLine++;
 			TOD_ASSERT(aCurLine < MAX_REANIM_LINES);
 			aCurPosX = -aLineWidth[aCurLine] * 0.5f;
 			aCurPosY += aFont->GetLineSpacing();
 		}
+		aCharIdx++;
 	}
+	mTextReanimCount = aCharIdx;
 }
 
 void MessageWidget::Update()
@@ -215,11 +225,10 @@ void MessageWidget::Update()
 		}
 	}
 
-	int aLabelLen = strlen(mLabel);
-	// 以下遍历每个文字的动画，设置其动画速率并更新其动画
-	for (int aPos = 0; aPos < aLabelLen; aPos++)
+	// Iterate reanimated glyphs by code-point index.
+	for (int aCharIdx = 0; aCharIdx < mTextReanimCount; aCharIdx++)
 	{
-		Reanimation* aTextReanim = mApp->ReanimationTryToGet(mTextReanimID[aPos]);
+		Reanimation* aTextReanim = mApp->ReanimationTryToGet(mTextReanimID[aCharIdx]);
 		if (aTextReanim == nullptr)
 		{
 			break;  // 当不存在文本动画时，跳出循环，直接返回
@@ -235,7 +244,7 @@ void MessageWidget::Update()
 			}
 			else
 			{
-				aTextReanim->mAnimRate = TodAnimateCurveFloat(0, 50, (mDisplayTime - mDuration) * aTextSpeed - aPos, 0.0f, 40.0f, TodCurves::CURVE_LINEAR);
+				aTextReanim->mAnimRate = TodAnimateCurveFloat(0, 50, (mDisplayTime - mDuration) * aTextSpeed - aCharIdx, 0.0f, 40.0f, TodCurves::CURVE_LINEAR);
 			}
 		}
 		else
@@ -244,7 +253,7 @@ void MessageWidget::Update()
 			{
 				aTextReanim->PlayReanim("anim_leave", ReanimLoopType::REANIM_PLAY_ONCE_AND_HOLD, 0, 0.0f);
 			}
-			aTextReanim->mAnimRate = TodAnimateCurveFloat(0, 50, (mSlideOffTime - mDuration) * aTextSpeed - aPos, 0.0f, 40.0f, TodCurves::CURVE_LINEAR);
+			aTextReanim->mAnimRate = TodAnimateCurveFloat(0, 50, (mSlideOffTime - mDuration) * aTextSpeed - aCharIdx, 0.0f, 40.0f, TodCurves::CURVE_LINEAR);
 		}
 
 		aTextReanim->Update();  //更新动画
@@ -253,10 +262,9 @@ void MessageWidget::Update()
 
 void MessageWidget::DrawReanimatedText(Graphics* g, _Font* theFont, const Color& theColor, float thePosY)
 {
-	int aLabelLen = strlen(mLabel);
-	for (int aPos = 0; aPos < aLabelLen; aPos++)
+	for (int aCharIdx = 0; aCharIdx < mTextReanimCount; aCharIdx++)
 	{
-		Reanimation* aTextReanim = mApp->ReanimationTryToGet(mTextReanimID[aPos]);
+		Reanimation* aTextReanim = mApp->ReanimationTryToGet(mTextReanimID[aCharIdx]);
 		if (aTextReanim == nullptr)
 		{
 			break;  // 当不存在文本动画时，跳出循环，直接返回
@@ -283,8 +291,9 @@ void MessageWidget::DrawReanimatedText(Graphics* g, _Font* theFont, const Color&
 
 		SexyMatrix3 aMatrix;
 		Reanimation::MatrixFromTransform(aTransform, aMatrix);
-		std::string aLetter;
-		aLetter.append(1, mLabel[aPos]);
+		const int aByteStart = mTextReanimByteOffset[aCharIdx];
+		const int aByteEnd = (aCharIdx + 1 < mTextReanimCount) ? mTextReanimByteOffset[aCharIdx + 1] : strlen(mLabel);
+		std::string aLetter(&mLabel[aByteStart], aByteEnd - aByteStart);
 		TodDrawStringMatrix(g, theFont, aMatrix, aLetter, aFinalColor);
 	}
 }

--- a/src/Lawn/MessageWidget.cpp
+++ b/src/Lawn/MessageWidget.cpp
@@ -71,7 +71,7 @@ void MessageWidget::ClearLabel()
 }
 
 // GOTY @Patoke: inlined 0x459715
-void MessageWidget::SetLabel(const std::string& theNewLabel, MessageStyle theMessageStyle)
+void MessageWidget::SetLabel(std::string_view theNewLabel, MessageStyle theMessageStyle)
 {
 	std::string aLabel = TodStringTranslate(theNewLabel);
 	TOD_ASSERT(aLabel.length() < MAX_MESSAGE_LENGTH - 1);

--- a/src/Lawn/MessageWidget.h
+++ b/src/Lawn/MessageWidget.h
@@ -46,6 +46,8 @@ public:
 	int32_t				mDuration;
 	MessageStyle		mMessageStyle;
 	ReanimationID		mTextReanimID[MAX_MESSAGE_LENGTH];
+	int32_t				mTextReanimByteOffset[MAX_MESSAGE_LENGTH];
+	int32_t				mTextReanimCount;
 	ReanimationType		mReanimType;
 	int32_t				mSlideOffTime;
 	char				mLabelNext[MAX_MESSAGE_LENGTH];

--- a/src/Lawn/MessageWidget.h
+++ b/src/Lawn/MessageWidget.h
@@ -57,7 +57,7 @@ public:
 	MessageWidget(LawnApp* theApp);
 	~MessageWidget() { ClearReanim(); }
 
-	/*inline*/ void		SetLabel(const std::string& theNewLabel, MessageStyle theMessageStyle);
+	/*inline*/ void		SetLabel(std::string_view theNewLabel, MessageStyle theMessageStyle);
 	void				Update();
 	void				Draw(Sexy::Graphics* g);
 	void				ClearReanim();

--- a/src/Lawn/System/DataSync.cpp
+++ b/src/Lawn/System/DataSync.cpp
@@ -542,9 +542,9 @@ void DataWriter::WriteDouble(double theDouble)
 	WriteBytes(&aRaw, sizeof(uint64_t));
 }
 
-void DataWriter::WriteString(const std::string& theStr)
+void DataWriter::WriteString(std::string_view theStr)
 {
 	uint16_t aStrLen = static_cast<uint16_t>(theStr.length());
 	WriteUInt16(aStrLen);
-	WriteBytes(theStr.c_str(), static_cast<uint32_t>(aStrLen));
+	WriteBytes(theStr.data(), static_cast<uint32_t>(aStrLen));
 }

--- a/src/Lawn/System/DataSync.h
+++ b/src/Lawn/System/DataSync.h
@@ -83,7 +83,7 @@ public:
 	void					WriteBool(bool theBool);
 	void					WriteFloat(float theFloat);
 	void					WriteDouble(double theDouble);
-	void					WriteString(const std::string& theStr);
+	void					WriteString(std::string_view theStr);
 	inline uint32_t			GetPos();
 	inline void				SetUInt32(uint32_t, uint32_t) { /* 未找到 */ }
 	inline void				SetUInt16(uint32_t, uint32_t) { /* 未找到 */ }

--- a/src/Lawn/System/TypingCheck.cpp
+++ b/src/Lawn/System/TypingCheck.cpp
@@ -22,12 +22,12 @@
 #include "TypingCheck.h"
 using namespace Sexy;
 
-TypingCheck::TypingCheck(const std::string& thePhrase)
+TypingCheck::TypingCheck(std::string_view thePhrase)
 {
 	SetPhrase(thePhrase);
 }
 
-void TypingCheck::SetPhrase(const std::string& thePhrase)
+void TypingCheck::SetPhrase(std::string_view thePhrase)
 {
 	for (size_t i = 0; i < thePhrase.size(); i++)
 		AddChar(thePhrase[i]);

--- a/src/Lawn/System/TypingCheck.h
+++ b/src/Lawn/System/TypingCheck.h
@@ -33,9 +33,9 @@ protected:
 
 public:
 	TypingCheck() : mPhrase() { }
-	TypingCheck(const std::string& thePhrase);
+	TypingCheck(std::string_view thePhrase);
 
-	void			SetPhrase(const std::string& thePhrase);
+	void			SetPhrase(std::string_view thePhrase);
 	/*inline*/ void	AddKeyCode(Sexy::KeyCode theKeyCode);
 	void			AddChar(char theChar);
 	/*inline*/ bool	Check();

--- a/src/Lawn/ToolTipWidget.cpp
+++ b/src/Lawn/ToolTipWidget.cpp
@@ -156,19 +156,19 @@ void ToolTipWidget::CalculateSize()
 	mHeight = aHeight + aLines.size() * 2 - 2;
 }
 
-void ToolTipWidget::SetLabel(const std::string& theLabel)
+void ToolTipWidget::SetLabel(std::string_view theLabel)
 {
 	mLabel = TodStringTranslate(theLabel);
 	CalculateSize();
 }
 
-void ToolTipWidget::SetTitle(const std::string& theTitle)
+void ToolTipWidget::SetTitle(std::string_view theTitle)
 {
 	mTitle = TodStringTranslate(theTitle);
 	CalculateSize();
 }
 
-void ToolTipWidget::SetWarningText(const std::string& theWarningText)
+void ToolTipWidget::SetWarningText(std::string_view theWarningText)
 {
 	mWarningText = TodStringTranslate(theWarningText);
 	CalculateSize();

--- a/src/Lawn/ToolTipWidget.h
+++ b/src/Lawn/ToolTipWidget.h
@@ -50,9 +50,9 @@ public:
     ToolTipWidget();
 
     void                Draw(Sexy::Graphics* g);
-    void                SetLabel(const std::string& theLabel);
-    void                SetTitle(const std::string& theTitle);
-    void                SetWarningText(const std::string& theWarningText);
+    void                SetLabel(std::string_view theLabel);
+    void                SetTitle(std::string_view theTitle);
+    void                SetWarningText(std::string_view theWarningText);
     void                CalculateSize();
     void                GetLines(std::vector<std::string>& theLines);
     inline void         FlashWarning() { mWarningFlashCounter = 70; }

--- a/src/Lawn/Widget/AwardScreen.cpp
+++ b/src/Lawn/Widget/AwardScreen.cpp
@@ -273,7 +273,7 @@ bool AwardScreen::IsPaperNote()
 	return mApp->IsAdventureMode() && (aLevel == 10 || aLevel == 20 || aLevel == 30 || aLevel == 40 || aLevel == 50);
 }
 
-void AwardScreen::DrawBottom(Graphics* g, const std::string& theTitle, const std::string& theAward, const std::string& theMessage)
+void AwardScreen::DrawBottom(Graphics* g, std::string_view theTitle, std::string_view theAward, std::string_view theMessage)
 {
 	g->DrawImage(Sexy::IMAGE_AWARDSCREEN_BACK, 0, 0);
 	TodDrawString(g, theTitle, BOARD_WIDTH / 2, 58, Sexy::FONT_DWARVENTODCRAFT24, Color(213, 159, 43), DS_ALIGN_CENTER);

--- a/src/Lawn/Widget/AwardScreen.h
+++ b/src/Lawn/Widget/AwardScreen.h
@@ -68,7 +68,7 @@ public:
 
 	/*inline*/ bool		IsPaperNote();
 	void				Resize(int theX, int theY, int theWidth, int theHeight) override { Widget::Resize(theX, theY, theWidth, theHeight); }
-	static void			DrawBottom(Graphics* g, const std::string& theTitle, const std::string& theAward, const std::string& theMessage);
+	static void			DrawBottom(Graphics* g, std::string_view theTitle, std::string_view theAward, std::string_view theMessage);
 	void				DrawAwardSeed(Graphics* g);
 	void				Draw(Graphics* g) override;
 	void				Update() override;

--- a/src/Lawn/Widget/ChallengeScreen.cpp
+++ b/src/Lawn/Widget/ChallengeScreen.cpp
@@ -523,11 +523,11 @@ void ChallengeScreen::DrawButton(Graphics* g, int theChallengeIndex)
 					aLine2Len = 0;
 				}
 
-				TodDrawString(g, aName.substr(0, aLine1Len), aPosX + 52, aPosY + 88, Sexy::FONT_BRIANNETOD12, aTextColor, DS_ALIGN_CENTER);
+				TodDrawString(g, std::string_view(aName).substr(0, aLine1Len), aPosX + 52, aPosY + 88, Sexy::FONT_BRIANNETOD12, aTextColor, DS_ALIGN_CENTER);
 				if (aLine2Len > 0)
 				{
 					const int aLine2Offset = (aName[aSplitBytePos] == ' ') ? aSplitBytePos + 1 : aSplitBytePos;
-					TodDrawString(g, aName.substr(aLine2Offset, aLine2Len), aPosX + 52, aPosY + 102, Sexy::FONT_BRIANNETOD12, aTextColor, DS_ALIGN_CENTER);
+					TodDrawString(g, std::string_view(aName).substr(aLine2Offset, aLine2Len), aPosX + 52, aPosY + 102, Sexy::FONT_BRIANNETOD12, aTextColor, DS_ALIGN_CENTER);
 				}
 			}
 

--- a/src/Lawn/Widget/ChallengeScreen.cpp
+++ b/src/Lawn/Widget/ChallengeScreen.cpp
@@ -462,36 +462,72 @@ void ChallengeScreen::DrawButton(Graphics* g, int theChallengeIndex)
 				aName = "?";
 			}
 
-			int aNameLen = aName.size();
-			int aAutoWrapNum = mApp->GetInteger("CHALLENGE_SCREEN_BUTTON_AUTO_WRAP_NUM", 13);
-			if (aNameLen < aAutoWrapNum)
+			// std::string::size() counts bytes; use the UTF-8 code-point count for the wrap decision.
+			int aNameCharLen = 0;
+			for (size_t aOffset = 0; ; )
+			{
+				char32_t aChar = 0;
+				if (!UTF8DecodeNext(aName, aOffset, aChar))
+					break;
+				aNameCharLen++;
+			}
+
+			const int aAutoWrapNum = mApp->GetInteger("CHALLENGE_SCREEN_BUTTON_AUTO_WRAP_NUM", 13);
+			if (aNameCharLen < aAutoWrapNum)
 			{
 				TodDrawString(g, aName, aPosX + 52, aPosY + 96, Sexy::FONT_BRIANNETOD12, aTextColor, DS_ALIGN_CENTER);
 			}
 			else
 			{
-				// 先尝试在名称字符串的后半段取空格以将字符串分隔为两行，若后半段中无空格则在整个字符串中寻找空格
-				int aHalfPos = (mPageIndex == CHALLENGE_PAGE_SURVIVAL && !aChallengeButton->mDisabled) ? 7 : (aNameLen / 2 - 1);
-				const char* aSpacedChar = strchr(aName.c_str() + aHalfPos, ' ');
-				if (aSpacedChar == nullptr)
+				// Split at a space in the second half, else any space; if none, the whole name stays on one line.
+				const int aHalfPosChar = (mPageIndex == CHALLENGE_PAGE_SURVIVAL && !aChallengeButton->mDisabled) ? 7 : (aNameCharLen / 2 - 1);
+				size_t aSplitBytePos = std::string::npos;
+				size_t aFallbackSpacePos = std::string::npos;
 				{
-					aSpacedChar = strchr(aName.c_str(), ' ');
+					size_t aOffset = 0;
+					char32_t aChar = 0;
+					int aCharIdx = 0;
+					while (true)
+					{
+						const size_t aCharStart = aOffset;
+						if (!UTF8DecodeNext(aName, aOffset, aChar))
+							break;
+						if (aChar == U' ')
+						{
+							if (aCharIdx >= aHalfPosChar)
+							{
+								aSplitBytePos = aCharStart;
+								break;
+							}
+							if (aFallbackSpacePos == std::string::npos)
+								aFallbackSpacePos = aCharStart;
+						}
+						aCharIdx++;
+					}
+					if (aSplitBytePos == std::string::npos)
+						aSplitBytePos = aFallbackSpacePos;
 				}
 
-				// 分别计算取得两行文本的长度
-				int aLine1Len = aNameLen;
-				int aLine2Len = 0;
-				if (aSpacedChar != nullptr)
+				int aLine1Len;
+				int aLine2Len;
+				if (aSplitBytePos != std::string::npos)
 				{
-					aLine1Len = aSpacedChar - aName.c_str();
-					aLine2Len = aNameLen - aLine1Len - 1;
+					aLine1Len = aSplitBytePos;
+					aLine2Len = aName.size() - aSplitBytePos;
+					if (aName[aSplitBytePos] == ' ')
+						aLine2Len--;
+				}
+				else
+				{
+					aLine1Len = aName.size();
+					aLine2Len = 0;
 				}
 
-				// 分别绘制两行文本字符串
 				TodDrawString(g, aName.substr(0, aLine1Len), aPosX + 52, aPosY + 88, Sexy::FONT_BRIANNETOD12, aTextColor, DS_ALIGN_CENTER);
 				if (aLine2Len > 0)
 				{
-					TodDrawString(g, aName.substr(aLine1Len + 1, aLine2Len), aPosX + 52, aPosY + 102, Sexy::FONT_BRIANNETOD12, aTextColor, DS_ALIGN_CENTER);
+					const int aLine2Offset = (aName[aSplitBytePos] == ' ') ? aSplitBytePos + 1 : aSplitBytePos;
+					TodDrawString(g, aName.substr(aLine2Offset, aLine2Len), aPosX + 52, aPosY + 102, Sexy::FONT_BRIANNETOD12, aTextColor, DS_ALIGN_CENTER);
 				}
 			}
 

--- a/src/Lawn/Widget/CreditScreen.cpp
+++ b/src/Lawn/Widget/CreditScreen.cpp
@@ -768,7 +768,7 @@ static int DrawCreditsContent(Graphics* g, int theYPos, bool theDraw)
             if (aRoles.size() > 1)
             {
                 if (theDraw && aYPos > -aLineHeight && aYPos < BOARD_HEIGHT + aLineHeight)
-                    TodDrawString(g, aRoles.substr(1), BOARD_WIDTH / 2, aYPos, aCreditsFont, Color::White, DrawStringJustification::DS_ALIGN_CENTER);
+                    TodDrawString(g, std::string_view(aRoles).substr(1), BOARD_WIDTH / 2, aYPos, aCreditsFont, Color::White, DrawStringJustification::DS_ALIGN_CENTER);
             }
             aYPos += aLineHeight + 10;
             continue;
@@ -788,7 +788,7 @@ static int DrawCreditsContent(Graphics* g, int theYPos, bool theDraw)
                 size_t aRoleEnd = aRoles.find('\n', aRolePos);
                 if (aRoleEnd == std::string::npos) aRoleEnd = aRoles.size();
                 if (aVisible && aRoleEnd > aRolePos)
-                    TodDrawString(g, aRoles.substr(aRolePos, aRoleEnd - aRolePos), ROLES_RIGHT_X, aYPos, aCreditsFont, Color::White, DrawStringJustification::DS_ALIGN_RIGHT);
+                    TodDrawString(g, std::string_view(aRoles).substr(aRolePos, aRoleEnd - aRolePos), ROLES_RIGHT_X, aYPos, aCreditsFont, Color::White, DrawStringJustification::DS_ALIGN_RIGHT);
                 aRolePos = aRoleEnd + 1;
             }
             if (aNamePos < aNames.size())
@@ -796,7 +796,7 @@ static int DrawCreditsContent(Graphics* g, int theYPos, bool theDraw)
                 size_t aNameEnd = aNames.find('\n', aNamePos);
                 if (aNameEnd == std::string::npos) aNameEnd = aNames.size();
                 if (aVisible && aNameEnd > aNamePos)
-                    TodDrawString(g, aNames.substr(aNamePos, aNameEnd - aNamePos), NAMES_LEFT_X, aYPos, aCreditsFont, Color::White, DrawStringJustification::DS_ALIGN_LEFT);
+                    TodDrawString(g, std::string_view(aNames).substr(aNamePos, aNameEnd - aNamePos), NAMES_LEFT_X, aYPos, aCreditsFont, Color::White, DrawStringJustification::DS_ALIGN_LEFT);
                 aNamePos = aNameEnd + 1;
             }
             aYPos += aLineHeight;

--- a/src/Lawn/Widget/GameButton.cpp
+++ b/src/Lawn/Widget/GameButton.cpp
@@ -269,17 +269,17 @@ void GameButton::Update()
 	}
 }
 
-void GameButton::SetLabel(const std::string& theLabel)
+void GameButton::SetLabel(std::string_view theLabel)
 {
 	mLabel = TodStringTranslate(theLabel);
 }
 
-void NewLawnButton::SetLabel(const std::string& theLabel)
+void NewLawnButton::SetLabel(std::string_view theLabel)
 {
 	mLabel = TodStringTranslate(theLabel);
 }
 
-void LawnStoneButton::SetLabel(const std::string& theLabel)
+void LawnStoneButton::SetLabel(std::string_view theLabel)
 {
 	mLabel = TodStringTranslate(theLabel);
 }
@@ -293,7 +293,7 @@ void LawnStoneButton::Draw(Graphics* g)
 	DrawStoneButton(g, 0, 0, mWidth, mHeight, isDown, mIsOver, mLabel);
 }
 
-LawnStoneButton* MakeButton(int theId, ButtonListener* theListener, const std::string& theText)
+LawnStoneButton* MakeButton(int theId, ButtonListener* theListener, std::string_view theText)
 {
 	LawnStoneButton* aButton = new LawnStoneButton(nullptr, theId, theListener);
 	aButton->SetLabel(theText);
@@ -402,7 +402,7 @@ bool NewLawnButton::IsPointVisible(int x, int y)
 }
 
 // GOTY @Patoke: 0x44B810
-NewLawnButton* MakeNewButton(int theId, ButtonListener* theListener, const std::string& theText, _Font* theFont, Image* theImageNormal, Image* theImageOver, Image* theImageDown)
+NewLawnButton* MakeNewButton(int theId, ButtonListener* theListener, std::string_view theText, _Font* theFont, Image* theImageNormal, Image* theImageOver, Image* theImageDown)
 {
 	NewLawnButton* aButton = new NewLawnButton(nullptr, theId, theListener);
 	aButton->SetFont(theFont == nullptr ? Sexy::FONT_BRIANNETOD12 : theFont);

--- a/src/Lawn/Widget/GameButton.h
+++ b/src/Lawn/Widget/GameButton.h
@@ -98,7 +98,7 @@ public:
 	/*inline*/ bool			IsMouseOver();
 	void					Update();
 	/*inline*/ void			Resize(int theX, int theY, int theWidth, int theHeight);
-	/*inline*/ void			SetLabel(const std::string& theLabel);
+	/*inline*/ void			SetLabel(std::string_view theLabel);
 };
 
 class LawnStoneButton : public DialogButton
@@ -107,7 +107,7 @@ public:
 	LawnStoneButton(Image* theComponentImage, int theId, ButtonListener* theListener) : DialogButton(theComponentImage, theId, theListener) { }
 
 	void					Draw(Graphics* g) override;
-	/*inline*/ void			SetLabel(const std::string& theLabel);
+	/*inline*/ void			SetLabel(std::string_view theLabel);
 };
 
 class NewLawnButton : public DialogButton
@@ -127,13 +127,13 @@ public:
 	
     void					Draw(Graphics* g) override;
 	bool					IsPointVisible(int x, int y) override;
-    void					SetLabel(const std::string& theLabel);
+    void					SetLabel(std::string_view theLabel);
 	// @Patoke: user defined
 	void					SetOffset(int theX, int theY);
 };
 
-LawnStoneButton*			MakeButton(int theId, ButtonListener* theListener, const std::string& theText);
-NewLawnButton*				MakeNewButton(int theId, ButtonListener* theListener, const std::string& theText, _Font* theFont, Image* theImageNormal, Image* theImageOver, Image* theImageDown);
+LawnStoneButton*			MakeButton(int theId, ButtonListener* theListener, std::string_view theText);
+NewLawnButton*				MakeNewButton(int theId, ButtonListener* theListener, std::string_view theText, _Font* theFont, Image* theImageNormal, Image* theImageOver, Image* theImageDown);
 void						DrawStoneButton(Graphics* g, int x, int y, int theWidth, int theHeight, bool isDown, bool isHighLighted, const std::string& theLabel);
 
 #endif

--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -2673,7 +2673,7 @@ void LawnApp::CrazyDaveTalkMessage(const std::string& theMessage)
 
 	int aWordsCount = 0;
 	bool isControlWord = false;
-	for (size_t i = 0; i < theMessage.size(); i++)
+	for (size_t i = 0; i < theMessage.size(); i++)  // byte count tracks CJK talk duration better than code points
 	{
 		if (theMessage[i] == '{')
 		{

--- a/src/Sexy.TodLib/Definition.cpp
+++ b/src/Sexy.TodLib/Definition.cpp
@@ -1301,7 +1301,7 @@ bool DefinitionWriteCompiledFile(const std::string& theCompiledFilePath, const D
     return false;
 }
 
-bool DefinitionCompileFile(const std::string theXMLFilePath, const std::string& theCompiledFilePath, const DefMap* theDefMap, void* theDefinition)
+bool DefinitionCompileFile(const std::string& theXMLFilePath, const std::string& theCompiledFilePath, const DefMap* theDefMap, void* theDefinition)
 {
     XMLParser aXMLParser = XMLParser();
     if (!aXMLParser.OpenFile(theXMLFilePath))

--- a/src/Sexy.TodLib/Definition.h
+++ b/src/Sexy.TodLib/Definition.h
@@ -182,7 +182,7 @@ bool                    DefinitionReadImageField(XMLParser* theXmlParser, Image*
 bool                    DefinitionReadFontField(XMLParser* theXmlParser, _Font** theFont);
 bool                    DefinitionReadField(XMLParser* theXmlParser, const DefMap* theDefMap, void* theDefinition, bool* theDone);
 bool                    DefinitionWriteCompiledFile(const std::string& theCompiledFilePath, const DefMap* theDefMap, void* theDefinition);
-bool                    DefinitionCompileFile(const std::string theXMLFilePath, const std::string& theCompiledFilePath, const DefMap* theDefMap, void* theDefinition);
+bool                    DefinitionCompileFile(const std::string& theXMLFilePath, const std::string& theCompiledFilePath, const DefMap* theDefMap, void* theDefinition);
 
 void                    DefMapWriteToCache(void*& theWritePtr, const DefMap* theDefMap, void* theDefinition);
 void                    DefWriteToCacheString(void*& theWritePtr, const char** theValue);

--- a/src/Sexy.TodLib/TodCommon.cpp
+++ b/src/Sexy.TodLib/TodCommon.cpp
@@ -428,7 +428,7 @@ float RandRangeFloat(float theMin, float theMax)
 	return Rand(theMax - theMin) + theMin;
 }
 
-void TodDrawString(Graphics* g, const std::string& theText, int thePosX, int thePosY, _Font* theFont, const Color& theColor, DrawStringJustification theJustification)
+void TodDrawString(Graphics* g, std::string_view theText, int thePosX, int thePosY, _Font* theFont, const Color& theColor, DrawStringJustification theJustification)
 {
 	std::string aFinalString = TodStringTranslate(theText);
 
@@ -462,7 +462,7 @@ static RenderCommand gRenderCommandPool[POOL_SIZE];
 static RenderCommand* gRenderTail[256];
 static RenderCommand* gRenderHead[256];
 
-void TodDrawStringMatrix(Graphics* g, const _Font* theFont, const SexyMatrix3& theMatrix, const std::string& theString, const Color& theColor)
+void TodDrawStringMatrix(Graphics* g, const _Font* theFont, const SexyMatrix3& theMatrix, std::string_view theString, const Color& theColor)
 {
 	std::string aFinalString = TodStringTranslate(theString);
 
@@ -1252,7 +1252,7 @@ void FreeGlobalAllocators()
 	gNumGlobalAllocators = 0;
 }
 
-std::string TodReplaceString(const std::string& theText, const char* theStringToFind, const std::string& theStringToSubstitute)
+std::string TodReplaceString(std::string_view theText, const char* theStringToFind, std::string_view theStringToSubstitute)
 {
 	std::string aFinalString = TodStringTranslate(theText);
 	size_t aPos = aFinalString.find(theStringToFind);
@@ -1265,7 +1265,7 @@ std::string TodReplaceString(const std::string& theText, const char* theStringTo
 	return aFinalString;
 }
 
-std::string TodReplaceNumberString(const std::string& theText, const char* theStringToFind, int theNumber)
+std::string TodReplaceNumberString(std::string_view theText, const char* theStringToFind, int theNumber)
 {
 	std::string aFinalString = TodStringTranslate(theText);
 	size_t aPos = aFinalString.find(theStringToFind);

--- a/src/Sexy.TodLib/TodCommon.h
+++ b/src/Sexy.TodLib/TodCommon.h
@@ -130,8 +130,8 @@ void					SexyMatrix3Inverse(const SexyMatrix3& m, SexyMatrix3& r);  // r = m ^ -
 void					SexyMatrix3Multiply(SexyMatrix3& m, const SexyMatrix3& l, const SexyMatrix3& r);  // m = l × r
 bool					TodIsPointInPolygon(const SexyVector2* thePolygonPoint, int theNumberPolygonPoints, const SexyVector2& theCheckPoint);
 
-void					TodDrawString(Graphics* g, const std::string& theText, int thePosX, int thePosY, _Font* theFont, const Color& theColor, DrawStringJustification theJustification);
-void					TodDrawStringMatrix(Graphics* g, const _Font* theFont, const SexyMatrix3& theMatrix, const std::string& theString, const Color& theColor);
+void					TodDrawString(Graphics* g, std::string_view theText, int thePosX, int thePosY, _Font* theFont, const Color& theColor, DrawStringJustification theJustification);
+void					TodDrawStringMatrix(Graphics* g, const _Font* theFont, const SexyMatrix3& theMatrix, std::string_view theString, const Color& theColor);
 void					TodDrawImageScaledF(Graphics* g, Image* theImage, float thePosX, float thePosY, float theScaleX, float theScaleY);
 void					TodDrawImageCenterScaledF(Graphics* g, Image* theImage, float thePosX, float thePosY, float theScaleX, float theScaleY);
 void					TodDrawImageCelF(Graphics* g, Image* theImageStrip, float thePosX, float thePosY, int theCelCol, int theCelRow);
@@ -145,8 +145,8 @@ void					FixPixelsOnAlphaEdgeForBlending(Image* theImage);
 uint32_t				AverageNearByPixels(MemoryImage* theImage, uint32_t* thePixel, int x, int y);
 void					Tod_SWTri_AddAllDrawTriFuncs();
 
-std::string				TodReplaceString(const std::string& theText, const char* theStringToFind, const std::string& theStringToSubstitute);
-std::string				TodReplaceNumberString(const std::string& theText, const char* theStringToFind, int theNumber);
+std::string				TodReplaceString(std::string_view theText, const char* theStringToFind, std::string_view theStringToSubstitute);
+std::string				TodReplaceNumberString(std::string_view theText, const char* theStringToFind, int theNumber);
 int						TodSnprintf(char* theBuffer, int theSize, const char* theFormat, ...);
 int						TodVsnprintf(char* theBuffer, int theSize, const char* theFormat, va_list theArgList);
 

--- a/src/Sexy.TodLib/TodStringFile.cpp
+++ b/src/Sexy.TodLib/TodStringFile.cpp
@@ -496,7 +496,7 @@ int TodDrawStringWrappedHelper(Graphics* g, const std::string& theText, const Re
 }
 
 // GOTY @Patoke: 0x5246A0
-void TodDrawStringWrapped(Graphics* g, const std::string& theText, const Rect& theRect, _Font* theFont, const Color& theColor, DrawStringJustification theJustification)
+void TodDrawStringWrapped(Graphics* g, std::string_view theText, const Rect& theRect, _Font* theFont, const Color& theColor, DrawStringJustification theJustification)
 {
 	std::string aTextFinal = TodStringTranslate(theText);
 	Rect aRectTodUse = theRect;

--- a/src/Sexy.TodLib/TodStringFile.cpp
+++ b/src/Sexy.TodLib/TodStringFile.cpp
@@ -158,7 +158,7 @@ void TodStringListLoad(const char* theFileName)
 		TodErrorMessageBox(Sexy::StrFormat("Failed to load string list file '%s'", theFileName).c_str(), "Error");
 }
 
-std::string TodStringListFind(const std::string& theName)
+std::string TodStringListFind(std::string_view theName)
 {
 	auto anItr = gSexyAppBase->mStringProperties.find(theName);
 	if (anItr != gSexyAppBase->mStringProperties.end())
@@ -167,19 +167,19 @@ std::string TodStringListFind(const std::string& theName)
 	}
 	else
 	{
-		return Sexy::StrFormat("<Missing %s>", theName.c_str());
+		return Sexy::StrFormat("<Missing %s>", std::string(theName).c_str());
 	}
 }
 
 // GOTY @Patoke: 0x523B90
-std::string TodStringTranslate(const std::string& theString)
+std::string TodStringTranslate(std::string_view theString)
 {
 	if (theString.size() >= 3 && theString[0] == '[')
 	{
-		std::string aName = theString.substr(1, theString.size() - 2);  // 取“[”与“]”中间的部分
+		std::string_view aName = theString.substr(1, theString.size() - 2);  // 取"["与"]"中间的部分
 		return TodStringListFind(aName);
 	}
-	return theString;
+	return std::string(theString);
 }
 
 std::string TodStringTranslate(const char* theString)
@@ -199,11 +199,11 @@ std::string TodStringTranslate(const char* theString)
 		return "";
 }
 
-bool TodStringListExists(const std::string& theString)
+bool TodStringListExists(std::string_view theString)
 {
 	if (theString.size() >= 3 && theString[0] == '[')
 	{
-		std::string aName = theString.substr(1, theString.size() - 2);  // 取“[”与“]”中间的部分
+		std::string_view aName = theString.substr(1, theString.size() - 2);  // 取"["与"]"中间的部分
 		return gSexyAppBase->mStringProperties.find(aName) != gSexyAppBase->mStringProperties.end();
 	}
 	return false;

--- a/src/Sexy.TodLib/TodStringFile.h
+++ b/src/Sexy.TodLib/TodStringFile.h
@@ -68,6 +68,6 @@ bool                CharIsSpaceInFormat(char theChar, const TodStringListFormat&
 int                 TodWriteString(Graphics* g, const std::string& theString, int theX, int theY, TodStringListFormat& theCurrentFormat, int theWidth, DrawStringJustification theJustification, bool drawString, int theOffset, int theLength);
 /*inline*/ int      TodWriteWordWrappedHelper(Graphics* g, const std::string& theString, int theX, int theY, TodStringListFormat& theCurrentFormat, int theWidth, DrawStringJustification theJustification, bool drawString, int theOffset, int theLength, int theMaxChars);
 int                 TodDrawStringWrappedHelper(Graphics* g, const std::string& theText, const Rect& theRect, _Font* theFont, const Color& theColor, DrawStringJustification theJustification, bool drawString);
-/*inline*/ void		TodDrawStringWrapped(Graphics* g, const std::string& theText, const Rect& theRect, _Font* theFont, const Color& theColor, DrawStringJustification theJustification);
+/*inline*/ void		TodDrawStringWrapped(Graphics* g, std::string_view theText, const Rect& theRect, _Font* theFont, const Color& theColor, DrawStringJustification theJustification);
 
 #endif  //__TODSTRINGFILE_H__

--- a/src/Sexy.TodLib/TodStringFile.h
+++ b/src/Sexy.TodLib/TodStringFile.h
@@ -59,10 +59,10 @@ bool                TodStringListReadValue(const char*& thePtr, std::string& the
 bool                TodStringListReadItems(const char* theFileText);
 bool                TodStringListReadFile(const char* theFileName);
 void                TodStringListLoad(const char* theFileName);
-std::string          TodStringListFind(const std::string& theName);
-std::string			TodStringTranslate(const std::string& theString);
+std::string         TodStringListFind(std::string_view theName);
+std::string			TodStringTranslate(std::string_view theString);
 std::string			TodStringTranslate(const char* theString);
-bool                TodStringListExists(const std::string& theString);
+bool                TodStringListExists(std::string_view theString);
 void                TodStringRemoveReturnChars(std::string& theString);
 bool                CharIsSpaceInFormat(char theChar, const TodStringListFormat& theCurrentFormat);
 int                 TodWriteString(Graphics* g, const std::string& theString, int theX, int theY, TodStringListFormat& theCurrentFormat, int theWidth, DrawStringJustification theJustification, bool drawString, int theOffset, int theLength);

--- a/src/SexyAppFramework/Common.cpp
+++ b/src/SexyAppFramework/Common.cpp
@@ -104,7 +104,7 @@ void Sexy::SetAppDataFolder(const std::string& thePath)
 	Sexy::gAppDataFolder = PathFromU8(thePath);
 }
 
-std::string Sexy::GetAppDataPath(const std::string& theRelativePath)
+std::string Sexy::GetAppDataPath(std::string_view theRelativePath)
 {
 	return PathToU8(Sexy::gAppDataFolder / PathFromU8(theRelativePath));
 }
@@ -120,7 +120,7 @@ void Sexy::SetResourceFolder(const std::string& thePath)
 	Sexy::gResourceFolderStr = PathToU8(Sexy::gResourceFolder);
 }
 
-std::string Sexy::GetResourcePath(const std::string& theRelativePath)
+std::string Sexy::GetResourcePath(std::string_view theRelativePath)
 {
 	return PathToU8(Sexy::gResourceFolder / PathFromU8(theRelativePath));
 }
@@ -232,12 +232,12 @@ std::string Sexy::GetCurDir()
 	return PathToU8(cur);
 }
 
-std::string Sexy::GetFullPath(const std::string& theRelPath)
+std::string Sexy::GetFullPath(std::string_view theRelPath)
 {
 	return GetPathFrom(theRelPath, GetCurDir());
 }
 
-std::string Sexy::GetPathFrom(const std::string& theRelPath, const std::string& theDir)
+std::string Sexy::GetPathFrom(std::string_view theRelPath, std::string_view theDir)
 {
 	std::filesystem::path relPath = PathFromU8(theRelPath);
 	if (IsPathRooted(theRelPath))
@@ -293,7 +293,7 @@ bool Sexy::AllowAllAccess(const std::string& theFileName)
 	return false;
 }
 
-bool Sexy::Deltree(const std::string& thePath)
+bool Sexy::Deltree(std::string_view thePath)
 {
 	std::error_code ec;
 	std::filesystem::path path = PathFromU8(thePath);
@@ -304,19 +304,19 @@ bool Sexy::Deltree(const std::string& thePath)
 	return !ec;
 }
 
-bool Sexy::FileExists(const std::string& theFileName)
+bool Sexy::FileExists(std::string_view theFileName)
 {
 	std::error_code ec;
 	return std::filesystem::exists(PathFromU8(theFileName), ec);
 }
 
-void Sexy::MkDir(const std::string& theDir)
+void Sexy::MkDir(std::string_view theDir)
 {
 	std::error_code ec;
 	std::filesystem::create_directories(PathFromU8(theDir), ec);
 }
 
-std::string Sexy::GetFileName(const std::string& thePath, bool noExtension)
+std::string Sexy::GetFileName(std::string_view thePath, bool noExtension)
 {
 	std::filesystem::path path = PathFromU8(thePath);
 	if (!path.has_filename())
@@ -328,7 +328,7 @@ std::string Sexy::GetFileName(const std::string& thePath, bool noExtension)
 	return PathToU8(path.filename());
 }
 
-std::string Sexy::GetFileDir(const std::string& thePath, bool withSlash)
+std::string Sexy::GetFileDir(std::string_view thePath, bool withSlash)
 {
 	std::filesystem::path path = PathFromU8(thePath);
 	std::filesystem::path parent = path.parent_path();
@@ -342,10 +342,10 @@ std::string Sexy::GetFileDir(const std::string& thePath, bool withSlash)
 	return result;
 }
 
-std::string Sexy::RemoveTrailingSlash(const std::string& theDirectory)
+std::string Sexy::RemoveTrailingSlash(std::string_view theDirectory)
 {
 	if (theDirectory.empty())
-		return theDirectory;
+		return std::string(theDirectory);
 
 	return PathToU8(PathFromU8(theDirectory).lexically_normal());
 }

--- a/src/SexyAppFramework/Common.cpp
+++ b/src/SexyAppFramework/Common.cpp
@@ -99,7 +99,7 @@ std::string Sexy::GetAppDataFolder()
 	return PathToU8(Sexy::gAppDataFolder);
 }
 
-void Sexy::SetAppDataFolder(const std::string& thePath)
+void Sexy::SetAppDataFolder(std::string_view thePath)
 {
 	Sexy::gAppDataFolder = PathFromU8(thePath);
 }
@@ -114,7 +114,7 @@ const std::string& Sexy::GetResourceFolder()
 	return Sexy::gResourceFolderStr;
 }
 
-void Sexy::SetResourceFolder(const std::string& thePath)
+void Sexy::SetResourceFolder(std::string_view thePath)
 {
 	Sexy::gResourceFolder = PathFromU8(thePath);
 	Sexy::gResourceFolderStr = PathToU8(Sexy::gResourceFolder);
@@ -125,26 +125,26 @@ std::string Sexy::GetResourcePath(std::string_view theRelativePath)
 	return PathToU8(Sexy::gResourceFolder / PathFromU8(theRelativePath));
 }
 
-std::string Sexy::StringToUpper(const std::string& theString)
+std::string Sexy::StringToUpper(std::string_view theString)
 {
-	std::string aString = theString;
+	std::string aString(theString);
 	std::transform(aString.begin(), aString.end(), aString.begin(),
 		[](unsigned char c) { return (char)std::toupper(c); });
 	return aString;
 }
 
-std::string Sexy::StringToLower(const std::string& theString)
+std::string Sexy::StringToLower(std::string_view theString)
 {
-	std::string aString = theString;
+	std::string aString(theString);
 	std::transform(aString.begin(), aString.end(), aString.begin(),
 		[](unsigned char c) { return (char)std::tolower(c); });
 	return aString;
 }
 
-std::string Sexy::Trim(const std::string& theString)
+std::string Sexy::Trim(std::string_view theString)
 {
 	if (theString.empty())
-		return theString;
+		return std::string(theString);
 
 	size_t start = 0;
 	while (start < theString.size() && std::isspace((unsigned char)theString[start]))
@@ -157,7 +157,7 @@ std::string Sexy::Trim(const std::string& theString)
 	while (end > start && std::isspace((unsigned char)theString[end]))
 		--end;
 
-	return theString.substr(start, end - start + 1);
+	return std::string(theString.substr(start, end - start + 1));
 }
 
 bool Sexy::StringToInt(const std::string& theString, int* theIntVal)
@@ -288,7 +288,7 @@ bool Sexy::IsPathRooted(std::string_view thePath)
 	return false;
 }
 
-bool Sexy::AllowAllAccess(const std::string& theFileName)
+bool Sexy::AllowAllAccess(std::string_view theFileName)
 {
 	return false;
 }
@@ -392,9 +392,9 @@ std::string Sexy::StrFormat(const char* fmt ...)
     return result;
 }
 
-std::string Sexy::Evaluate(const std::string& theString, const DefinesMap& theDefinesMap)
+std::string Sexy::Evaluate(std::string_view theString, const DefinesMap& theDefinesMap)
 {
-	std::string anEvaluatedString = theString;
+	std::string anEvaluatedString(theString);
 
 	for (;;)
 	{
@@ -422,13 +422,13 @@ std::string Sexy::Evaluate(const std::string& theString, const DefinesMap& theDe
 	return anEvaluatedString;
 }
 
-std::string Sexy::XMLDecodeString(const std::string& theString)
+std::string Sexy::XMLDecodeString(std::string_view theString)
 {
 	std::string aNewString;
 	aNewString.reserve(theString.size());
 
 	if (theString.find('&') == std::string::npos)
-		return theString;
+		return std::string(theString);
 
 	for (size_t i = 0; i < theString.length(); i++)
 	{
@@ -440,7 +440,7 @@ std::string Sexy::XMLDecodeString(const std::string& theString)
 
 			if (aSemiPos != std::string::npos)
 			{
-				std::string anEntName = theString.substr(i+1, aSemiPos-i-1);
+				std::string anEntName(theString.substr(i+1, aSemiPos-i-1));
 				i = aSemiPos;
 											
 				if (anEntName == "lt")
@@ -466,7 +466,7 @@ std::string Sexy::XMLDecodeString(const std::string& theString)
 	return aNewString;
 }
 
-std::string Sexy::XMLEncodeString(const std::string& theString)
+std::string Sexy::XMLEncodeString(std::string_view theString)
 {
 	std::string aNewString;
 	aNewString.reserve(theString.size() * 2);
@@ -519,12 +519,12 @@ std::string Sexy::XMLEncodeString(const std::string& theString)
 	return aNewString;
 }
 
-std::string Sexy::Upper(const std::string& _data)
+std::string Sexy::Upper(std::string_view _data)
 {
 	return StringToUpper(_data);
 }
 
-std::string Sexy::Lower(const std::string& _data)
+std::string Sexy::Lower(std::string_view _data)
 {
 	return StringToLower(_data);
 }
@@ -599,9 +599,9 @@ void Sexy::SMemW(void*& _Dst, const void* _Src, size_t _Size)
 	_Dst = (void*)((uintptr_t)_Dst + _Size);
 }
 
-void Sexy::SMemWStr(void*& _Dst, const std::string& theString)
+void Sexy::SMemWStr(void*& _Dst, std::string_view theString)
 {
 	size_t aStrLen = theString.size();
 	SMemW(_Dst, &aStrLen, sizeof(aStrLen));
-	SMemW(_Dst, theString.c_str(), aStrLen);
+	SMemW(_Dst, theString.data(), aStrLen);
 }

--- a/src/SexyAppFramework/Common.h
+++ b/src/SexyAppFramework/Common.h
@@ -134,10 +134,10 @@ extern std::string	VFormat(const char* fmt, va_list argPtr);
 extern std::string	StrFormat(const char* fmt ...);
 std::string			GetAppDataFolder();
 void				SetAppDataFolder(const std::string& thePath);
-std::string			GetAppDataPath(const std::string& theRelativePath);
+std::string			GetAppDataPath(std::string_view theRelativePath);
 const std::string&	GetResourceFolder();
 void				SetResourceFolder(const std::string& thePath);
-std::string			GetResourcePath(const std::string& theRelativePath);
+std::string			GetResourcePath(std::string_view theRelativePath);
 std::string			StringToUpper(const std::string& theString);
 std::string			StringToLower(const std::string& theString);
 std::string			Upper(const std::string& theData);
@@ -152,15 +152,15 @@ std::string			Evaluate(const std::string& theString, const DefinesMap& theDefine
 std::string			XMLDecodeString(const std::string& theString);
 std::string			XMLEncodeString(const std::string& theString);
 
-bool				Deltree(const std::string& thePath);
-bool				FileExists(const std::string& theFileName);
-void				MkDir(const std::string& theDir);
-std::string			GetFileName(const std::string& thePath, bool noExtension = false);
-std::string			GetFileDir(const std::string& thePath, bool withSlash = false);
-std::string			RemoveTrailingSlash(const std::string& theDirectory);
+bool				Deltree(std::string_view thePath);
+bool				FileExists(std::string_view theFileName);
+void				MkDir(std::string_view theDir);
+std::string			GetFileName(std::string_view thePath, bool noExtension = false);
+std::string			GetFileDir(std::string_view thePath, bool withSlash = false);
+std::string			RemoveTrailingSlash(std::string_view theDirectory);
 std::string			GetCurDir();
-std::string			GetFullPath(const std::string& theRelPath);
-std::string			GetPathFrom(const std::string& theRelPath, const std::string& theDir);
+std::string			GetFullPath(std::string_view theRelPath);
+std::string			GetPathFrom(std::string_view theRelPath, std::string_view theDir);
 bool				IsPathRooted(std::string_view thePath);
 bool				AllowAllAccess(const std::string& theFileName);
 
@@ -171,17 +171,17 @@ void				SMemRStr(void*& _Src, std::string& theString);
 void				SMemW(void*& _Dst, const void* _Src, size_t _Size);
 void				SMemWStr(void*& _Dst, const std::string& theString);
 
-inline void			inlineLTrim(std::string &theData, const std::string& theChars = " \t\r\n")
+inline void			inlineLTrim(std::string &theData, std::string_view theChars = " \t\r\n")
 {
     theData.erase(0, theData.find_first_not_of(theChars));
 }
 
-inline void			inlineRTrim(std::string &theData, const std::string& theChars = " \t\r\n")
+inline void			inlineRTrim(std::string &theData, std::string_view theChars = " \t\r\n")
 {
     theData.resize(theData.find_last_not_of(theChars) + 1);
 }
 
-inline void			inlineTrim(std::string &theData, const std::string& theChars = " \t\r\n")
+inline void			inlineTrim(std::string &theData, std::string_view theChars = " \t\r\n")
 {
 	inlineRTrim(theData, theChars);
 	inlineLTrim(theData, theChars);

--- a/src/SexyAppFramework/Common.h
+++ b/src/SexyAppFramework/Common.h
@@ -188,7 +188,7 @@ inline void			inlineTrim(std::string &theData, const std::string& theChars = " \
 }
 
 // Decode next UTF-8 codepoint, advancing theOffset. Returns false on end/error.
-inline bool UTF8DecodeNext(const std::string& theString, size_t& theOffset, char32_t& theOutChar)
+inline bool UTF8DecodeNext(std::string_view theString, size_t& theOffset, char32_t& theOutChar)
 {
 	if (theOffset >= theString.size())
 		return false;

--- a/src/SexyAppFramework/Common.h
+++ b/src/SexyAppFramework/Common.h
@@ -133,24 +133,24 @@ void				SRand(ulong theSeed);
 extern std::string	VFormat(const char* fmt, va_list argPtr);
 extern std::string	StrFormat(const char* fmt ...);
 std::string			GetAppDataFolder();
-void				SetAppDataFolder(const std::string& thePath);
+void				SetAppDataFolder(std::string_view thePath);
 std::string			GetAppDataPath(std::string_view theRelativePath);
 const std::string&	GetResourceFolder();
-void				SetResourceFolder(const std::string& thePath);
+void				SetResourceFolder(std::string_view thePath);
 std::string			GetResourcePath(std::string_view theRelativePath);
-std::string			StringToUpper(const std::string& theString);
-std::string			StringToLower(const std::string& theString);
-std::string			Upper(const std::string& theData);
-std::string			Lower(const std::string& theData);
-std::string			Trim(const std::string& theString);
+std::string			StringToUpper(std::string_view theString);
+std::string			StringToLower(std::string_view theString);
+std::string			Upper(std::string_view theData);
+std::string			Lower(std::string_view theData);
+std::string			Trim(std::string_view theString);
 bool				StringToInt(const std::string& theString, int* theIntVal);
 bool				StringToDouble(const std::string& theString, double* theDoubleVal);
 int					StrFindNoCase(const char *theStr, const char *theFind);
 bool				StrPrefixNoCase(const char *theStr, const char *thePrefix, int maxLength = 10000000);
 std::string			CommaSeperate(int theValue);
-std::string			Evaluate(const std::string& theString, const DefinesMap& theDefinesMap);
-std::string			XMLDecodeString(const std::string& theString);
-std::string			XMLEncodeString(const std::string& theString);
+std::string			Evaluate(std::string_view theString, const DefinesMap& theDefinesMap);
+std::string			XMLDecodeString(std::string_view theString);
+std::string			XMLEncodeString(std::string_view theString);
 
 bool				Deltree(std::string_view thePath);
 bool				FileExists(std::string_view theFileName);
@@ -162,14 +162,14 @@ std::string			GetCurDir();
 std::string			GetFullPath(std::string_view theRelPath);
 std::string			GetPathFrom(std::string_view theRelPath, std::string_view theDir);
 bool				IsPathRooted(std::string_view thePath);
-bool				AllowAllAccess(const std::string& theFileName);
+bool				AllowAllAccess(std::string_view theFileName);
 
 // Read memory and then move the pointer
 void				SMemR(void*& _Src, void* _Dst, size_t _Size);
 void				SMemRStr(void*& _Src, std::string& theString);
 // Write memory and then move the pointer
 void				SMemW(void*& _Dst, const void* _Src, size_t _Size);
-void				SMemWStr(void*& _Dst, const std::string& theString);
+void				SMemWStr(void*& _Dst, std::string_view theString);
 
 inline void			inlineLTrim(std::string &theData, std::string_view theChars = " \t\r\n")
 {

--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -3002,64 +3002,64 @@ void SexyAppBase::ShowResourceError(bool doExit)
 		DoExit(0);
 }
 
-bool SexyAppBase::GetBoolean(const std::string& theId)
+bool SexyAppBase::GetBoolean(std::string_view theId)
 {
 	StringBoolMap::iterator anItr = mBoolProperties.find(theId);
 	DBG_ASSERTE(anItr != mBoolProperties.end());
-	
-	if (anItr != mBoolProperties.end())	
+
+	if (anItr != mBoolProperties.end())
 		return anItr->second;
 	else
 		return false;
 }
 
-bool SexyAppBase::GetBoolean(const std::string& theId, bool theDefault)
+bool SexyAppBase::GetBoolean(std::string_view theId, bool theDefault)
 {
-	StringBoolMap::iterator anItr = mBoolProperties.find(theId);	
-	
-	if (anItr != mBoolProperties.end())	
+	StringBoolMap::iterator anItr = mBoolProperties.find(theId);
+
+	if (anItr != mBoolProperties.end())
 		return anItr->second;
 	else
-		return theDefault;	
+		return theDefault;
 }
 
-int SexyAppBase::GetInteger(const std::string& theId)
+int SexyAppBase::GetInteger(std::string_view theId)
 {
 	StringIntMap::iterator anItr = mIntProperties.find(theId);
 	DBG_ASSERTE(anItr != mIntProperties.end());
-	
-	if (anItr != mIntProperties.end())	
+
+	if (anItr != mIntProperties.end())
 		return anItr->second;
 	else
 		return false;
 }
 
-int SexyAppBase::GetInteger(const std::string& theId, int theDefault)
+int SexyAppBase::GetInteger(std::string_view theId, int theDefault)
 {
-	StringIntMap::iterator anItr = mIntProperties.find(theId);	
-	
-	if (anItr != mIntProperties.end())	
+	StringIntMap::iterator anItr = mIntProperties.find(theId);
+
+	if (anItr != mIntProperties.end())
 		return anItr->second;
 	else
-		return theDefault;	
+		return theDefault;
 }
 
-double SexyAppBase::GetDouble(const std::string& theId)
+double SexyAppBase::GetDouble(std::string_view theId)
 {
 	StringDoubleMap::iterator anItr = mDoubleProperties.find(theId);
 	DBG_ASSERTE(anItr != mDoubleProperties.end());
-	
+
 	if (anItr != mDoubleProperties.end())
 		return anItr->second;
 	else
 		return false;
 }
 
-double SexyAppBase::GetDouble(const std::string& theId, double theDefault)
+double SexyAppBase::GetDouble(std::string_view theId, double theDefault)
 {
-	StringDoubleMap::iterator anItr = mDoubleProperties.find(theId);	
-	
-	if (anItr != mDoubleProperties.end())	
+	StringDoubleMap::iterator anItr = mDoubleProperties.find(theId);
+
+	if (anItr != mDoubleProperties.end())
 		return anItr->second;
 	else
 		return theDefault;
@@ -3086,7 +3086,7 @@ std::string SexyAppBase::GetString(std::string_view theId, std::string_view theD
 		return std::string(theDefault);	
 }
 
-std::vector<std::string> SexyAppBase::GetStringVector(const std::string& theId)
+std::vector<std::string> SexyAppBase::GetStringVector(std::string_view theId)
 {
 	StringStringVectorMap::iterator anItr = mStringVectorProperties.find(theId);
 	DBG_ASSERTE(anItr != mStringVectorProperties.end());

--- a/src/SexyAppFramework/SexyAppBase.h
+++ b/src/SexyAppFramework/SexyAppBase.h
@@ -77,10 +77,10 @@ typedef std::list<Dialog*> DialogList;
 //typedef std::list<MSG> WindowsMessageList;
 //typedef std::basic_string<TCHAR> tstring; // string of TCHARs
 
-typedef std::map<std::string, bool> StringBoolMap;
-typedef std::map<std::string, int> StringIntMap;
-typedef std::map<std::string, double> StringDoubleMap;
-typedef std::map<std::string, std::vector<std::string>> StringStringVectorMap;
+typedef std::map<std::string, bool, std::less<>> StringBoolMap;
+typedef std::map<std::string, int, std::less<>> StringIntMap;
+typedef std::map<std::string, double, std::less<>> StringDoubleMap;
+typedef std::map<std::string, std::vector<std::string>, std::less<>> StringStringVectorMap;
 
 enum
 {
@@ -532,16 +532,16 @@ public:
 	void					LoadResourceManifest();
 	void					ShowResourceError(bool doExit = false);
 	
-	bool					GetBoolean(const std::string& theId);
-	bool					GetBoolean(const std::string& theId, bool theDefault);	
-	int						GetInteger(const std::string& theId);
-	int						GetInteger(const std::string& theId, int theDefault);
-	double					GetDouble(const std::string& theId);
-	double					GetDouble(const std::string& theId, double theDefault);
+	bool					GetBoolean(std::string_view theId);
+	bool					GetBoolean(std::string_view theId, bool theDefault);
+	int						GetInteger(std::string_view theId);
+	int						GetInteger(std::string_view theId, int theDefault);
+	double					GetDouble(std::string_view theId);
+	double					GetDouble(std::string_view theId, double theDefault);
 	std::string				GetString(std::string_view theId);
 	std::string				GetString(std::string_view theId, std::string_view theDefault);
 
-	std::vector<std::string>	GetStringVector(const std::string& theId);
+	std::vector<std::string>	GetStringVector(std::string_view theId);
 
 	void					SetBoolean(const std::string& theId, bool theValue);
 	void					SetInteger(const std::string& theId, int theValue);

--- a/src/SexyAppFramework/graphics/Font.h
+++ b/src/SexyAppFramework/graphics/Font.h
@@ -53,11 +53,11 @@ public:
 	virtual int				GetHeight();
 	virtual int				GetLineSpacingOffset();
 	virtual int				GetLineSpacing();
-	virtual int				StringWidth(const std::string& theString) = 0;
+	virtual int				StringWidth(std::string_view theString) = 0;
 	virtual int				CharWidth(char32_t theChar) = 0;
 	virtual int				CharWidthKern(char32_t theChar, char32_t thePrevChar) = 0;
 
-	virtual void			DrawString(Graphics* g, int theX, int theY, const std::string& theString, const Color& theColor, const Rect& theClipRect) = 0;
+	virtual void			DrawString(Graphics* g, int theX, int theY, std::string_view theString, const Color& theColor, const Rect& theClipRect) = 0;
 
 	virtual _Font*			Duplicate() = 0;
 };

--- a/src/SexyAppFramework/graphics/Graphics.cpp
+++ b/src/SexyAppFramework/graphics/Graphics.cpp
@@ -664,7 +664,7 @@ void Graphics::DrawLineAA(int theStartX, int theStartY, int theEndX, int theEndY
 	mDestImage->DrawLineAA(aStartX, aStartY, aEndX, aEndY, mColor, mDrawMode);
 }
 
-void Graphics::DrawString(const std::string& theString, int theX, int theY)
+void Graphics::DrawString(std::string_view theString, int theX, int theY)
 {
 	if (mFont != nullptr)
 		mFont->DrawString(this, theX, theY, theString, mColor, mClipRect);
@@ -1003,7 +1003,7 @@ void Graphics::SetScale(float theScaleX, float theScaleY, float theOrigX, float 
 	mScaleOrigY = theOrigY + mTransY;
 }
 
-int Graphics::StringWidth(const std::string& theString)
+int Graphics::StringWidth(std::string_view theString)
 {
 	return mFont->StringWidth(theString);
 }
@@ -1097,7 +1097,7 @@ void Graphics::DrawImageCel(Image* theImageStrip, const Rect& theDestRect, int t
 	DrawImage(theImageStrip,theDestRect,aSrcRect);
 }
 
-int Graphics::WriteString(const std::string& theString, int theX, int theY, int theWidth, int theJustification, bool drawString, int theOffset, int theLength, int theOldColor)
+int Graphics::WriteString(std::string_view theString, int theX, int theY, int theWidth, int theJustification, bool drawString, int theOffset, int theLength, int theOldColor)
 {
 	// _Font* aFont = GetFont(); // unused
 	if (theOldColor==-1)
@@ -1141,7 +1141,7 @@ int Graphics::WriteString(const std::string& theString, int theX, int theY, int 
 				uint32_t aColor = 0;
 				if (theString[i+1]=='o')
 				{
-					if (strncmp(theString.c_str()+i+1, "oldclr", 6) == 0)
+					if (theString.compare(i+1, 6, "oldclr") == 0)
 						aColor = theOldColor;
 				}
 				else
@@ -1189,7 +1189,7 @@ int Graphics::WriteString(const std::string& theString, int theX, int theY, int 
 	return aXOffset;
 }
 
-static int WriteWordWrappedHelper(Graphics *g, const std::string& theString, int theX, int theY, int theWidth, int theJustification, bool drawString, int theOffset, int theLength, int theOldColor, int theMaxChars)
+static int WriteWordWrappedHelper(Graphics *g, std::string_view theString, int theX, int theY, int theWidth, int theJustification, bool drawString, int theOffset, int theLength, int theOldColor, int theMaxChars)
 {
 	if (theOffset+theLength>theMaxChars)
 	{
@@ -1201,7 +1201,7 @@ static int WriteWordWrappedHelper(Graphics *g, const std::string& theString, int
 	return g->WriteString(theString,theX,theY,theWidth,theJustification,drawString,theOffset,theLength,theOldColor);
 }
 
-int	Graphics::WriteWordWrapped(const Rect& theRect, const std::string& theLine, int theLineSpacing, int theJustification, int *theMaxWidth, int theMaxChars, int *theLastWidth)
+int	Graphics::WriteWordWrapped(const Rect& theRect, std::string_view theLine, int theLineSpacing, int theJustification, int *theMaxWidth, int theMaxChars, int *theLastWidth)
 {
 	Color anOrigColor = GetColor();
 	int anOrigColorInt = anOrigColor.ToInt();
@@ -1383,12 +1383,12 @@ int	Graphics::WriteWordWrapped(const Rect& theRect, const std::string& theLine, 
 	//返回时，aYOffset 增量为 (行数 + 1) * 行距。以 aYOffset 减去末行多算的一次行距，再加上字体下沉部分的高度，得到文本底部的纵向偏移值，即文本区域高度。
 	return aYOffset + aFont->GetDescent() - theLineSpacing;
 }
-int	Graphics::DrawStringColor(const std::string& theLine, int theX, int theY, int theOldColor)
+int	Graphics::DrawStringColor(std::string_view theLine, int theX, int theY, int theOldColor)
 {
 	return WriteString(theLine, theX, theY, -1, -1,true,0,-1,theOldColor);
 }
 
-int	Graphics::DrawStringWordWrapped(const std::string& theLine, int theX, int theY, int theWrapWidth, int theLineSpacing, int theJustification, int *theMaxWidth)
+int	Graphics::DrawStringWordWrapped(std::string_view theLine, int theX, int theY, int theWrapWidth, int theLineSpacing, int theJustification, int *theMaxWidth)
 {
 	/*这个函数在正式版中被删得只剩前三个参数了……*/
 	int aYOffset = mFont->GetAscent() - mFont->GetAscentPadding();
@@ -1397,7 +1397,7 @@ int	Graphics::DrawStringWordWrapped(const std::string& theLine, int theX, int th
 	return WriteWordWrapped(aRect, theLine, theLineSpacing, theJustification, theMaxWidth);
 }
 
-int	Graphics::GetWordWrappedHeight(int theWidth, const std::string& theLine, int theLineSpacing, int *theMaxWidth)
+int	Graphics::GetWordWrappedHeight(int theWidth, std::string_view theLine, int theLineSpacing, int *theMaxWidth)
 {
 	Graphics aTestG;
 	aTestG.SetFont(mFont);

--- a/src/SexyAppFramework/graphics/Graphics.h
+++ b/src/SexyAppFramework/graphics/Graphics.h
@@ -135,7 +135,7 @@ public:
 	void					DrawRect(const Rect& theRect);
 	void					ClearRect(int theX, int theY, int theWidth, int theHeight);	
 	void					ClearRect(const Rect& theRect);
-	void					DrawString(const std::string& theString, int theX, int theY);
+	void					DrawString(std::string_view theString, int theX, int theY);
 	
 private:
 	bool					DrawLineClipHelper(double* theStartX, double* theStartY, double *theEndX, double* theEndY);
@@ -188,15 +188,15 @@ public:
 	// In progress: Only affects DrawImage
 	void					SetScale(float theScaleX, float theScaleY, float theOrigX, float theOrigY);
 
-	int						StringWidth(const std::string& theString);
+	int						StringWidth(std::string_view theString);
 	void					DrawImageBox(const Rect& theDest, Image* theComponentImage);
 	void					DrawImageBox(const Rect& theSrc, const Rect& theDest, Image* theComponentImage);
 
-	int						WriteString(const std::string& theString, int theX, int theY, int theWidth = -1, int theJustification = 0, bool drawString = true, int theOffset = 0, int theLength = -1, int theOldColor = -1);
-	int						WriteWordWrapped(const Rect& theRect, const std::string& theLine, int theLineSpacing = -1, int theJustification = -1, int *theMaxWidth = nullptr, int theMaxChars = -1, int* theLastWidth = nullptr);
-	int						DrawStringColor(const std::string& theString, int theX, int theY, int theOldColor = -1); //works like DrawString but can have color tags like ^ff0000^.
-	int						DrawStringWordWrapped(const std::string& theLine, int theX, int theY, int theWrapWidth = 10000000, int theLineSpacing = -1, int theJustification = -1, int *theMaxWidth = nullptr); //works like DrawString but also word wraps
-	int						GetWordWrappedHeight(int theWidth, const std::string& theLine, int theLineSpacing = -1, int *theMaxWidth = nullptr);
+	int						WriteString(std::string_view theString, int theX, int theY, int theWidth = -1, int theJustification = 0, bool drawString = true, int theOffset = 0, int theLength = -1, int theOldColor = -1);
+	int						WriteWordWrapped(const Rect& theRect, std::string_view theLine, int theLineSpacing = -1, int theJustification = -1, int *theMaxWidth = nullptr, int theMaxChars = -1, int* theLastWidth = nullptr);
+	int						DrawStringColor(std::string_view theString, int theX, int theY, int theOldColor = -1); //works like DrawString but can have color tags like ^ff0000^.
+	int						DrawStringWordWrapped(std::string_view theLine, int theX, int theY, int theWrapWidth = 10000000, int theLineSpacing = -1, int theJustification = -1, int *theMaxWidth = nullptr); //works like DrawString but also word wraps
+	int						GetWordWrappedHeight(int theWidth, std::string_view theLine, int theLineSpacing = -1, int *theMaxWidth = nullptr);
 
 	bool					Is3D() { return mIs3D; }
 };

--- a/src/SexyAppFramework/graphics/ImageFont.cpp
+++ b/src/SexyAppFramework/graphics/ImageFont.cpp
@@ -1384,7 +1384,7 @@ void ImageFont::GenerateActiveFontLayers()
 	}
 }
 
-int ImageFont::StringWidth(const std::string& theString)
+int ImageFont::StringWidth(std::string_view theString)
 {
 	int aWidth = 0;
 	char32_t aPrevChar = 0;
@@ -1469,7 +1469,7 @@ static RenderCommand gRenderCommandPool[POOL_SIZE];
 static RenderCommand* gRenderTail[256];
 static RenderCommand* gRenderHead[256];
 
-void ImageFont::DrawStringEx(Graphics* g, int theX, int theY, const std::string& theString, const Color& theColor, RectList* theDrawnAreas, int* theWidth)
+void ImageFont::DrawStringEx(Graphics* g, int theX, int theY, std::string_view theString, const Color& theColor, RectList* theDrawnAreas, int* theWidth)
 {
 	std::scoped_lock anAutoCrit(gRenderCritSec);
 
@@ -1655,7 +1655,7 @@ void ImageFont::DrawStringEx(Graphics* g, int theX, int theY, const std::string&
 	g->SetColorizeImages(colorizeImages);
 }
 
-void ImageFont::DrawString(Graphics* g, int theX, int theY, const std::string& theString, const Color& theColor, const Rect& theClipRect)
+void ImageFont::DrawString(Graphics* g, int theX, int theY, std::string_view theString, const Color& theColor, const Rect& theClipRect)
 {
 	(void)theClipRect;
 	DrawStringEx(g, theX, theY, theString, theColor, nullptr, nullptr);

--- a/src/SexyAppFramework/graphics/ImageFont.h
+++ b/src/SexyAppFramework/graphics/ImageFont.h
@@ -175,7 +175,7 @@ public:
 
 public:
 	virtual void			GenerateActiveFontLayers();
-	virtual void			DrawStringEx(Graphics* g, int theX, int theY, const std::string& theString, const Color& theColor, RectList* theDrawnAreas, int* theWidth);
+	virtual void			DrawStringEx(Graphics* g, int theX, int theY, std::string_view theString, const Color& theColor, RectList* theDrawnAreas, int* theWidth);
 
 public:
 	ImageFont(SexyAppBase* theSexyApp, const std::string& theFontDescFileName);
@@ -190,8 +190,8 @@ public:
 	
 	int						CharWidth(char32_t theChar) override;
 	int						CharWidthKern(char32_t theChar, char32_t thePrevChar) override;
-	int						StringWidth(const std::string& theString) override;
-	void					DrawString(Graphics* g, int theX, int theY, const std::string& theString, const Color& theColor, const Rect& theClipRect) override;
+	int						StringWidth(std::string_view theString) override;
+	void					DrawString(Graphics* g, int theX, int theY, std::string_view theString, const Color& theColor, const Rect& theClipRect) override;
 
 	_Font*					Duplicate() override;
 

--- a/src/SexyAppFramework/misc/Buffer.cpp
+++ b/src/SexyAppFramework/misc/Buffer.cpp
@@ -216,7 +216,7 @@ bool Buffer::ToUTF8String(std::string* theString) const
 	return false;
 }
 
-void Buffer::FromWebString(const std::string& theString)
+void Buffer::FromWebString(std::string_view theString)
 {
 	Clear();
 

--- a/src/SexyAppFramework/misc/Buffer.h
+++ b/src/SexyAppFramework/misc/Buffer.h
@@ -48,7 +48,7 @@ public:
 	void					SeekFront() const;
 	void					Clear();
 
-	void					FromWebString(const std::string& theString);
+	void					FromWebString(std::string_view theString);
 	void					WriteByte(uchar theByte);
 	void					WriteNumBits(int theNum, int theBits);
 	static int				GetBitsRequired(int theNum, bool isSigned);

--- a/src/SexyAppFramework/misc/XMLParser.cpp
+++ b/src/SexyAppFramework/misc/XMLParser.cpp
@@ -313,7 +313,7 @@ bool XMLParser::OpenFile(const std::string& theFileName)
 	return true;
 }
 
-void XMLParser::SetStringSource(const std::string& theString)
+void XMLParser::SetStringSource(std::string_view theString)
 {
 	Init();
 

--- a/src/SexyAppFramework/misc/XMLParser.h
+++ b/src/SexyAppFramework/misc/XMLParser.h
@@ -114,7 +114,7 @@ public:
 
 	void					SetEncodingType(XMLEncodingType theEncoding);
 	bool					OpenFile(const std::string& theFilename);
-	void					SetStringSource(const std::string& theString);
+	void					SetStringSource(std::string_view theString);
 	bool					NextElement(XMLElement* theElement);
 	std::string				GetErrorText();
 	int						GetCurrentLineNum();

--- a/src/SexyAppFramework/widget/TextWidget.cpp
+++ b/src/SexyAppFramework/widget/TextWidget.cpp
@@ -59,7 +59,7 @@ void TextWidget::Clear()
 	MarkDirty();
 }
 
-void TextWidget::DrawColorString(Graphics* g, const std::string& theString, int x, int y, bool useColors)
+void TextWidget::DrawColorString(Graphics* g, std::string_view theString, int x, int y, bool useColors)
 {		
 	int aWidth = 0;
 	
@@ -90,7 +90,7 @@ void TextWidget::DrawColorString(Graphics* g, const std::string& theString, int 
 		g->DrawString(aCurString, x + aWidth, y);
 }	
 
-void TextWidget::DrawColorStringHilited(Graphics* g, const std::string& theString, int x, int y, int theStartPos, int theEndPos)
+void TextWidget::DrawColorStringHilited(Graphics* g, std::string_view theString, int x, int y, int theStartPos, int theEndPos)
 {
 	DrawColorString(g, theString, x, y, true);				
 	
@@ -110,26 +110,26 @@ void TextWidget::DrawColorStringHilited(Graphics* g, const std::string& theStrin
 	}
 }
 
-int TextWidget::GetStringIndex(const std::string& theString, int thePixel)
+int TextWidget::GetStringIndex(std::string_view theString, int thePixel)
 {
 	int aPos = 0;
-	
+
 	for (int i = 0; i < (int)theString.length(); i++)
 	{
-		std::string aLoSubStr = theString.substr(0, i);
-		std::string aHiSubStr = theString.substr(0, i+1);
-			
+		std::string_view aLoSubStr = theString.substr(0, i);
+		std::string_view aHiSubStr = theString.substr(0, i+1);
+
 		int aLoLen = GetColorStringWidth(aLoSubStr);
 		int aHiLen = GetColorStringWidth(aHiSubStr);
 		if (thePixel >= (aLoLen+aHiLen)/2)
 			aPos = i+1;
 	}
-	
+
 	return aPos;
 }
 
 //UNICODE
-int TextWidget::GetColorStringWidth(const std::string& theString)
+int TextWidget::GetColorStringWidth(std::string_view theString)
 {				
 	int aWidth = 0;	
 	std::string aTempString;
@@ -193,7 +193,7 @@ void TextWidget::Resize(int theX, int theY, int theWidth, int theHeight)
 }
 
 //UNICODE
-Color TextWidget::GetLastColor(const std::string& theString)
+Color TextWidget::GetLastColor(std::string_view theString)
 {
 	int anIdx = theString.rfind((char)0xFF);
 	if (anIdx < 0)

--- a/src/SexyAppFramework/widget/TextWidget.h
+++ b/src/SexyAppFramework/widget/TextWidget.h
@@ -55,13 +55,13 @@ public:
 	virtual std::vector<std::string> GetLines();
 	virtual void SetLines(std::vector<std::string> theNewLines);
 	virtual void Clear();
-	virtual void DrawColorString(Graphics* g, const std::string& theString, int x, int y, bool useColors);
-	virtual void DrawColorStringHilited(Graphics* g, const std::string& theString, int x, int y, int theStartPos, int theEndPos);
-	virtual int GetStringIndex(const std::string& theString, int thePixel);
-	
-	virtual int GetColorStringWidth(const std::string& theString);
+	virtual void DrawColorString(Graphics* g, std::string_view theString, int x, int y, bool useColors);
+	virtual void DrawColorStringHilited(Graphics* g, std::string_view theString, int x, int y, int theStartPos, int theEndPos);
+	virtual int GetStringIndex(std::string_view theString, int thePixel);
+
+	virtual int GetColorStringWidth(std::string_view theString);
 	void         Resize(int theX, int theY, int theWidth, int theHeight) override;
-	virtual Color GetLastColor(const std::string& theString);
+	virtual Color GetLastColor(std::string_view theString);
 	virtual void AddToPhysicalLines(int theIdx, const std::string& theLine);
 	
 	virtual void AddLine(const std::string& theString);

--- a/src/SexyAppFramework/widget/Widget.cpp
+++ b/src/SexyAppFramework/widget/Widget.cpp
@@ -313,7 +313,7 @@ void Widget::MouseWheel(int){}
 
 //////// Helper functions
 
-Rect Widget::WriteCenteredLine(Graphics* g, int anOffset, const std::string& theLine)
+Rect Widget::WriteCenteredLine(Graphics* g, int anOffset, std::string_view theLine)
 {
 	_Font* aFont = g->GetFont();
 	int aWidth = aFont->StringWidth(theLine);
@@ -324,7 +324,7 @@ Rect Widget::WriteCenteredLine(Graphics* g, int anOffset, const std::string& the
 	return Rect(aX, anOffset - aFont->GetAscent(), aWidth, aFont->GetHeight());
 }
 
-Rect Widget::WriteCenteredLine(Graphics* g, int anOffset, const std::string& theLine, Color theColor1, Color theColor2, const Point& theShadowOffset)
+Rect Widget::WriteCenteredLine(Graphics* g, int anOffset, std::string_view theLine, Color theColor1, Color theColor2, const Point& theShadowOffset)
 {
 	_Font* aFont = g->GetFont();
 	int aWidth = aFont->StringWidth(theLine);
@@ -345,7 +345,7 @@ Rect Widget::WriteCenteredLine(Graphics* g, int anOffset, const std::string& the
 		aFont->GetHeight() + abs(theShadowOffset.mY));
 }
 
-int Widget::WriteString(Graphics* g, const std::string& theString, int theX, int theY, int theWidth, int theJustification, bool drawString, int theOffset, int theLength)
+int Widget::WriteString(Graphics* g, std::string_view theString, int theX, int theY, int theWidth, int theJustification, bool drawString, int theOffset, int theLength)
 {
 	bool oldColored = g->mWriteColoredString;
 	g->mWriteColoredString = mWriteColoredString;
@@ -355,7 +355,7 @@ int Widget::WriteString(Graphics* g, const std::string& theString, int theX, int
 	return aXOffset;
 }
 
-int	Widget::WriteWordWrapped(Graphics* g, const Rect& theRect, const std::string& theLine, int theLineSpacing, int theJustification)
+int	Widget::WriteWordWrapped(Graphics* g, const Rect& theRect, std::string_view theLine, int theLineSpacing, int theJustification)
 {
 	bool oldColored = g->mWriteColoredString;
 	g->mWriteColoredString = mWriteColoredString;
@@ -365,7 +365,7 @@ int	Widget::WriteWordWrapped(Graphics* g, const Rect& theRect, const std::string
 	return aReturn;
 }
 
-int Widget::GetWordWrappedHeight(Graphics* g, int theWidth, const std::string& theLine, int aLineSpacing)
+int Widget::GetWordWrappedHeight(Graphics* g, int theWidth, std::string_view theLine, int aLineSpacing)
 {
 	return g->GetWordWrappedHeight(theWidth,theLine,aLineSpacing);
 }

--- a/src/SexyAppFramework/widget/Widget.h
+++ b/src/SexyAppFramework/widget/Widget.h
@@ -105,12 +105,12 @@ public:
 	
 	//////// Helper functions
 	
-	virtual Rect			WriteCenteredLine(Graphics* g, int anOffset, const std::string& theLine);
-	virtual Rect			WriteCenteredLine(Graphics* g, int anOffset, const std::string& theLine, Color theColor1, Color theColor2, const Point& theShadowOffset = Point(1,2));
+	virtual Rect			WriteCenteredLine(Graphics* g, int anOffset, std::string_view theLine);
+	virtual Rect			WriteCenteredLine(Graphics* g, int anOffset, std::string_view theLine, Color theColor1, Color theColor2, const Point& theShadowOffset = Point(1,2));
 
-	virtual int				WriteString(Graphics* g, const std::string& theString, int theX, int theY, int theWidth = -1, int theJustification = -1, bool drawString = true, int theOffset = 0, int theLength = -1);
-	virtual int				WriteWordWrapped(Graphics* g, const Rect& theRect, const std::string& theLine, int theLineSpacing, int theJustification);
-	virtual int				GetWordWrappedHeight(Graphics* g, int theWidth, const std::string& theLine, int aLineSpacing);
+	virtual int				WriteString(Graphics* g, std::string_view theString, int theX, int theY, int theWidth = -1, int theJustification = -1, bool drawString = true, int theOffset = 0, int theLength = -1);
+	virtual int				WriteWordWrapped(Graphics* g, const Rect& theRect, std::string_view theLine, int theLineSpacing, int theJustification);
+	virtual int				GetWordWrappedHeight(Graphics* g, int theWidth, std::string_view theLine, int aLineSpacing);
 	virtual int				GetNumDigits(int theNumber);
 	virtual void			WriteNumberFromStrip(Graphics* g, int theNumber, int theX, int theY, Image* theNumberStrip, int aSpacing);
 	virtual bool			Contains(int theX, int theY);


### PR DESCRIPTION
This pull request makes several improvements to string handling across the codebase, focusing on increased efficiency and better Unicode (UTF-8) support. The most important changes are the migration of many string parameters from `const std::string&` to `std::string_view`, and reworking text rendering and animation logic to correctly handle multi-byte UTF-8 characters. Additionally, various UI components have been updated to use these new interfaces and improved logic.

### String Handling and API Modernization

* Changed many function parameters from `const std::string&` to `std::string_view` for improved efficiency and flexibility, including in `Board`, `MessageWidget`, `ToolTipWidget`, `AwardScreen`, `DataWriter`, and `TypingCheck` classes. [[1]](diffhunk://#diff-f28a1c8555f4582838a756e3433b9042d5edeaa8bb0e7aead4efec26636c2b06L1991-R1991) [[2]](diffhunk://#diff-f28a1c8555f4582838a756e3433b9042d5edeaa8bb0e7aead4efec26636c2b06L2005-R2005) [[3]](diffhunk://#diff-ffa13631f5b3b876f9c59ca2b76619355df54d53c9891bdce09d88e68d70af98L265-R265) [[4]](diffhunk://#diff-ffa13631f5b3b876f9c59ca2b76619355df54d53c9891bdce09d88e68d70af98L470-R470) [[5]](diffhunk://#diff-b6958dfb02d5e35e2244e5b3d879d8eaa8825c6fdb64b7fc668e378f78dc0d6bL73-R74) [[6]](diffhunk://#diff-59bd2f0cf47d290f7825a1a06c69294cb79793fe266674490b800b3e4477b475L58-R60) [[7]](diffhunk://#diff-0baa03547b5f873852e193639fdf201087418e9f681dd2369c02688b9eb9b7c3L545-R549) [[8]](diffhunk://#diff-f585356171440326eb197e8a9c3f13d509730892ed54f17f15acd4f3cb38670dL86-R86) [[9]](diffhunk://#diff-3cc04ee29912c0714c66f8b9219b763e052fbf4aa7d11dd85420ce15c680b83bL25-R30) [[10]](diffhunk://#diff-e047fe0ab007363aace1bd85bbb4e8b9c9f7b773911aedc87f8d89e833c184c6L36-R38) [[11]](diffhunk://#diff-3f5278205a5e7444b0433cad1ee4964d8aaebc628d360fdeda193a4715cbc888L159-R171) [[12]](diffhunk://#diff-5436daa4483e721f4c3fc6c1db9e509558b476fb16a4ce2c86da818562fe88a1L53-R55) [[13]](diffhunk://#diff-ab6476ed78256c1d691c41167e97618ae277b7f7c8ffd527f2c1f90c9e973263L276-R276) [[14]](diffhunk://#diff-71e1fdd58a9bbd6a1afd07eab445a8e15ab700b88455a584590f7131fff711c9L71-R71)

### Unicode and UTF-8 Support

* Updated text animation and rendering logic in `MessageWidget` to iterate over UTF-8 code points rather than bytes, ensuring correct handling of multi-byte characters for animations and drawing. This includes maintaining per-character animation state and offsets. [[1]](diffhunk://#diff-b6958dfb02d5e35e2244e5b3d879d8eaa8825c6fdb64b7fc668e378f78dc0d6bL178-R205) [[2]](diffhunk://#diff-b6958dfb02d5e35e2244e5b3d879d8eaa8825c6fdb64b7fc668e378f78dc0d6bL218-R231) [[3]](diffhunk://#diff-b6958dfb02d5e35e2244e5b3d879d8eaa8825c6fdb64b7fc668e378f78dc0d6bL238-R247) [[4]](diffhunk://#diff-b6958dfb02d5e35e2244e5b3d879d8eaa8825c6fdb64b7fc668e378f78dc0d6bL247-R256) [[5]](diffhunk://#diff-b6958dfb02d5e35e2244e5b3d879d8eaa8825c6fdb64b7fc668e378f78dc0d6bL256-R267) [[6]](diffhunk://#diff-b6958dfb02d5e35e2244e5b3d879d8eaa8825c6fdb64b7fc668e378f78dc0d6bL286-R296) [[7]](diffhunk://#diff-59bd2f0cf47d290f7825a1a06c69294cb79793fe266674490b800b3e4477b475R49-R50)
* Improved auto-wrapping and line splitting in `ChallengeScreen` to count UTF-8 code points instead of bytes, resulting in correct wrapping for non-ASCII text.

### UI and Drawing Updates

* Updated various UI drawing routines (e.g., credits, tooltips, award screens) to accept and use `std::string_view`, and to handle substrings more efficiently and safely. [[1]](diffhunk://#diff-d30da8e2c8cd9e6e2632c9032ac51a47b2bf3727618c4a4d10e19a71e0237b54L771-R771) [[2]](diffhunk://#diff-d30da8e2c8cd9e6e2632c9032ac51a47b2bf3727618c4a4d10e19a71e0237b54L791-R799) [[3]](diffhunk://#diff-3f5278205a5e7444b0433cad1ee4964d8aaebc628d360fdeda193a4715cbc888L159-R171) [[4]](diffhunk://#diff-ab6476ed78256c1d691c41167e97618ae277b7f7c8ffd527f2c1f90c9e973263L276-R276)

These changes collectively modernize string handling, improve performance by reducing unnecessary allocations, and ensure correct display and animation of internationalized text.

Close #328