### PR TITLE
Fix: correct free planting cheat tooltip

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -3581,7 +3581,7 @@ void Board::UpdateToolTip()
 	int aPlantCost = GetCurrentPlantCost(aSeedPacket->mPacketType, aSeedPacket->mImitaterType);
 	if (mApp->mEasyPlantingCheat)
 	{
-		mToolTip->SetWarningText("FREE_PLANTING_CHEAT");
+		mToolTip->SetWarningText("[FREE_PLANTING_CHEAT]");
 	}
 	else if (!aSeedPacket->mActive && (gLawnApp->mGameMode == GameMode::GAMEMODE_CHALLENGE_BEGHOULED || gLawnApp->mGameMode == GameMode::GAMEMODE_CHALLENGE_BEGHOULED_TWIST))
 	{


### PR DESCRIPTION
The original file “properties/LawnString.txt” contains a string ID named “[FREE_PLANTING_CHEAT],” whose corresponding string value is intended to display as a warning message reading “Free Planting.” However, due to a bug in the original program, this content does not display properly. This PR corrects the string ID for the “Free Planting” warning message to ensure it displays correctly.