### PR TITLE
Fix: avoid color pollution in TodWriteString width measurement

### DIFF
--- a/src/Sexy.TodLib/TodStringFile.cpp
+++ b/src/Sexy.TodLib/TodStringFile.cpp
@@ -236,21 +236,23 @@ bool CharIsSpaceInFormat(char theChar, const TodStringListFormat& theCurrentForm
 int TodWriteString(Graphics* g, const std::string& theString, int theX, int theY, TodStringListFormat& theCurrentFormat, int theWidth, DrawStringJustification theJustification, bool drawString, int theOffset, int theLength)
 {
 	_Font* aFont = *theCurrentFormat.mNewFont;
-	if (drawString)  // 如果需要实际绘制
+	if (drawString)
 	{
-		int aSpareX = theWidth - TodWriteString(g, theString, theX, theY, theCurrentFormat, theWidth, DrawStringJustification::DS_ALIGN_LEFT, false, theOffset, theLength);
-		switch (theJustification)  // 根据对齐方式调整实际绘制的横坐标
+		const auto aMeasureSpareX = [&]() -> int {
+			TodStringListFormat aMeasureFormat = theCurrentFormat;
+			return theWidth - TodWriteString(g, theString, theX, theY, aMeasureFormat, theWidth, DrawStringJustification::DS_ALIGN_LEFT, false, theOffset, theLength);
+		};
+		switch (theJustification)
 		{
 		case DrawStringJustification::DS_ALIGN_RIGHT:
 		case DrawStringJustification::DS_ALIGN_RIGHT_VERTICAL_MIDDLE:
-			theX += aSpareX;
+			theX += aMeasureSpareX();
 			break;
 		case DrawStringJustification::DS_ALIGN_CENTER:
 		case DrawStringJustification::DS_ALIGN_CENTER_VERTICAL_MIDDLE:
-			theX += aSpareX / 2;
+			theX += aMeasureSpareX() / 2;
 			break;
-		case DrawStringJustification::DS_ALIGN_LEFT:
-		case DrawStringJustification::DS_ALIGN_LEFT_VERTICAL_MIDDLE:
+		default:
 			break;
 		}
 	}


### PR DESCRIPTION
TodWriteString previously ran an unconditional recursive measurement pass (drawString=false) on the same TodStringListFormat reference used by the real draw pass. The measurement does not draw, but it still applies inline format tags through TodWriteStringSetFormat, advancing the shared mNewColor to the last tag in the line. The draw pass then started with that polluted color, drawing any leading text before a mid-line color tag in the tag's color.

The Chinese LawnStrings expose this: the Peashooter flavor text ends in "{FLAVOR}...{STAT}\n...", so the wrapped line ending in "{STAT}" had its leading FLAVOR text drawn red. The English strings have no mid-line color tag after FLAVOR and were unaffected.

Measure into a local copy of the format state, and only for the RIGHT/CENTER alignments that need the horizontal offset. This makes the measurement side-effect-free for every alignment.

Close #334