### PR TITLE
Fix: correct loading task accounting

### DIFF
--- a/src/Lawn/System/Music.cpp
+++ b/src/Lawn/System/Music.cpp
@@ -54,17 +54,32 @@ Music::Music()
 
 MusicFileData gMusicFileData[MusicFile::NUM_MUSIC_FILES];
 
-bool Music::TodLoadMusic(MusicFile theMusicFile, const std::string& theFileName)
+struct MusicLoadEntry
+{
+	MusicFile					mMusicFile;
+	std::string_view			mFileName;
+};
+
+static constexpr int MUSIC_LOADING_TASK_WEIGHT = 3500;
+static constexpr MusicLoadEntry MUSIC_LOADING_FILES[] = {
+	{MusicFile::MUSIC_FILE_DRUMS, "sounds/mainmusic.mo3"},
+	{MusicFile::MUSIC_FILE_CREDITS_ZOMBIES_ON_YOUR_LAWN, "sounds/ZombiesOnYourLawn.ogg"}
+};
+
+const int Music::MUSIC_LOADING_TASKS = MUSIC_LOADING_TASK_WEIGHT * static_cast<int>(sizeof(MUSIC_LOADING_FILES) / sizeof(MUSIC_LOADING_FILES[0]));
+
+bool Music::TodLoadMusic(MusicFile theMusicFile, std::string_view theFileName)
 {
 	Mix_Music* aHMusic = 0;
 	SDLMusicInterface* anSDL = (SDLMusicInterface*)mApp->mMusicInterface;
+	std::string aFileName(theFileName);
 	std::string anExt;
 
-	size_t aDot = theFileName.rfind('.');
+	size_t aDot = aFileName.rfind('.');
 	if (aDot != std::string::npos)
-		anExt = StringToLower(theFileName.substr(aDot + 1));
+		anExt = StringToLower(aFileName.substr(aDot + 1));
 
-	PFILE* pFile = p_fopen(theFileName.c_str(), "rb");
+	PFILE* pFile = p_fopen(aFileName.c_str(), "rb");
 	if (pFile == nullptr)
 		return false;
 
@@ -151,7 +166,7 @@ void Music::SetupVolumeForTune(MusicTune theMusicTune, float theDrumsVolume, flo
 	}
 }
 
-void Music::LoadSong(MusicFile theMusicFile, const std::string& theFileName)
+void Music::LoadSong(MusicFile theMusicFile, std::string_view theFileName)
 {
 	TodHesitationTrace("preloadsong");
 	if (!TodLoadMusic(theMusicFile, theFileName))
@@ -161,7 +176,7 @@ void Music::LoadSong(MusicFile theMusicFile, const std::string& theFileName)
 	}
 	else
 	{
-		TodHesitationTrace("song '%s'", theFileName.c_str());
+		TodHesitationTrace("song '%.*s'", static_cast<int>(theFileName.size()), theFileName.data());
 	}
 }
 
@@ -173,20 +188,11 @@ void Music::MusicTitleScreenInit()
 
 void Music::MusicInit()
 {
-#ifdef PVZ_DEBUG
-	int aNumLoadingTasks = mApp->mCompletedLoadingThreadTasks + GetNumLoadingTasks();
-#endif
-
-	LoadSong(MusicFile::MUSIC_FILE_DRUMS, "sounds/mainmusic.mo3");
-	mApp->mCompletedLoadingThreadTasks += 3500;
-
-	LoadSong(MusicFile::MUSIC_FILE_CREDITS_ZOMBIES_ON_YOUR_LAWN, "sounds/ZombiesOnYourLawn.ogg");
-	mApp->mCompletedLoadingThreadTasks += 3500;
-
-#ifdef PVZ_DEBUG
-	if (mApp->mCompletedLoadingThreadTasks != aNumLoadingTasks)
-		TodTrace("Didn't calculate loading task count correctly!!!!");
-#endif
+	for (const auto& aMusic : MUSIC_LOADING_FILES)
+	{
+		LoadSong(aMusic.mMusicFile, aMusic.mFileName);
+		mApp->mCompletedLoadingThreadTasks += MUSIC_LOADING_TASK_WEIGHT;
+	}
 }
 
 void Music::MusicCreditScreenInit()
@@ -698,9 +704,4 @@ void Music::GameMusicPause(bool thePause)
 		}
 		mPaused = false;
 	}
-}
-
-int Music::GetNumLoadingTasks()
-{
-	return 3500 * 1;
 }

--- a/src/Lawn/System/Music.h
+++ b/src/Lawn/System/Music.h
@@ -24,6 +24,7 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <SDL_mixer_ext/SDL_mixer_ext.h>
 
 class LawnApp;
@@ -112,6 +113,8 @@ public:
 public:
 	Music();
 
+	static const int			MUSIC_LOADING_TASKS;
+
 	void						MusicInit();
 	void						MusicDispose() { ; }
 	void						MusicUpdate();
@@ -119,21 +122,20 @@ public:
 	/*inline*/ void				PlayMusic(MusicTune theMusicTune, int theOffset = -1, int theDrumsOffset = -1);
 	/*inline*/ Mix_Music*		GetMusicHandle(MusicFile theMusicFile);
 	void						StartGameMusic();
-	/*inline*/ void				LoadSong(MusicFile theMusicFile, const std::string& theFileName);
+	/*inline*/ void				LoadSong(MusicFile theMusicFile, std::string_view theFileName);
 	void						MusicResync();
 	void						UpdateMusicBurst();
 	/*inline*/ void				StartBurst();
 	void						GameMusicPause(bool thePause);
 	void						PlayFromOffset(MusicFile theMusicFile, int theOffset, double theVolume);
 	void						MusicResyncChannel(MusicFile theMusicFileToMatch, MusicFile theMusicFileToSync);
-	bool						TodLoadMusic(MusicFile theMusicFile, const std::string& theFileName);
+	bool						TodLoadMusic(MusicFile theMusicFile, std::string_view theFileName);
 	void						MusicTitleScreenInit();
 	/*inline*/ void				MakeSureMusicIsPlaying(MusicTune theMusicTune);
 	/*inline*/ void				FadeOut(int theFadeOutDuration);
 	void						SetupVolumeForTune(MusicTune theMusicTune, float theDrumsVolume, float theHihatsVolume);
 	unsigned long				GetMusicOrder(MusicFile theMusicFile);
 	void						MusicCreditScreenInit();
-	int							GetNumLoadingTasks();
 };
 
 #endif

--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -3093,7 +3093,7 @@ int LawnApp::GetNumPreloadingTasks()
 
 void LawnApp::PreloadForUser()
 {
-	int aNumTasks = mNumLoadingThreadTasks + GetNumPreloadingTasks();
+	int aNumTasks = mCompletedLoadingThreadTasks + GetNumPreloadingTasks();
 	if (mTitleScreen && mTitleScreen->mQuickLoadKey != KeyCode::KEYCODE_UNKNOWN)
 	{
 		TodTrace("preload canceled\n");
@@ -3147,7 +3147,7 @@ void LawnApp::PreloadForUser()
 
 		for (ZombieType i = ZombieType::ZOMBIE_NORMAL; i < ZombieType::NUM_ZOMBIE_TYPES; i = static_cast<ZombieType>(static_cast<int>(i) + 1))
 		{
-			if (HasFinishedAdventure() || mPlayerInfo->mLevel >= GetZombieDefinition(i).mStartingLevel)
+			if (!HasFinishedAdventure() && mPlayerInfo->mLevel < GetZombieDefinition(i).mStartingLevel)
 			{
 				continue;
 			}

--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -1754,7 +1754,7 @@ void LawnApp::LoadingThreadProc()
 	}
 	mNumLoadingThreadTasks += 636;
 	mNumLoadingThreadTasks += GetNumPreloadingTasks();
-	mNumLoadingThreadTasks += mMusic->GetNumLoadingTasks();
+	mNumLoadingThreadTasks += Music::MUSIC_LOADING_TASKS;
 
 	PerfTimer aTimer;
 	aTimer.Start();

--- a/src/Sexy.TodLib/TodParticle.cpp
+++ b/src/Sexy.TodLib/TodParticle.cpp
@@ -222,7 +222,7 @@ void TodParticleLoadDefinitions(const ParticleParams* theParticleParamArray, int
 			snprintf(aBuf, sizeof(aBuf), "Failed to load particle '%s'", aParticleParams.mParticleFileName);
 			TodErrorMessageBox(aBuf, "Error");
 		}
-		gSexyAppBase->mNumLoadingThreadTasks += 6;
+		gSexyAppBase->mCompletedLoadingThreadTasks += 6;
 	}
 }
 


### PR DESCRIPTION
Replace GetNumLoadingTasks with a shared constexpr music-loading table so the loading-thread budget matches the work done in MusicInit. Also widen music file path parameters to std::string_view.

Use mCompletedLoadingThreadTasks as the preload target base and preload
unlocked zombies consistently with GetNumPreloadingTasks.