### PR TITLE
Fix: unify resource error handling and use SDL message box for fatal errors on most platforms

### DIFF
--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -1879,13 +1879,17 @@ void SexyAppBase::Popup(const std::string& theString)
 
 	BeginPopup();
 	if (!mShutdown)
+	{
 		Sexy::PrintF("FATAL ERROR\n===\n%s\n", theString.c_str());
-
-#ifdef __SWITCH__
-	ErrorApplicationConfig c;
-	errorApplicationCreate(&c, "Fatal error", theString.c_str());
-	errorApplicationShow(&c);
+#if defined(__SWITCH__)
+		ErrorApplicationConfig c;
+		errorApplicationCreate(&c, "Fatal error", theString.c_str());
+		errorApplicationShow(&c);
+#elif !defined(__3DS__) && !defined(__EMSCRIPTEN__)
+		if (std::this_thread::get_id() == mPrimaryThreadId)
+			SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "FATAL ERROR", theString.c_str(), NULL);
 #endif
+	}
 
 	EndPopup();
 }
@@ -2997,9 +3001,34 @@ void SexyAppBase::LoadResourceManifest()
 
 void SexyAppBase::ShowResourceError(bool doExit)
 {
-	Popup(mResourceManager->GetErrorText());	
+	const std::string& aError = mResourceManager->GetErrorText();
+#if defined(__IPHONEOS__)
+	// Documents folder is only shown in the Files app / iTunes once it contains a file
+	const std::filesystem::path aResourceDir(GetResourceFolder());
+	const bool aHasGameResources = !aResourceDir.empty() &&
+		std::filesystem::is_regular_file(aResourceDir / "main.pak") &&
+		std::filesystem::is_directory(aResourceDir / "properties");
+	if (!aHasGameResources)
+	{
+		const std::filesystem::path aReadmePath = aResourceDir / "README.txt";
+		if (!aResourceDir.empty() && !std::filesystem::exists(aReadmePath))
+			std::ofstream(aReadmePath, std::ios::out | std::ios::trunc)
+				<< "Place your `main.pak` and `properties/` folder here to play the game.\n";
+	}
+	std::string aMessage =
+		"Please place main.pak and the properties/ folder into the "
+		"PvZ Portable folder using the Files app or Finder/iTunes file sharing.";
+	if (!aError.empty())
+		aMessage += "\n\n(" + aError + ")";
+#else
+	std::string aMessage;
+	if (!aError.empty())
+		aMessage = aError + "\n\n";
+	aMessage += "Please place main.pak and the properties/ folder into:\n" + GetResourceFolder();
+#endif
+	Popup(aMessage);
 	if (doExit)
-		DoExit(0);
+		DoExit(1);
 }
 
 bool SexyAppBase::GetBoolean(std::string_view theId)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,6 @@
 #include "Resources.h"
 #include "Sexy.TodLib/TodStringFile.h"
 #include <cstdlib>
-#include <filesystem>
 #include <vector>
 using namespace Sexy;
 
@@ -38,11 +37,6 @@ using namespace Sexy;
 extern "C" {
 	unsigned int __stacksize__ = 512 * 1024;
 }
-#endif
-
-#ifdef __IPHONEOS__
-#include <SDL.h>
-#include <fstream>
 #endif
 
 #ifdef __EMSCRIPTEN__
@@ -104,40 +98,6 @@ int main(int argc, char** argv)
 
 #ifdef _WIN32
 	BuildUtf8ArgsFromWin32(argc, argv);
-#endif
-
-#ifdef __IPHONEOS__
-	bool aHasGameResources = false;
-	std::filesystem::path aDocsPath;
-	const char* aHome = std::getenv("HOME");
-	if (aHome != nullptr && aHome[0] != '\0')
-	{
-		aDocsPath = std::filesystem::path(aHome) / "Documents";
-		aHasGameResources = std::filesystem::is_regular_file(aDocsPath / "main.pak") &&
-			std::filesystem::is_directory(aDocsPath / "properties");
-	}
-
-	if (!aHasGameResources)
-	{
-		const std::filesystem::path aReadmePath = aDocsPath / "README.txt";
-		if (!aDocsPath.empty() && !std::filesystem::exists(aReadmePath))
-		{
-			std::ofstream(aReadmePath, std::ios::out | std::ios::trunc)
-				<< "Place your `main.pak` and `properties/` folder here to play the game.\n";
-		}
-
-		SDL_Init(SDL_INIT_VIDEO);
-		SDL_ShowSimpleMessageBox(
-			SDL_MESSAGEBOX_ERROR,
-			"Resources Not Found",
-			"Please place main.pak and the properties/ folder into the "
-			"PvZ Portable folder using the Files app or Finder/iTunes file sharing.\n\n"
-			"The app will now exit.",
-			NULL
-		);
-		SDL_Quit();
-		return 1;
-	}
 #endif
 
 	TodStringListSetColors(gLawnStringFormats, gLawnStringFormatCount);


### PR DESCRIPTION
Move iOS resource check and README creation from main() into ShowResourceError(), add SDL_ShowSimpleMessageBox for fatal errors on desktop/mobile platforms, and remove duplicate iOS-specific early exit logic.

Close #339