### PR TITLE
Fix: use live mouse position in GameButton::IsMouseOver

### DIFF
--- a/src/Lawn/Widget/AwardScreen.cpp
+++ b/src/Lawn/Widget/AwardScreen.cpp
@@ -591,9 +591,6 @@ void AwardScreen::MouseDown(int x, int y, int theClickCount)
 {
 	(void)x;(void)y;
 	if (theClickCount == 1) {
-		mStartButton->Update(); // @Patoke: implemented
-		mMenuButton->Update();
-		mContinueButton->Update();
 		if (mStartButton->IsMouseOver() || mMenuButton->IsMouseOver() || mContinueButton->IsMouseOver())
 			mApp->PlaySample(Sexy::SOUND_TAP);
 	}

--- a/src/Lawn/Widget/GameButton.cpp
+++ b/src/Lawn/Widget/GameButton.cpp
@@ -219,13 +219,14 @@ void GameButton::Resize(int theX, int theY, int theWidth, int theHeight)
 
 bool GameButton::IsMouseOver()
 {
-	return mIsOver && !mDisabled && !mBtnNoDraw;
-}
+	if (mDisabled || mBtnNoDraw)
+		return false;
 
-// GOTY @Patoke: 0x44AF50
-void GameButton::Update()
-{
 	WidgetManager* aManager = mApp->mWidgetManager;
+	bool aFocusMatches = aManager->mFocusWidget && aManager->mFocusWidget == mParentWidget;
+	if (!aFocusMatches && mApp->GetDialogCount() > 0)
+		return false;
+
 	int aMouseX = aManager->mLastMouseX, aMouseY = aManager->mLastMouseY;
 	if (mParentWidget)
 	{
@@ -233,17 +234,20 @@ void GameButton::Update()
 		aMouseX -= anAbsPos.mX;
 		aMouseY -= anAbsPos.mY;
 	}
+	return Rect(mX, mY, mWidth, mHeight).Contains(aMouseX, aMouseY);
+}
 
-	if ((aManager->mFocusWidget && aManager->mFocusWidget == mParentWidget) || mApp->GetDialogCount() <= 0)
-	{
-		mIsOver = Rect(mX, mY, mWidth, mHeight).Contains(aMouseX, aMouseY);
+// GOTY @Patoke: 0x44AF50
+void GameButton::Update()
+{
+	WidgetManager* aManager = mApp->mWidgetManager;
+	mIsOver = IsMouseOver();
+
+	bool aFocusMatches = aManager->mFocusWidget && aManager->mFocusWidget == mParentWidget;
+	if (aFocusMatches || mApp->GetDialogCount() <= 0)
 		mIsDown = aManager->mDownButtons & 5;
-	}
 	else
-	{
-		mIsOver = false;
 		mIsDown = false;
-	}
 
 	if (!mIsDown && !mIsOver && mOverAlpha > 0)
 	{


### PR DESCRIPTION
GameButton is not a Widget and is not driven by WidgetManager hover events; its IsMouseOver() returned the cached mIsOver, which is only refreshed in Update(). Because the main loop processes input before the per-frame Update, a touch tap (no preceding hover) read the stale value in MouseDown, so buttons whose action runs in MouseDown, such as the imitater on the seed chooser, ignored the first tap and only responded on the second.

Compute IsMouseOver() from the current WidgetManager mouse position instead, and derive mIsOver from it in Update() so the cached member still drives the hover-fade animation. The AwardScreen button preheat is now redundant, so drop it.