### PR TITLE
Fix: save mid-level game before Shutdown() halts music

### DIFF
--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -188,7 +188,6 @@ LawnApp::~LawnApp()
 	if (mBoard)
 	{
 		mBoardResult = BoardResult::BOARDRESULT_QUIT_APP;
-		mBoard->TryToSaveGame();
 		WriteCurrentUserConfig();
 		KillBoard();
 	}
@@ -320,6 +319,16 @@ void LawnApp::Shutdown()
 	if (!mShutdown)
 	{
 		SexyAppBase::Shutdown();
+	}
+}
+
+void LawnApp::ShutdownHook()
+{
+	// Save mid-level game while the music is still alive, before Shutdown() stops it.
+	if (mBoard)
+	{
+		mBoardResult = BoardResult::BOARDRESULT_QUIT_APP;
+		mBoard->TryToSaveGame();
 	}
 }
 

--- a/src/LawnApp.h
+++ b/src/LawnApp.h
@@ -204,6 +204,7 @@ public:
 	Dialog*							DoDialog(int theDialogId, bool isModal, const std::string& theDialogHeader, const std::string& theDialogLines, const std::string& theDialogFooter, int theButtonMode) override;
 	virtual Dialog*					DoDialogDelay(int theDialogId, bool isModal, const std::string& theDialogHeader, const std::string& theDialogLines, const std::string& theDialogFooter, int theButtonMode);
 	void							Shutdown() override;
+	void							ShutdownHook() override;
 	void							Init() override;
 	void							Start() override;
 	Dialog*							NewDialog(int theDialogId, bool isModal, const std::string& theDialogHeader, const std::string& theDialogLines, const std::string& theDialogFooter, int theButtonMode) override;


### PR DESCRIPTION
- Override LawnApp::ShutdownHook() to save the mid-level game while the
  music is still alive, before SexyAppBase::Shutdown() halts all music
  streams, so GetMusicOrder() returns a valid playback position.
- Previously the save ran in ~LawnApp, after StopAllMusic() had already
  halted the streams, so GetMusicOrder() returned -1 and a fresh-process
  reload started the music from the tune's default offset instead of the
  saved position.
- Remove the now-redundant TryToSaveGame() call from ~LawnApp;
  WriteCurrentUserConfig() and KillBoard() remain there.