### PR TITLE
Feat: load Android native libraries directly and handle edge-to-edge insets

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,16 +2,13 @@ plugins {
     id 'com.android.application'
 }
 
-// Since Kotlin 1.8 the jdk7/jdk8 classes live inside kotlin-stdlib itself.
-// Exclude the legacy split modules so transitive deps don't cause duplicates.
+// Avoid duplicate Kotlin stdlib classes (Kotlin 1.8+).
 configurations.all {
     exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk7'
     exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'
 }
 
-// Set usePrebuiltLibs=true (e.g., -PusePrebuiltLibs=true) when native .so files
-// are already placed under app/src/main/jniLibs/<abi>/ (used in CI).
-// Otherwise, Gradle will invoke CMake via externalNativeBuild.
+// -PusePrebuiltLibs=true packages prebuilt jniLibs (CI); otherwise build via CMake.
 def prebuilt = project.hasProperty('usePrebuiltLibs') && project.usePrebuiltLibs.toBoolean()
 
 android {
@@ -45,7 +42,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            // Use debug signing so the APK is directly installable without a release keystore
+            // Debug-signed so the APK installs without a release keystore
             signingConfig signingConfigs.debug
         }
     }
@@ -70,12 +67,6 @@ android {
 
     buildFeatures {
         prefab true
-    }
-
-    packaging {
-        jniLibs {
-            useLegacyPackaging true
-        }
     }
 
     lint {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
 
     <application
         android:allowBackup="true"
+        android:extractNativeLibs="false"
         android:appCategory="game"
         android:isGame="true"
         android:icon="@mipmap/ic_launcher"

--- a/android/app/src/main/java/io/github/wszqkzqk/pvzportable/ResourceImportActivity.java
+++ b/android/app/src/main/java/io/github/wszqkzqk/pvzportable/ResourceImportActivity.java
@@ -31,9 +31,13 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.EdgeToEdge;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.documentfile.provider.DocumentFile;
 
 import java.io.BufferedOutputStream;
@@ -91,7 +95,13 @@ public class ResourceImportActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
         setContentView(R.layout.activity_resource_import);
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content), (v, insets) -> {
+            Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(bars.left, bars.top, bars.right, bars.bottom);
+            return insets;
+        });
 
         gameDir = getExternalFilesDir(null);
         if (gameDir != null && !gameDir.exists()) gameDir.mkdirs();


### PR DESCRIPTION
This pull request includes several improvements to the Android build configuration and user interface, focusing on modernizing packaging settings, enhancing window insets handling, and updating manifest attributes. The main changes are grouped below:

**Build configuration and packaging updates:**

* Simplified and clarified comments regarding Kotlin stdlib exclusions and the use of prebuilt JNI libraries in `android/app/build.gradle`, making the configuration easier to understand and maintain.
* Removed the `packaging.jniLibs.useLegacyPackaging` block from `android/app/build.gradle`, reflecting a shift to modern native library packaging practices.
* Updated the release build type comment for clarity, indicating that debug signing is used for easier APK installation.

**Manifest and native library extraction:**

* Added `android:extractNativeLibs="false"` to the `<application>` tag in `AndroidManifest.xml`, ensuring that native libraries are not extracted at runtime and are instead loaded directly from the APK, which is recommended for modern Android apps.

**UI and system bar handling:**

* Integrated AndroidX Edge-to-Edge APIs in `ResourceImportActivity.java` to provide a more immersive UI experience by handling system bar insets and applying appropriate padding. [[1]](diffhunk://#diff-6c4185c462fdb3f8dd8accd7c14798012acce9adc6a89440fce876d440e104faR34-R40) [[2]](diffhunk://#diff-6c4185c462fdb3f8dd8accd7c14798012acce9adc6a89440fce876d440e104faR98-R104)