### PR TITLE
Fix: handle UTF-8 whitespace by code point in Sexy::Trim

### DIFF
--- a/src/SexyAppFramework/Common.cpp
+++ b/src/SexyAppFramework/Common.cpp
@@ -58,6 +58,22 @@ static inline void SexyLogV(SDL_LogPriority thePriority, const char* theFormat, 
 	SDL_LogMessage(SDL_LOG_CATEGORY_APPLICATION, thePriority, "%s", aBuffer.c_str());
 }
 
+static inline bool IsUnicodeSpace(char32_t theChar)
+{
+	switch (theChar)
+	{
+	case 0x0085: case 0x00A0: case 0x1680:
+	case 0x2000: case 0x2001: case 0x2002: case 0x2003:
+	case 0x2004: case 0x2005: case 0x2006: case 0x2007:
+	case 0x2008: case 0x2009: case 0x200A:
+	case 0x2028: case 0x2029: case 0x202F: case 0x205F:
+	case 0x3000:
+		return true;
+	default:
+		return theChar < 0x80 && std::isspace(static_cast<unsigned char>(theChar));
+	}
+}
+
 void Sexy::PrintF(const char *text, ...)
 {
 	va_list args;
@@ -147,17 +163,36 @@ std::string Sexy::Trim(std::string_view theString)
 		return std::string(theString);
 
 	size_t start = 0;
-	while (start < theString.size() && std::isspace((unsigned char)theString[start]))
-		++start;
+	while (start < theString.size())
+	{
+		size_t aOffset = start;
+		char32_t aChar = 0;
+		if (!UTF8DecodeNext(theString, aOffset, aChar))
+			break;
+		if (!IsUnicodeSpace(aChar))
+			break;
+		start = aOffset;
+	}
 
-	if (start == theString.size())
+	if (start >= theString.size())
 		return std::string();
 
-	size_t end = theString.size() - 1;
-	while (end > start && std::isspace((unsigned char)theString[end]))
-		--end;
+	size_t end = theString.size();
+	while (end > start)
+	{
+		size_t aCharStart = end - 1;
+		while (aCharStart > start && (static_cast<unsigned char>(theString[aCharStart]) & 0xC0) == 0x80)
+			--aCharStart;
+		size_t aOffset = aCharStart;
+		char32_t aChar = 0;
+		if (!UTF8DecodeNext(theString, aOffset, aChar) || aOffset != end)
+			break;
+		if (!IsUnicodeSpace(aChar))
+			break;
+		end = aCharStart;
+	}
 
-	return std::string(theString.substr(start, end - start + 1));
+	return std::string(theString.substr(start, end - start));
 }
 
 bool Sexy::StringToInt(const std::string& theString, int* theIntVal)


### PR DESCRIPTION
The Chinese LawnStrings.txt is stored as UTF-16LE, and a few TREE_OF_WISDOM values carry a trailing U+00A0 (NO-BREAK SPACE). Buffer::ToUTF8String converts the file to UTF-8 (U+00A0 -> C2 A0), but Sexy::Trim stripped only ASCII whitespace via std::isspace, so the multibyte NBSP survived into rendering. The Chinese BrianneTod16 font happens to include a .notdef glyph for U+00A0, so it drew as a tofu box at the end of the sentence. The English strings have no trailing NBSP and were unaffected.

The original binary parses LawnStrings as UTF-16LE and trims with the wide iswspace, where iswspace(0x00A0) is true, so it never shows the box; the portable UTF-8 path lost that wide whitespace semantics.

Decode by code point in Sexy::Trim and treat the Unicode White_Space set as whitespace, matching the wide iswspace behavior. Mid-text non-breaking spaces are preserved.