### PR TITLE
Fix: join loading thread instead of detaching it

### DIFF
--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -408,6 +408,8 @@ SexyAppBase::~SexyAppBase()
 {
 	Shutdown();
 
+	WaitForLoadingThread();
+
 	DialogMap::iterator aDialogItr = mDialogMap.begin();
 	while (aDialogItr != mDialogMap.end())
 	{
@@ -446,8 +448,6 @@ SexyAppBase::~SexyAppBase()
 			mSysCursors[aCursorIdx] = nullptr;
 		}
 	}
-
-	WaitForLoadingThread();	
 
 	gSexyAppBase = nullptr;
 
@@ -914,16 +914,8 @@ std::string SexyAppBase::GetProductVersion(const std::string& thePath)
 
 void SexyAppBase::WaitForLoadingThread()
 {
-#ifdef __EMSCRIPTEN__
-	return;
-#endif
-	int ms = 20;
-
-	timespec ts;
-	ts.tv_sec = ms / 1000;
-	ts.tv_nsec = (ms % 1000) * 1000000;
-	while ((mLoadingThreadStarted) && (!mLoadingThreadCompleted))
-		nanosleep(&ts, &ts);
+	if (mLoadingThread.joinable())
+		mLoadingThread.join();
 }
 
 void SexyAppBase::SetCursorImage(int theCursorNum, Image* theImage)
@@ -2282,7 +2274,7 @@ void SexyAppBase::StartLoadingThread()
 		LoadingThreadProcStub(this);
 #else
 		//_beginthread(LoadingThreadProcStub, 0, this);
-		std::thread(LoadingThreadProcStub, this).detach();
+		mLoadingThread = std::thread(LoadingThreadProcStub, this); // keep joinable: detach() throws on devkitA64/libnx
 #endif
 	}
 }

--- a/src/SexyAppFramework/SexyAppBase.h
+++ b/src/SexyAppFramework/SexyAppBase.h
@@ -188,6 +188,7 @@ public:
 	DialogMap				mDialogMap;
 	DialogList				mDialogList;
 	std::thread::id			mPrimaryThreadId;
+	std::thread				mLoadingThread;
 	bool					mSEHOccured;
 	bool					mShutdown;
 	bool					mExitToTop;


### PR DESCRIPTION
std::thread::detach() throws on devkitA64 (libnx), destroying the still-joinable temporary and calling std::terminate() mid-loading, which crashes the Switch port (#196).

Keep the loading thread as a member and join it in WaitForLoadingThread() (replacing the 20 ms polling loop), and move the destructor's wait ahead of subsystem teardown so the loading thread can no longer outlive mResourceManager.