### PR TITLE
feat: NixOS 下快速创建临时开发环境

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,20 @@ sudo pacman -S --needed base-devel cmake libjpeg-turbo libogg libopenmpt libpng 
 
 You can install the required dependencies using the following command:
 
+
 ```bash
 sudo apt install cmake ninja-build libogg-dev libjpeg-dev libopenmpt-dev libpng-dev libvorbis-dev libmpg123-dev libsdl2-dev
+```
+
+### NixOS
+
+You can install the required dependencies using the following command:
+> [!note]
+>
+> The dependencies will be auto delete when you exit the nix-shell.
+
+```bash
+nix-shell
 ```
 
 ### Windows (MSYS2 UCRT64)

--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ sudo pacman -S --needed base-devel cmake libjpeg-turbo libogg libopenmpt libpng 
 
 You can install the required dependencies using the following command:
 
-
 ```bash
 sudo apt install cmake ninja-build libogg-dev libjpeg-dev libopenmpt-dev libpng-dev libvorbis-dev libmpg123-dev libsdl2-dev
 ```

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,24 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    cmake
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = with pkgs; [
+    libogg
+    libjpeg
+    libopenmpt
+    libpng
+    libvorbis
+    libmpg123
+    SDL2
+  ];
+
+  shellHook = ''
+    echo "Welcome to the development environment!"
+    echo "All dependencies have been installed temporarily."
+  '';
+}


### PR DESCRIPTION
这样在 NixOS 下，运行命令`nix-shell`即可一键配置临时环境（依赖全部装好），开发完后退出终端即自动删除