### PR TITLE
Fix Android ZIP import path traversal

### DIFF
--- a/android/app/src/main/java/io/github/wszqkzqk/pvzportable/ResourceImportActivity.java
+++ b/android/app/src/main/java/io/github/wszqkzqk/pvzportable/ResourceImportActivity.java
@@ -181,7 +181,7 @@ public class ResourceImportActivity extends AppCompatActivity {
                     String name = stripCommonPrefix(entry.getName());
                     if (name == null) { zis.closeEntry(); continue; }
 
-                    File outFile = new File(gameDir, name);
+                    File outFile = resolveWithinGameDir(new File(gameDir, name));
                     File parent = outFile.getParentFile();
                     if (parent != null && !parent.exists()) parent.mkdirs();
 
@@ -234,6 +234,17 @@ public class ResourceImportActivity extends AppCompatActivity {
                name.startsWith("compiled/");
     }
 
+    private File resolveWithinGameDir(File candidate) throws IOException {
+        File canonicalGameDir = gameDir.getCanonicalFile();
+        File canonicalCandidate = candidate.getCanonicalFile();
+        String gameDirPath = canonicalGameDir.getPath();
+        String candidatePath = canonicalCandidate.getPath();
+        if (!candidatePath.equals(gameDirPath) && !candidatePath.startsWith(gameDirPath + File.separator)) {
+            throw new IOException("Import entry is outside the game directory");
+        }
+        return canonicalCandidate;
+    }
+
     private void importFromDirectory(Uri treeUri) {
         setWorking(true);
         new Thread(() -> {
@@ -274,16 +285,17 @@ public class ResourceImportActivity extends AppCompatActivity {
     }
 
     private void copyDocumentTree(DocumentFile src, File destDir) throws IOException {
-        if (!destDir.exists()) destDir.mkdirs();
+        File safeDestDir = resolveWithinGameDir(destDir);
+        if (!safeDestDir.exists()) safeDestDir.mkdirs();
         for (DocumentFile child : src.listFiles()) {
             if (child.isDirectory()) {
                 String name = child.getName();
                 if (name == null) continue;
-                copyDocumentTree(child, new File(destDir, name));
+                copyDocumentTree(child, resolveWithinGameDir(new File(safeDestDir, name)));
             } else {
                 String name = child.getName();
                 if (name == null) continue;
-                File outFile = new File(destDir, name);
+                File outFile = resolveWithinGameDir(new File(safeDestDir, name));
                 try (InputStream is = getContentResolver().openInputStream(child.getUri());
                      OutputStream os = new BufferedOutputStream(new FileOutputStream(outFile), BUFFER_SIZE)) {
                     if (is == null) continue;
@@ -387,7 +399,7 @@ public class ResourceImportActivity extends AppCompatActivity {
                     if (entry.isDirectory()) { zis.closeEntry(); continue; }
                     String name = entry.getName();
                     if (!name.startsWith("userdata/")) name = "userdata/" + name;
-                    File outFile = new File(gameDir, name);
+                    File outFile = resolveWithinGameDir(new File(gameDir, name));
                     File parent = outFile.getParentFile();
                     if (parent != null && !parent.exists()) parent.mkdirs();
                     try (OutputStream os = new BufferedOutputStream(new FileOutputStream(outFile), BUFFER_SIZE)) {


### PR DESCRIPTION
## Summary

- Reject resource and save archive entries that resolve outside the game directory.
- Apply the same containment check to names supplied through SAF directory imports.

## Cause

Archive and document names were written directly under the game directory. A traversal component could escape that directory and overwrite other app-writable files.

## Checks

- `git diff --check`
- Java canonical-path harness: valid properties and userdata paths accepted; traversal paths rejected.
