### PR TITLE
Fix: keep edit widgets visible above the soft keyboard on Android

### DIFF
--- a/android/app/src/main/java/io/github/wszqkzqk/pvzportable/PvZPortableActivity.java
+++ b/android/app/src/main/java/io/github/wszqkzqk/pvzportable/PvZPortableActivity.java
@@ -31,6 +31,7 @@ import android.view.Window;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
 import android.view.WindowManager;
+import android.widget.RelativeLayout;
 import android.window.OnBackInvokedCallback;
 import android.window.OnBackInvokedDispatcher;
 
@@ -57,6 +58,7 @@ public class PvZPortableActivity extends SDLActivity {
 
         super.onCreate(savedInstanceState);
         hideSystemUI();
+        setupImeLayoutAdjustment();
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             mBackCallback = this::dispatchBackToSdl;
@@ -110,6 +112,28 @@ public class PvZPortableActivity extends SDLActivity {
                 | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                 | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
                 | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION);
+        }
+    }
+
+    private void setupImeLayoutAdjustment() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING); // legacy adjustPan is inert with edge-to-edge on R+
+            View content = findViewById(android.R.id.content);
+            content.setOnApplyWindowInsetsListener((v, insets) -> {
+                int shift = 0;
+                if (insets.isVisible(WindowInsets.Type.ime()) && mTextEdit != null) {
+                    int imeBottom = insets.getInsets(WindowInsets.Type.ime()).bottom;
+                    View dummyEdit = mTextEdit; // DummyEdit is package-private, access via View
+                    if (dummyEdit.getLayoutParams() instanceof RelativeLayout.LayoutParams) {
+                        RelativeLayout.LayoutParams p = (RelativeLayout.LayoutParams) dummyEdit.getLayoutParams();
+                        shift = Math.max(0, p.topMargin + p.height - (v.getHeight() - imeBottom));
+                    }
+                }
+                mLayout.setTranslationY(-shift);
+                return v.onApplyWindowInsets(insets);
+            });
+        } else {
+            getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
         }
     }
 

--- a/src/SexyAppFramework/SexyAppBase.h
+++ b/src/SexyAppFramework/SexyAppBase.h
@@ -512,6 +512,7 @@ public:
 	void					InitInput();
 	bool					StartTextInput(std::string& theInput); // set theInput and return true if using soft keyboard capability and user pressed OK (e.g. Switch libnx swkbd)
 	void					StopTextInput();
+	void					SetTextInputRect(const Rect& theRect); // caret rect in logical coords; anchors the IME UI (candidate window, keyboard pan)
 	bool					Is3DAccelerated();
 	bool					Is3DAccelerationSupported();
 	bool					Is3DAccelerationRecommended();

--- a/src/SexyAppFramework/platform/3ds/Input.cpp
+++ b/src/SexyAppFramework/platform/3ds/Input.cpp
@@ -90,6 +90,11 @@ void SexyAppBase::StopTextInput()
 	
 }
 
+void SexyAppBase::SetTextInputRect(const Rect& theRect)
+{
+	(void)theRect;
+}
+
 bool SexyAppBase::ProcessDeferredMessages(bool singleMessage)
 {
 	/*

--- a/src/SexyAppFramework/platform/default/Input.cpp
+++ b/src/SexyAppFramework/platform/default/Input.cpp
@@ -342,6 +342,21 @@ void SexyAppBase::StopTextInput()
 #endif
 }
 
+void SexyAppBase::SetTextInputRect(const Rect& theRect)
+{
+	const Rect& aLogical = mWidgetManager->mMouseDestRect;
+	const Rect& aPresent = mWidgetManager->mMouseSourceRect; // presentation/window pixels, inverse of RemapMouse
+	if (aLogical.mWidth <= 0 || aLogical.mHeight <= 0)
+		return;
+
+	SDL_Rect aRect;
+	aRect.x = (theRect.mX - aLogical.mX) * aPresent.mWidth / aLogical.mWidth + aPresent.mX;
+	aRect.y = (theRect.mY - aLogical.mY) * aPresent.mHeight / aLogical.mHeight + aPresent.mY;
+	aRect.w = theRect.mWidth * aPresent.mWidth / aLogical.mWidth;
+	aRect.h = theRect.mHeight * aPresent.mHeight / aLogical.mHeight;
+	SDL_SetTextInputRect(&aRect);
+}
+
 bool SexyAppBase::ProcessDeferredMessages(bool singleMessage)
 {
 #ifdef __EMSCRIPTEN__

--- a/src/SexyAppFramework/platform/switch/Input.cpp
+++ b/src/SexyAppFramework/platform/switch/Input.cpp
@@ -84,6 +84,11 @@ void SexyAppBase::StopTextInput()
 	
 }
 
+void SexyAppBase::SetTextInputRect(const Rect& theRect)
+{
+	(void)theRect;
+}
+
 bool SexyAppBase::ProcessDeferredMessages(bool singleMessage)
 {
 	if (!appletMainLoop())

--- a/src/SexyAppFramework/widget/EditWidget.cpp
+++ b/src/SexyAppFramework/widget/EditWidget.cpp
@@ -46,6 +46,7 @@ EditWidget::EditWidget(int theId, EditListener* theEditListener)
 	mFont = nullptr;
 
 	mHadDoubleClick = false;
+	mHadFocusBeforePress = false;
 	mHilitePos = -1;
 	mLastModifyIdx = -1;
 	mLeftPos = 0;
@@ -118,6 +119,7 @@ std::string& EditWidget::GetDisplayString()
 
 bool EditWidget::WantsFocus()
 {
+	mHadFocusBeforePress = mHasFocus; // WidgetManager calls WantsFocus right before SetFocus on each press
 	return true;
 }
 
@@ -156,8 +158,8 @@ void EditWidget::Draw(Graphics* g) // Already translated
 				
 		if (i == 1)
 		{
-			int aCursorX = mFont->StringWidth(aString.substr(0, mCursorPos)) - mFont->StringWidth(aString.substr(0, mLeftPos));
-			int aHiliteX = aCursorX+2;
+			int aCursorX = GetCaretXOffset();
+			int aHiliteX = aCursorX + 2;
 			if ((mHilitePos != -1) && (mCursorPos != mHilitePos))
 				aHiliteX = mFont->StringWidth(aString.substr(0, mHilitePos)) - mFont->StringWidth(aString.substr(0, mLeftPos));
 			
@@ -206,6 +208,24 @@ void EditWidget::UpdateCaretPos()
 	//SetCaretPos(aPoint.mX,aPoint.mY);
 }
 
+int EditWidget::GetCaretXOffset()
+{
+	std::string &aString = GetDisplayString();
+	return mFont->StringWidth(aString.substr(0, mCursorPos)) - mFont->StringWidth(aString.substr(0, mLeftPos));
+}
+
+void EditWidget::UpdateTextInputArea()
+{
+	if (mFont == nullptr || mWidgetManager == nullptr || !mHasFocus) // FocusCursor may fire while unattached or unfocused
+		return;
+
+	int aCursorX = std::min(std::max(0, GetCaretXOffset()), mWidth-8);
+
+	Point anAbsPos = GetAbsPos();
+	int aTextY = anAbsPos.mY + (mHeight - mFont->GetHeight())/2; // match where the caret is drawn
+	mWidgetManager->mApp->SetTextInputRect(Rect(anAbsPos.mX + 4 + aCursorX, aTextY, 1, mFont->GetHeight()));
+}
+
 void EditWidget::GotFocus()
 {
 	Widget::GotFocus();
@@ -213,6 +233,8 @@ void EditWidget::GotFocus()
 	mShowingCursor = true;
 	mBlinkAcc = 0;
 	MarkDirty();
+
+	UpdateTextInputArea(); // set before StartTextInput so the platform anchors the IME upfront
 
 	std::string value;
 	bool wrote = mWidgetManager->mApp->StartTextInput(value);
@@ -612,11 +634,21 @@ void EditWidget::FocusCursor(bool bigJump)
 			MarkDirty();
 		}
 	}
+
+	UpdateTextInputArea();
 }
 
 void EditWidget::MouseDown(int x, int y, int theBtnNum, int theClickCount)
 {
 	Widget::MouseDown(x, y, theBtnNum, theClickCount);
+
+	if (mHadFocusBeforePress) // restart the session on a repeat press; the first press goes through GotFocus
+	{
+		std::string value;
+		bool wrote = mWidgetManager->mApp->StartTextInput(value);
+		if (wrote)
+			SetText(value);
+	}
 
 	mHilitePos = -1;
 	mCursorPos = GetCharAt(x, y);

--- a/src/SexyAppFramework/widget/EditWidget.h
+++ b/src/SexyAppFramework/widget/EditWidget.h
@@ -63,6 +63,7 @@ public:
 	bool					mShowingCursor;
 	bool					mDrawSelOverride; // set this to true to draw selected text even when not in focus
 	bool					mHadDoubleClick;	// Used to fix a bug with double clicking to hilite a word after the widget manager started calling mouse drag before mouse down/up events
+	bool					mHadFocusBeforePress; // mHasFocus snapshot taken in WantsFocus (pre-SetFocus)
 	int						mCursorPos;
 	int						mHilitePos;
 	int						mBlinkAcc;
@@ -83,6 +84,8 @@ protected:
 	std::string&			GetDisplayString();
 	virtual void			HiliteWord();
 	void					UpdateCaretPos();
+	void					UpdateTextInputArea();
+	int						GetCaretXOffset();
 
 public:
 	virtual void			SetFont(_Font* theFont, _Font* theWidthCheckFont = nullptr);


### PR DESCRIPTION
SDL's Android backend pans the window so the view placed at the text
input rect stays above the IME, but the app never set the rect, so the
pan had no anchor and the keyboard covered edit widgets. Tapping an
already-focused edit widget could not reopen a dismissed keyboard
either, because SetFocus does not refire for the same widget.

- Feed the caret rect (logical coords) to SDL_SetTextInputRect via a
  new SexyAppBase::SetTextInputRect, refreshed from
  EditWidget::GotFocus/FocusCursor; it also anchors the IME candidate
  window on desktop and enables keyboard avoidance on iOS
- Restart the text input session when an already-focused edit widget
  is tapped, so a dismissed soft keyboard re-opens
- With edge-to-edge (decorFitsSystemWindows=false) legacy adjustPan
  is inert on Android 11+, so PvZPortableActivity pans the content
  itself from WindowInsets.Type.ime() (adjustNothing), falling back
  to legacy adjustPan on older releases