### PR TITLE
Fix: write challenge records to the correct profile in AddPreviewProfiles

### DIFF
--- a/src/Lawn/Widget/GameSelector.cpp
+++ b/src/Lawn/Widget/GameSelector.cpp
@@ -1180,7 +1180,7 @@ void GameSelector::KeyChar(char theChar)
 		mApp->mPlayerInfo->mHasUnlockedPuzzleMode = true;
 		mApp->mPlayerInfo->mHasUnlockedSurvivalMode = true;
 
-		for (int i = 1; i < 100; i++)
+		for (int i = 1; i <= 100; i++)
 			if (i != static_cast<int>(GameMode::GAMEMODE_TREE_OF_WISDOM) && i != static_cast<int>(GameMode::GAMEMODE_SCARY_POTTER_ENDLESS) &&
 				i != static_cast<int>(GameMode::GAMEMODE_PUZZLE_I_ZOMBIE_ENDLESS) && i != static_cast<int>(GameMode::GAMEMODE_SURVIVAL_ENDLESS_STAGE_3))
 				mApp->mPlayerInfo->mChallengeRecords[i - 1] = 20;
@@ -1480,10 +1480,10 @@ void GameSelector::AddPreviewProfiles()
 		aProfile->mPurchases[StoreItem::STORE_ITEM_TREE_OF_WISDOM] = 1;
 
 		aProfile->mChallengeRecords[static_cast<int>(GameMode::GAMEMODE_TREE_OF_WISDOM) - 1] = 1;
-		for (int i = 1; i < 100; i++)
+		for (int i = 1; i <= 100; i++)
 			if (i != static_cast<int>(GameMode::GAMEMODE_TREE_OF_WISDOM) && i != static_cast<int>(GameMode::GAMEMODE_SCARY_POTTER_ENDLESS) &&
 				i != static_cast<int>(GameMode::GAMEMODE_PUZZLE_I_ZOMBIE_ENDLESS) && i != static_cast<int>(GameMode::GAMEMODE_SURVIVAL_ENDLESS_STAGE_3))
-				mApp->mPlayerInfo->mChallengeRecords[i - 1] = 20;
+				aProfile->mChallengeRecords[i - 1] = 20;
 
 		aProfile->SaveDetails();
 	}


### PR DESCRIPTION
The Full Unlock block wrote records to mApp->mPlayerInfo (nullptr at the only call site) instead of the newly created profile. Also fix the loop bound to include the last record.