### PR TITLE
Feat: use timestamped demo file names and replay the newest by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,13 +314,13 @@ python scripts/pvzp-v4-converter.py import level.yaml ~/.local/io.github.wszqkzq
 
 ## Recording and Playing Back Gameplay
 
-The game can record a gameplay session into a `.dmo` demo file and replay it deterministically later. Demo files are written to the current working directory:
+The game can record a gameplay session into a `.dmo` demo file and replay it deterministically later. Automatically named demo files are written to the current working directory:
 
-- `-record` — record to a new file named after the current time, in the form `pvzp-YYYYMMDD-HHMMSS.dmo`; existing recordings are never overwritten.
-- `-play` — play back the newest recording.
-- `-playnum=<N>` — play back the N-th newest recording; `1` is the newest.
-- `-recnum=<N>` — record and keep only the newest `N` recordings.
-- `-demofile="<path>"` — use an explicit file for `-record` or `-play` instead.
+- `-record` — record to a file named after the current local time, in the form `pvzp-YYYYMMDD-HHMMSS[-N].dmo`.
+- `-play` — play back the first matching `pvzp-*.dmo` recording in descending timestamp/name order.
+- `-playnum=<N>` — play back the N-th recording in descending timestamp/name order; `1` selects the first.
+- `-recnum=<N>` — record and keep the first `N` files matching the automatic timestamp pattern in descending timestamp/name order; other `pvzp-*.dmo` files are left untouched.
+- `-demofile="<path>"` — use an explicit file for `-record`, `-recnum`, `-play`, or `-playnum` instead; using an explicit target disables automatic retention.
 
 This feature is primarily designed for debugging and regression testing.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ A **cross-platform** community-driven reimplementation of Plants vs. Zombies: Ga
   - Theoretically supports big-endian platforms, but untested due to lack of hardware
 - [x] Unlockable **Hidden Limbo Page** with additional levels in the original game
   - To unlock it, open the Mini-Games / Puzzle / Survival selection screen and tap any blank area **5 times in rapid succession**
+- [x] **Record and deterministically replay** gameplay sessions — see [Recording and Playing Back Gameplay](#recording-and-playing-back-gameplay)
 
 This project supports the following platforms (including but not limited to):
 
@@ -310,6 +311,18 @@ python scripts/pvzp-v4-converter.py export ~/.local/io.github.wszqkzqk/PvZPortab
 mv ~/.local/io.github.wszqkzqk/PvZPortable/userdata/game1_13.v4 ~/.local/io.github.wszqkzqk/PvZPortable/userdata/game1_13.v4.bak
 python scripts/pvzp-v4-converter.py import level.yaml ~/.local/io.github.wszqkzqk/PvZPortable/userdata/game1_13.v4
 ```
+
+## Recording and Playing Back Gameplay
+
+The game can record a gameplay session into a `.dmo` demo file and replay it deterministically later. Demo files are written to the current working directory:
+
+- `-record` — record to a new file named after the current time, in the form `pvzp-YYYYMMDD-HHMMSS.dmo`; existing recordings are never overwritten.
+- `-play` — play back the newest recording.
+- `-playnum=<N>` — play back the N-th newest recording; `1` is the newest.
+- `-recnum=<N>` — record and keep only the newest `N` recordings.
+- `-demofile="<path>"` — use an explicit file for `-record` or `-play` instead.
+
+This feature is primarily designed for debugging and regression testing.
 
 ## Contributing
 

--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -84,8 +84,8 @@
 
 using namespace Sexy;
 
-const int DEMO_FILE_ID = 0x42BEEF78;
-const int DEMO_VERSION = 6; // v6: text input is recorded as UTF-8 (DEMO_KEY_TEXT)
+constexpr int DEMO_FILE_ID = 0x42BEEF78;
+constexpr int DEMO_VERSION = 6; // v6: text input is recorded as UTF-8 (DEMO_KEY_TEXT)
 
 SexyAppBase* Sexy::gSexyAppBase = nullptr;
 
@@ -387,6 +387,7 @@ SexyAppBase::SexyAppBase()
 
 	mDemoPrefix = "sexyapp";
 	mDemoFileName = mDemoPrefix + ".dmo";
+	mHasCustomDemoFile = false;
 	mDemoRecordFileLimit = 0;
 	mPlayingDemoBuffer = false;
 	mManualShutdown = false;
@@ -611,27 +612,47 @@ bool SexyAppBase::ReadDemoBuffer(std::string &theError)
 	return true;
 }
 
-// Lists theDemoPrefix + "-*.dmo" files newest first; zero-padded timestamps sort chronologically by name
-static void FindDemoFiles(std::string_view theDemoPrefix, std::vector<std::string>& theFiles)
+// Matches the reserved automatic naming pattern: theDemoPrefix + "-YYYYMMDD-HHMMSS[-N].dmo"
+static bool IsStampedDemoFileName(std::string_view theDemoPrefix, std::string_view theName)
 {
-	theFiles.clear();
+	const size_t aStampLen = theDemoPrefix.size() + 16; // "-YYYYMMDD-HHMMSS"
+	if (theName.size() < aStampLen + 4 || !theName.starts_with(theDemoPrefix) || !theName.ends_with(".dmo"))
+		return false;
+
+	auto aDigits = [](std::string_view theStr) {
+		return !theStr.empty() && std::all_of(theStr.begin(), theStr.end(), [](char c) { return c >= '0' && c <= '9'; });
+	};
+	const std::string_view aStamp(theName.data() + theDemoPrefix.size(), 16);
+	if (aStamp[0] != '-' || aStamp[9] != '-' || !aDigits(aStamp.substr(1, 8)) || !aDigits(aStamp.substr(10, 6)))
+		return false;
+
+	const std::string_view aSuffix(theName.data() + aStampLen, theName.size() - aStampLen - 4);
+	return aSuffix.empty() || (aSuffix[0] == '-' && aDigits(aSuffix.substr(1)));
+}
+
+static std::vector<std::string> FindDemoFiles(std::string_view theDemoPrefix, bool theStampedOnly = false)
+{
+	std::vector<std::string> aFiles;
 
 	const std::string aFilter = std::string(theDemoPrefix) + '-';
 	std::error_code anError;
 	for (const std::filesystem::directory_entry& anEntry : std::filesystem::directory_iterator(".", anError))
 	{
+		std::error_code aTypeError;
 		std::string aName = PathToU8(anEntry.path().filename());
-		if (aName.starts_with(aFilter) && aName.ends_with(".dmo"))
-			theFiles.push_back(aName);
+		if (anEntry.is_regular_file(aTypeError) && aName.starts_with(aFilter) && aName.ends_with(".dmo") &&
+			(!theStampedOnly || IsStampedDemoFileName(theDemoPrefix, aName))) // automatic management is stamped-only; playback is permissive
+			aFiles.push_back(aName);
 	}
 
 	const size_t aStampLen = theDemoPrefix.size() + 16; // "-YYYYMMDD-HHMMSS"
 	auto aKeyOf = [aStampLen](const std::string& theName) {
 		return std::make_tuple(std::string_view(theName).substr(0, aStampLen), theName.size(), std::string_view(theName));
 	};
-	std::sort(theFiles.begin(), theFiles.end(), [&aKeyOf](const std::string& theA, const std::string& theB) {
-		return aKeyOf(theA) > aKeyOf(theB); // newest first: stamp, then longer (suffixed) name, then lexicographic
+	std::sort(aFiles.begin(), aFiles.end(), [&aKeyOf](const std::string& theA, const std::string& theB) {
+		return aKeyOf(theA) > aKeyOf(theB); // stamp, then longer (suffixed) name, then lexicographic
 	});
+	return aFiles;
 }
 
 void SexyAppBase::WriteDemoBuffer()
@@ -678,10 +699,10 @@ void SexyAppBase::WriteDemoBuffer()
 
 			aFile.write(reinterpret_cast<const char*>(mDemoBuffer.GetDataPtr()), mDemoBuffer.GetDataLen());
 			aFile.close();
-			if (aFile && mDemoRecordFileLimit != 0)
+			// Prune only files matching the automatic naming pattern; explicit targets never trigger retention
+			if (aFile && mDemoRecordFileLimit != 0 && !mHasCustomDemoFile && IsStampedDemoFileName(mDemoPrefix, mDemoFileName))
 			{
-				std::vector<std::string> aDemoFiles;
-				FindDemoFiles(mDemoPrefix, aDemoFiles);
+				auto aDemoFiles = FindDemoFiles(mDemoPrefix, true);
 				for (size_t i = mDemoRecordFileLimit; i < aDemoFiles.size(); ++i)
 				{
 					std::error_code anError;
@@ -3354,8 +3375,7 @@ static std::string GetTimestampedDemoFileName(std::string_view theDemoPrefix)
 		aNowTM.tm_year + 1900, aNowTM.tm_mon + 1, aNowTM.tm_mday, aNowTM.tm_hour, aNowTM.tm_min, aNowTM.tm_sec);
 	std::string aName = aBaseName + ".dmo";
 	const std::string aSuffixPrefix = aBaseName + '-';
-	std::vector<std::string> aDemoFiles;
-	FindDemoFiles(theDemoPrefix, aDemoFiles);
+	auto aDemoFiles = FindDemoFiles(theDemoPrefix, true);
 	for (const std::string& aFileName : aDemoFiles)
 	{
 		if (aFileName == aName)
@@ -3369,48 +3389,32 @@ static std::string GetTimestampedDemoFileName(std::string_view theDemoPrefix)
 
 void SexyAppBase::HandleCmdLineParam(const std::string& theParamName, const std::string& theParamValue)
 {
-	if (theParamName == "-play")
+	if (theParamName == "-play" || theParamName == "-playnum")
 	{
-		if (mDemoFileName == mDemoPrefix + ".dmo") // no -demofile given: play the newest recording
+		if (!mHasCustomDemoFile)
 		{
-			std::vector<std::string> aDemoFiles;
-			FindDemoFiles(mDemoPrefix, aDemoFiles);
+			auto aDemoFiles = FindDemoFiles(mDemoPrefix);
 			if (!aDemoFiles.empty())
-				mDemoFileName = aDemoFiles.front();
+			{
+				size_t aIndex = 0; // -play: first; -playnum: N-th in timestamp/name order
+				if (theParamName == "-playnum")
+					aIndex = static_cast<size_t>(std::max(atoi(theParamValue.c_str()), 1) - 1);
+				mDemoFileName = aDemoFiles[std::min(aIndex, aDemoFiles.size() - 1)];
+			}
 		}
 		mPlayingDemoBuffer = true;
 		mRecordingDemoBuffer = false;
 	}
-	else if (theParamName == "-recnum")
+	else if (theParamName == "-record" || theParamName == "-recnum")
 	{
-		int aNum = atoi(theParamValue.c_str());
-		if (aNum<=0)
-			aNum=5;
-		mDemoRecordFileLimit = static_cast<uint>(aNum);
-
-		mDemoFileName = GetTimestampedDemoFileName(mDemoPrefix);
-		if (mDemoFileName.length() < 2)
+		if (theParamName == "-recnum") // keep only the first N recordings in timestamp/name order
 		{
-			mDemoFileName = GetAppDataPath(mDemoFileName);
+			int aNum = atoi(theParamValue.c_str());
+			if (aNum<=0)
+				aNum=5;
+			mDemoRecordFileLimit = static_cast<uint>(aNum);
 		}
-		mRecordingDemoBuffer = true;
-		mPlayingDemoBuffer = false;
-	}
-	else if (theParamName == "-playnum")
-	{
-		int aNum = std::max(atoi(theParamValue.c_str()), 1);
-
-		std::vector<std::string> aDemoFiles;
-		FindDemoFiles(mDemoPrefix, aDemoFiles);
-		if (static_cast<size_t>(aNum) <= aDemoFiles.size())
-			mDemoFileName = aDemoFiles[aNum - 1]; // N-th newest
-		mRecordingDemoBuffer = false;
-		mPlayingDemoBuffer = true;
-	}
-	else if (theParamName == "-record")
-	{
-		mDemoRecordFileLimit = 0;
-		if (mDemoFileName == mDemoPrefix + ".dmo") // no -demofile given: timestamp to avoid overwriting
+		if (!mHasCustomDemoFile) // choose an automatic timestamped name
 			mDemoFileName = GetTimestampedDemoFileName(mDemoPrefix);
 		mRecordingDemoBuffer = true;
 		mPlayingDemoBuffer = false;
@@ -3418,6 +3422,7 @@ void SexyAppBase::HandleCmdLineParam(const std::string& theParamName, const std:
 	else if (theParamName == "-demofile")
 	{
 		mDemoFileName = theParamValue;
+		mHasCustomDemoFile = true;
 		if (mDemoFileName.length() < 2)
 		{
 			mDemoFileName = GetAppDataPath(mDemoFileName);

--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -27,6 +27,7 @@
 //#define SEXY_MEMTRACE
 
 #include <string>
+#include <string_view>
 #include <fstream>
 #include <time.h>
 #include <math.h>
@@ -36,6 +37,8 @@
 #include <cstring>
 #include <chrono>
 #include <filesystem>
+#include <system_error>
+#include <tuple>
 
 #include <SDL.h>
 
@@ -384,6 +387,7 @@ SexyAppBase::SexyAppBase()
 
 	mDemoPrefix = "sexyapp";
 	mDemoFileName = mDemoPrefix + ".dmo";
+	mDemoRecordFileLimit = 0;
 	mPlayingDemoBuffer = false;
 	mManualShutdown = false;
 	mRecordingDemoBuffer = false;
@@ -607,6 +611,29 @@ bool SexyAppBase::ReadDemoBuffer(std::string &theError)
 	return true;
 }
 
+// Lists theDemoPrefix + "-*.dmo" files newest first; zero-padded timestamps sort chronologically by name
+static void FindDemoFiles(std::string_view theDemoPrefix, std::vector<std::string>& theFiles)
+{
+	theFiles.clear();
+
+	const std::string aFilter = std::string(theDemoPrefix) + '-';
+	std::error_code anError;
+	for (const std::filesystem::directory_entry& anEntry : std::filesystem::directory_iterator(".", anError))
+	{
+		std::string aName = PathToU8(anEntry.path().filename());
+		if (aName.starts_with(aFilter) && aName.ends_with(".dmo"))
+			theFiles.push_back(aName);
+	}
+
+	const size_t aStampLen = theDemoPrefix.size() + 16; // "-YYYYMMDD-HHMMSS"
+	auto aKeyOf = [aStampLen](const std::string& theName) {
+		return std::make_tuple(std::string_view(theName).substr(0, aStampLen), theName.size(), std::string_view(theName));
+	};
+	std::sort(theFiles.begin(), theFiles.end(), [&aKeyOf](const std::string& theA, const std::string& theB) {
+		return aKeyOf(theA) > aKeyOf(theB); // newest first: stamp, then longer (suffixed) name, then lexicographic
+	});
+}
+
 void SexyAppBase::WriteDemoBuffer()
 {
 	if (mRecordingDemoBuffer)
@@ -650,6 +677,17 @@ void SexyAppBase::WriteDemoBuffer()
 			aFile.write(reinterpret_cast<const char*>(&aDemoLength), sizeof(aDemoLength));
 
 			aFile.write(reinterpret_cast<const char*>(mDemoBuffer.GetDataPtr()), mDemoBuffer.GetDataLen());
+			aFile.close();
+			if (aFile && mDemoRecordFileLimit != 0)
+			{
+				std::vector<std::string> aDemoFiles;
+				FindDemoFiles(mDemoPrefix, aDemoFiles);
+				for (size_t i = mDemoRecordFileLimit; i < aDemoFiles.size(); ++i)
+				{
+					std::error_code anError;
+					std::filesystem::remove(PathFromU8(aDemoFiles[i]), anError);
+				}
+			}
 		}		
 	}
 }
@@ -3307,19 +3345,39 @@ void SexyAppBase::ParseCmdLine(const std::string& theCmdLine)
 	}
 }
 
-static int GetMaxDemoFileNum(const std::string& theDemoPrefix, int theMaxToKeep, bool doErase)
+static std::string GetTimestampedDemoFileName(std::string_view theDemoPrefix)
 {
-	(void)theDemoPrefix;
-	(void)theMaxToKeep;
-	(void)doErase;
-	// Demo file enumeration not implemented
-	return 0;
+	time_t aNow = time(nullptr);
+	tm aNowTM = *localtime(&aNow);
+
+	std::string aBaseName = StrFormat((std::string(theDemoPrefix) + "-%04d%02d%02d-%02d%02d%02d").c_str(),
+		aNowTM.tm_year + 1900, aNowTM.tm_mon + 1, aNowTM.tm_mday, aNowTM.tm_hour, aNowTM.tm_min, aNowTM.tm_sec);
+	std::string aName = aBaseName + ".dmo";
+	const std::string aSuffixPrefix = aBaseName + '-';
+	std::vector<std::string> aDemoFiles;
+	FindDemoFiles(theDemoPrefix, aDemoFiles);
+	for (const std::string& aFileName : aDemoFiles)
+	{
+		if (aFileName == aName)
+			return aBaseName + "-2.dmo";
+		if (aFileName.starts_with(aSuffixPrefix))
+			return StrFormat("%s-%d.dmo", aBaseName.c_str(), atoi(aFileName.c_str() + aSuffixPrefix.length()) + 1);
+	}
+
+	return aName;
 }
 
 void SexyAppBase::HandleCmdLineParam(const std::string& theParamName, const std::string& theParamValue)
 {
 	if (theParamName == "-play")
 	{
+		if (mDemoFileName == mDemoPrefix + ".dmo") // no -demofile given: play the newest recording
+		{
+			std::vector<std::string> aDemoFiles;
+			FindDemoFiles(mDemoPrefix, aDemoFiles);
+			if (!aDemoFiles.empty())
+				mDemoFileName = aDemoFiles.front();
+		}
 		mPlayingDemoBuffer = true;
 		mRecordingDemoBuffer = false;
 	}
@@ -3328,9 +3386,9 @@ void SexyAppBase::HandleCmdLineParam(const std::string& theParamName, const std:
 		int aNum = atoi(theParamValue.c_str());
 		if (aNum<=0)
 			aNum=5;
+		mDemoRecordFileLimit = static_cast<uint>(aNum);
 
-		int aDemoFileNum = GetMaxDemoFileNum(mDemoPrefix, aNum, true) + 1;
-		mDemoFileName = StrFormat((mDemoPrefix + "%d.dmo").c_str(), aDemoFileNum);
+		mDemoFileName = GetTimestampedDemoFileName(mDemoPrefix);
 		if (mDemoFileName.length() < 2)
 		{
 			mDemoFileName = GetAppDataPath(mDemoFileName);
@@ -3340,16 +3398,20 @@ void SexyAppBase::HandleCmdLineParam(const std::string& theParamName, const std:
 	}
 	else if (theParamName == "-playnum")
 	{
-		int aNum = atoi(theParamValue.c_str())-1;
-		aNum = std::max(aNum, 0);
+		int aNum = std::max(atoi(theParamValue.c_str()), 1);
 
-		int aDemoFileNum = GetMaxDemoFileNum(mDemoPrefix, aNum, false)-aNum;
-		mDemoFileName = StrFormat((mDemoPrefix + "%d.dmo").c_str(), aDemoFileNum);
+		std::vector<std::string> aDemoFiles;
+		FindDemoFiles(mDemoPrefix, aDemoFiles);
+		if (static_cast<size_t>(aNum) <= aDemoFiles.size())
+			mDemoFileName = aDemoFiles[aNum - 1]; // N-th newest
 		mRecordingDemoBuffer = false;
 		mPlayingDemoBuffer = true;
 	}
 	else if (theParamName == "-record")
 	{
+		mDemoRecordFileLimit = 0;
+		if (mDemoFileName == mDemoPrefix + ".dmo") // no -demofile given: timestamp to avoid overwriting
+			mDemoFileName = GetTimestampedDemoFileName(mDemoPrefix);
 		mRecordingDemoBuffer = true;
 		mPlayingDemoBuffer = false;
 	}

--- a/src/SexyAppFramework/SexyAppBase.h
+++ b/src/SexyAppFramework/SexyAppBase.h
@@ -303,6 +303,7 @@ public:
 	bool					mManualShutdown;
 	std::string				mDemoPrefix;
 	std::string				mDemoFileName;
+	uint					mDemoRecordFileLimit;
 	Buffer					mDemoBuffer;
 	int						mDemoLength;
 	int						mLastDemoMouseX;

--- a/src/SexyAppFramework/SexyAppBase.h
+++ b/src/SexyAppFramework/SexyAppBase.h
@@ -303,6 +303,7 @@ public:
 	bool					mManualShutdown;
 	std::string				mDemoPrefix;
 	std::string				mDemoFileName;
+	bool					mHasCustomDemoFile; // an explicit -demofile overrides automatic demo file selection
 	uint					mDemoRecordFileLimit;
 	Buffer					mDemoBuffer;
 	int						mDemoLength;


### PR DESCRIPTION
-record always wrote to the same pvzp.dmo, clobbering the previous recording, and the numbered-file mechanism behind -recnum/-playnum was an unimplemented stub.

- Recordings are now named pvzp-YYYYMMDD-HHMMSS.dmo, with a -N suffix to disambiguate same-second runs
- -play with no -demofile resolves the newest timestamped recording, falling back to the legacy fixed pvzp.dmo when none exists
- -recnum keeps only the newest N recordings and -playnum picks the N-th newest, making the previously stubbed flags functional
- Document the demo file flags in the README