### PR TITLE
Fix: make wall-clock time deterministic in demo sessions

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -142,7 +142,7 @@ Board::Board(LawnApp* theApp)
 	mIntervalDrawTime = 0;
 	mIntervalDrawCountStart = 0;
 	mPreloadTime = 0;
-	mGameID = time(0);
+	mGameID = mApp->GetNowTime();
 	mMinFPS = 1000.0f;
 	mGravesCleared = 0;
 	mPlantsEaten = 0;
@@ -180,6 +180,7 @@ Board::Board(LawnApp* theApp)
 	mAdvice = new MessageWidget(mApp);
 	mBackground = BackgroundType::BACKGROUND_1_DAY;
 	mMainCounter = 0;
+	mBoardUpdateCounter = 0;
 	mTutorialState = TutorialState::TUTORIAL_OFF;
 	mTutorialTimer = -1;
 	mTutorialParticleID = ParticleSystemID::PARTICLESYSTEMID_NULL;
@@ -1387,6 +1388,7 @@ void Board::GetZenButtonRect(GameObjectType theObjectType, Rect& theRect)
 void Board::InitLevel()
 {
 	mMainCounter = 0;
+	mBoardUpdateCounter = 0;
 	mEnableGraveStones = false;
 	mSodPosition = 0;
 	mPrevBoardResult = mApp->mBoardResult;
@@ -5811,6 +5813,7 @@ void Board::Update()
 	Widget::Update();
 	MarkDirty();
 
+	mBoardUpdateCounter++;
 	mCutScene->Update();
 	UpdateMousePosition();
 	if (mApp->mGameMode == GameMode::GAMEMODE_CHALLENGE_ZEN_GARDEN)
@@ -5886,7 +5889,7 @@ void Board::Update()
 	{
 		mApp->mPoolEffect->mPoolCounter++;
 	}
-	if (mBackground == BackgroundType::BACKGROUND_3_POOL && mPoolSparklyParticleID == ParticleSystemID::PARTICLESYSTEMID_NULL && mDrawCount > 0)
+	if (mBackground == BackgroundType::BACKGROUND_3_POOL && mPoolSparklyParticleID == ParticleSystemID::PARTICLESYSTEMID_NULL)
 	{
 		int aRenderPosition = MakeRenderOrder(RenderLayer::RENDER_LAYER_GROUND, 2, 0);
 		TodParticleSystem* aPoolParticle = mApp->AddTodParticle(450, 295, aRenderPosition, ParticleEffect::PARTICLE_POOL_SPARKLY);

--- a/src/Lawn/Board.h
+++ b/src/Lawn/Board.h
@@ -177,6 +177,7 @@ public:
 	int32_t							mNumWaves;
 	uint32_t						mMainCounter;
 	uint32_t						mEffectCounter;
+	uint32_t						mBoardUpdateCounter; // ticks since level start; unlike mMainCounter it also advances outside SCENE_PLAYING
 	uint32_t						mDrawCount;
 	int32_t							mRiseFromGraveCounter;
 	int32_t							mOutOfMoneyCounter;

--- a/src/Lawn/CutScene.cpp
+++ b/src/Lawn/CutScene.cpp
@@ -1432,7 +1432,7 @@ void CutScene::Update()
 		return;
 	}
 
-	if (mApp->mGameScene != GameScenes::SCENE_LEVEL_INTRO || mBoard->mDrawCount == 0)
+	if (mApp->mGameScene != GameScenes::SCENE_LEVEL_INTRO || mBoard->mBoardUpdateCounter <= 1) // the first frame is drawn after the first update tick, so defer one tick deterministically
 		return;
 
 	// 进行预加载

--- a/src/Lawn/LawnCommon.cpp
+++ b/src/Lawn/LawnCommon.cpp
@@ -142,10 +142,9 @@ std::string GetLegacySavedGameName(GameMode theGameMode, int theProfileId)
     return GetAppDataPath(StrFormat("userdata/game%d_%d.dat", theProfileId, static_cast<int>(theGameMode)));
 }
 
-int GetCurrentDaysSince2000()
+int GetCurrentDaysSince2000(time_t theTime)
 {
-    time_t aNow = time(0);
-    tm aNowTM = *localtime(&aNow);
+    tm aNowTM = *localtime(&theTime);
 
     int dy = aNowTM.tm_year - 100;
     return dy * 365 + (dy - 1) / 400 - (dy - 1) / 100 + (dy - 1) / 4 + aNowTM.tm_yday + 1;

--- a/src/Lawn/LawnCommon.h
+++ b/src/Lawn/LawnCommon.h
@@ -25,6 +25,7 @@
 #include "../ConstEnums.h"
 #include "graphics/Graphics.h"
 #include "widget//EditWidget.h"
+#include <time.h>
 
 using namespace Sexy;
 // using namespace std;
@@ -78,6 +79,6 @@ void						DrawEditBox(Graphics* g, EditWidget* theWidget);
 // ====================================================================================================
 std::string					GetSavedGameName(GameMode theGameMode, int theProfileId);
 std::string					GetLegacySavedGameName(GameMode theGameMode, int theProfileId);
-int							GetCurrentDaysSince2000();
+int							GetCurrentDaysSince2000(time_t theTime);
 
 #endif

--- a/src/Lawn/Widget/ChallengeScreen.cpp
+++ b/src/Lawn/Widget/ChallengeScreen.cpp
@@ -123,7 +123,7 @@ ChallengeScreen::ChallengeScreen(LawnApp* theApp, ChallengePage thePage)
 	mUnlockStateCounter = 0;
 	mLimboPageUnlocked = false;
 	mClickCount = 0;
-	mLastClickTime = 0;
+	mLastClickUpdateCnt = 0;
 	mLoadedResourceNames.push_back("DelayLoad_ChallengeScreen");
 
 	for (std::string& resource : mLoadedResourceNames)
@@ -770,13 +770,13 @@ void ChallengeScreen::MouseDown(int x, int y, int theClickCount)
 	if (mLimboPageUnlocked)
 		return;
 
-	constexpr int MAX_GAP_MS = 200;
+	constexpr int MAX_GAP_TICKS = 20; // 200 ms at 100 update ticks/sec
 	constexpr int CLICKS_NEEDED = 5;
 
-	uint32_t aNow = SDL_GetTicks();
-	if (aNow - mLastClickTime > MAX_GAP_MS)
+	int aNow = mApp->mUpdateCount;
+	if (aNow - mLastClickUpdateCnt > MAX_GAP_TICKS)
 		mClickCount = 0;
-	mLastClickTime = aNow;
+	mLastClickUpdateCnt = aNow;
 	mClickCount++;
 	if (mClickCount >= CLICKS_NEEDED)
 	{

--- a/src/Lawn/Widget/ChallengeScreen.h
+++ b/src/Lawn/Widget/ChallengeScreen.h
@@ -56,7 +56,7 @@ public:
     float                       mLockShakeY;
     bool                        mLimboPageUnlocked;
     int                         mClickCount;
-    uint32_t                    mLastClickTime;
+    int                         mLastClickUpdateCnt;
 
 public:
     ChallengeScreen(LawnApp* theApp, ChallengePage thePage);

--- a/src/Lawn/Widget/StoreScreen.cpp
+++ b/src/Lawn/Widget/StoreScreen.cpp
@@ -216,7 +216,7 @@ bool StoreScreen::IsItemSoldOut(StoreItem theStoreItem)
     else if (theStoreItem == STORE_ITEM_BONUS_LAWN_MOWER)
         return aPlayer->mPurchases[STORE_ITEM_BONUS_LAWN_MOWER] >= 2;
     else if (IsPottedPlant(theStoreItem))
-        return mApp->mZenGarden->IsZenGardenFull(true) || aPlayer->mPurchases[theStoreItem] == GetCurrentDaysSince2000();
+        return mApp->mZenGarden->IsZenGardenFull(true) || aPlayer->mPurchases[theStoreItem] == GetCurrentDaysSince2000(mApp->GetNowTime());
     else return aPlayer->mPurchases[theStoreItem];
 
     unreachable();
@@ -988,7 +988,7 @@ void StoreScreen::PurchaseItem(StoreItem theStoreItem)
             }
             else if (theStoreItem == STORE_ITEM_STINKY_THE_SNAIL)
             {
-                uint32_t aTime = static_cast<uint32_t>(time(0));
+                uint32_t aTime = static_cast<uint32_t>(mApp->GetNowTime());
                 if (aTime == 0) aTime = 1;
                 mApp->mPlayerInfo->mPurchases[theStoreItem] = aTime;
             }
@@ -1039,7 +1039,7 @@ void StoreScreen::PurchaseItem(StoreItem theStoreItem)
                 mApp->mZenGarden->AddPottedPlant(&mPottedPlantSpecs);
                 mPottedPlantSpecs.InitializePottedPlant(SEED_MARIGOLD);
                 mPottedPlantSpecs.mDrawVariation = (DrawVariation)RandRangeInt(VARIATION_MARIGOLD_WHITE, VARIATION_MARIGOLD_LIGHT_GREEN);
-                mApp->mPlayerInfo->mPurchases[theStoreItem] = GetCurrentDaysSince2000();
+                mApp->mPlayerInfo->mPurchases[theStoreItem] = GetCurrentDaysSince2000(mApp->GetNowTime());
             }
             else
             {

--- a/src/Lawn/ZenGarden.cpp
+++ b/src/Lawn/ZenGarden.cpp
@@ -104,7 +104,7 @@ ZenGarden::ZenGarden()
     mApp = (LawnApp*)gSexyAppBase;
     mBoard = nullptr;
     mGardenType = GardenType::GARDEN_MAIN;
-    mNowTime = time(0);
+    mNowTime = time(nullptr); // constructed on the loading thread: GetNowTime() reads main-thread state; refreshed before any use
     mNowTM = *localtime(&mNowTime);
 }
 
@@ -284,7 +284,7 @@ PottedPlant* ZenGarden::PottedPlantFromIndex(intptr_t thePottedPlantIndex)
 void ZenGarden::ZenGardenInitLevel()
 {
     mBoard = mApp->mBoard;
-    mNowTime = time(0);
+    mNowTime = mApp->GetNowTime();
     mNowTM = *localtime(&mNowTime);
 
     for (int i = 0; i < mApp->mPlayerInfo->mNumPottedPlants; i++)
@@ -1725,8 +1725,8 @@ void ZenGarden::ZenGardenUpdate()
         return;
     }
 
-    // Cache time(0) and localtime() once per frame to avoid repeated syscalls
-    mNowTime = time(0);
+    // Cache the current time and localtime() once per frame to avoid repeated calls
+    mNowTime = mApp->GetNowTime();
     mNowTM = *localtime(&mNowTime);
 
     mApp->UpdateCrazyDave();
@@ -2374,7 +2374,7 @@ void ZenGarden::OpenStore()
     }
     else
     {
-        mNowTime = time(0);
+        mNowTime = mApp->GetNowTime();
         mNowTM = *localtime(&mNowTime);
 
         mApp->mMusic->MakeSureMusicIsPlaying(MusicTune::MUSIC_TUNE_ZEN_GARDEN);

--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -1278,6 +1278,9 @@ void LawnApp::Init()
 	if (mShutdown) // MakeWindow() failed
 		return;
 
+	if (mRecordingDemoBuffer || mPlayingDemoBuffer)
+		mAppRandSeed = mRandSeed; // demo sessions derive the app-level seed from the recorded one
+
 	// @Patoke: horrible debug checks, breaks the whole exe in release mode
 //#ifdef PVZ_DEBUG
 	TodAssertInitForApp();

--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -81,7 +81,7 @@
 using namespace Sexy;
 
 const int DEMO_FILE_ID = 0x42BEEF78;
-const int DEMO_VERSION = 3; // v3: demo-synced IO is main-thread only (no loading-thread commands in the stream)
+const int DEMO_VERSION = 4; // v4: header also carries the session start time for the demo-synced clock
 
 SexyAppBase* Sexy::gSexyAppBase = nullptr;
 
@@ -389,6 +389,7 @@ SexyAppBase::SexyAppBase()
 	mLastDemoMouseX = 0;
 	mLastDemoMouseY = 0;
 	mLastDemoUpdateCnt = 0;
+	mDemoStartTime = 0;
 	mDemoNeedsCommand = true;
 	mDemoLoadingComplete = false;
 	mDemoLength = 0;
@@ -510,6 +511,9 @@ bool SexyAppBase::ReadDemoBuffer(std::string &theError)
 	mRandSeed = FromLE32(mRandSeed);
 	SRand(mRandSeed);
 
+	if (!aFile.read(reinterpret_cast<char*>(&mDemoStartTime), sizeof(mDemoStartTime))) return false;
+	mDemoStartTime = FromLE64(mDemoStartTime);
+
 	ushort aStrLen = 4;
 	if (!aFile.read(reinterpret_cast<char*>(&aStrLen), sizeof(aStrLen))) return false;
 	aStrLen = std::min<ushort>(FromLE16(aStrLen), 255);
@@ -611,6 +615,9 @@ void SexyAppBase::WriteDemoBuffer()
 
 			uint32_t aRandSeed = ToLE32(mRandSeed);
 			aFile.write(reinterpret_cast<const char*>(&aRandSeed), sizeof(aRandSeed));
+
+			uint64_t aDemoStartTime = ToLE64(mDemoStartTime);
+			aFile.write(reinterpret_cast<const char*>(&aDemoStartTime), sizeof(aDemoStartTime));
 
 			ushort aStrLen = ToLE16(static_cast<uint16_t>(mProductVersion.length()));
 			aFile.write(reinterpret_cast<const char*>(&aStrLen), sizeof(aStrLen));		
@@ -3455,6 +3462,9 @@ void SexyAppBase::Init()
 	{
 		mRandSeed = SDL_GetTicks();
 		SRand(mRandSeed);
+
+		if (mRecordingDemoBuffer)
+			mDemoStartTime = static_cast<uint64_t>(time(nullptr)); // synthetic clock base; mUpdateCount is still 0 here
 	}
 
 	srand(SDL_GetTicks());

--- a/src/SexyAppFramework/SexyAppBase.h
+++ b/src/SexyAppFramework/SexyAppBase.h
@@ -33,6 +33,7 @@
 #include "misc/Buffer.h"
 #include <mutex>
 #include <thread>
+#include <time.h>
 #include <set>
 #include <string_view>
 #include "graphics/SharedImage.h"
@@ -306,6 +307,7 @@ public:
 	int						mLastDemoMouseX;
 	int						mLastDemoMouseY;
 	int						mLastDemoUpdateCnt;
+	uint64_t				mDemoStartTime; // wall clock at session start, base of the demo-synced clock
 	bool					mDemoNeedsCommand;
 	bool					mDemoIsShortCmd;
 	int						mDemoCmdNum;
@@ -394,6 +396,14 @@ protected:
 	inline bool				IsOnPrimaryThread() const { return std::this_thread::get_id() == mPrimaryThreadId; } // demo-synced IO is primary-thread only
 
 public:
+	// Demo-synced wall clock: real time normally; session start time advanced by update ticks during demo record/playback
+	inline time_t			GetNowTime() const
+	{
+		if (mRecordingDemoBuffer || mPlayingDemoBuffer)
+			return static_cast<time_t>(mDemoStartTime) + mUpdateCount / 100;
+		return time(nullptr);
+	}
+
 	SexyAppBase();
 	virtual ~SexyAppBase();
 


### PR DESCRIPTION
Route all demo-visible time queries through a demo-synced clock (GetNowTime): real time normally, session start time advanced by update ticks during record/playback. The demo file header (v4) now carries the session start time, and draw-timing-dependent checks (board preload gate, pool sparkle, limbo unlock gap) are keyed to update ticks instead so replay produces identical state.