### PR TITLE
fix(ci): bundle SDL3 in macOS artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,11 @@ jobs:
         echo "Bundling dependencies..."
         dylibbundler -of -b -x dist/pvz-portable -d dist/libs -p @executable_path/libs/
 
+        # Homebrew's SDL2 formula is sdl2-compat, which loads SDL3 at runtime.
+        # dylibbundler cannot discover libraries loaded with dlopen(), so bundle it explicitly.
+        cp -L "$(brew --prefix sdl3)/lib/libSDL3.dylib" dist/libs/libSDL3.dylib
+
+        codesign --force -s - dist/libs/libSDL3.dylib
         codesign --force --deep -s - dist/pvz-portable
 
     - name: Upload Artifact


### PR DESCRIPTION
## Summary

- bundle Homebrew's SDL3 dylib in the macOS portable artifact
- ad-hoc sign the copied SDL3 library alongside the executable

## Root cause

Homebrew's `sdl2` formula now resolves to `sdl2-compat`, which loads SDL3 at runtime with `dlopen()`. `dylibbundler` only discovers linked Mach-O dependencies, so the existing workflow packages `libSDL2-2.0.0.dylib` but omits `libSDL3.dylib`. The resulting artifact exits at startup with `Failed loading SDL3 library.`

## Impact

The macOS artifact is self-contained again and can launch without a system-level SDL3 installation.

## Validation

- parsed `.github/workflows/ci.yml` as YAML
- ran `git diff --check`
- simulated the final artifact layout on arm64 macOS 15.5
- confirmed dyld loaded `libs/libSDL3.dylib` and the game rendered its first frame
