### PR TITLE
Fix: bundle SDL3 in macOS CI artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,10 @@ jobs:
         echo "Bundling dependencies..."
         dylibbundler -of -b -x dist/pvz-portable -d dist/libs -p @executable_path/libs/
 
+        # Homebrew's SDL2 formula is sdl2-compat, which loads SDL3 at runtime.
+        # dylibbundler cannot discover libraries loaded with dlopen(), so bundle it explicitly.
+        install -m 755 "$(brew --prefix sdl3)/lib/libSDL3.dylib" dist/libs/libSDL3.dylib
+
         codesign --force --deep -s - dist/pvz-portable
 
     - name: Upload Artifact


### PR DESCRIPTION
Homebrew's sdl2 formula is now sdl2-compat, which loads SDL3 at runtime via dlopen() and is invisible to dylibbundler. Bundle libSDL3.dylib explicitly so the macOS artifact is self-contained.

Close #378