### PR TITLE
Fix: eliminate signed overflow in runtime frame counters

### DIFF
--- a/src/Lawn/System/DataSync.cpp
+++ b/src/Lawn/System/DataSync.cpp
@@ -195,21 +195,10 @@ DataSync::~DataSync()
 {
 }
 
-void DataSync::ResetPointerTable()
-{
-	mIntToPointerMap.clear();
-	mPointerToIntMap.clear();
-	mPointerSyncList.clear();
-	mCurPointerIndex = 1;
-	mPointerToIntMap[nullptr] = 0;
-	mIntToPointerMap[0] = nullptr;
-}
-
 void DataSync::Reset()
 {
 	mReader = nullptr;
 	mWriter = nullptr;
-	ResetPointerTable();
 }
 
 void DataSync::SyncBytes(void* theData, uint32_t theDataLen)

--- a/src/Lawn/System/DataSync.h
+++ b/src/Lawn/System/DataSync.h
@@ -85,15 +85,9 @@ public:
 	void					WriteDouble(double theDouble);
 	void					WriteString(std::string_view theStr);
 	inline uint32_t			GetPos();
-	inline void				SetUInt32(uint32_t, uint32_t) { /* 未找到 */ }
-	inline void				SetUInt16(uint32_t, uint32_t) { /* 未找到 */ }
-	inline void				SetUInt8(uint32_t, uint32_t) { /* 未找到 */ }
 	inline void*			GetDataPtr() { return mData; }
-	inline int				GetDataLen() { return mDataLen; }
+	inline uint32_t			GetDataLen() { return mDataLen; }
 };
-
-typedef std::map<void*, int> PointerToIntMap;
-typedef std::map<int, void*> IntToPointerMap;
 
 class DataSync
 {
@@ -101,13 +95,8 @@ protected:
 	DataReader*				mReader;
 	DataWriter*				mWriter;
 	int						mVersion;
-	PointerToIntMap			mPointerToIntMap;
-	IntToPointerMap			mIntToPointerMap;
-	std::vector<void**>		mPointerSyncList;
-	int						mCurPointerIndex;
 
 protected:
-	void ResetPointerTable();
 	void Reset();
 
 public:
@@ -115,7 +104,6 @@ public:
 	DataSync(DataWriter& theWriter);
 	virtual ~DataSync();
 
-	inline void				SyncPointers() { /* 未找到 */ }
 	inline void				SetReader(DataReader* theReader) { mReader = theReader; }
 	inline void				SetWriter(DataWriter* theWriter) { mWriter = theWriter; }
 	inline DataReader*		GetReader() { return mReader; }
@@ -153,8 +141,6 @@ public:
 	void					SyncFloat(float& theFloat);
 	void					SyncDouble(double& theDouble);
 	void					SyncString(std::string& theStr);
-	inline void				SyncPointer(void**) { /* 未找到 */ }
-	inline void				RegisterPointer(void*) { /* 未找到 */ }
 	inline void				SetVersion(int theVersion) { mVersion = theVersion; }
 	inline int				GetVersion() const { return mVersion; }
 };

--- a/src/Lawn/System/SaveGame.cpp
+++ b/src/Lawn/System/SaveGame.cpp
@@ -2355,7 +2355,7 @@ static bool WriteChunkV4(std::vector<unsigned char>& thePayload, uint32_t theChu
 	aChunkWriter.OpenMemory(0x200);
 	aChunkWriter.WriteUInt32(SAVE4_CHUNK_VERSION);
 	aChunkWriter.WriteUInt32(1U);
-	aChunkWriter.WriteUInt32(static_cast<uint32_t>(aFieldWriter.GetDataLen()));
+	aChunkWriter.WriteUInt32(aFieldWriter.GetDataLen());
 	aChunkWriter.WriteBytes(aFieldWriter.GetDataPtr(), aFieldWriter.GetDataLen());
 
 	std::vector<unsigned char> aChunk;
@@ -2636,8 +2636,15 @@ public:
 public:
 	inline int		ByteLeftToRead() { return (mBuffer.mDataBitSize - mBuffer.mReadBitPos + 7) / 8; }
 	void			SyncBytes(void* theDest, int theReadSize);
-	void			SyncInt(int& theInt);
-	inline void		SyncUint(uint32_t& theInt) { SyncInt((signed int&)theInt); }
+	void			SyncInt32(int32_t& theInt32);
+	void			SyncUInt32(uint32_t& theUInt32);
+	inline void		SyncInt(int& theInt)
+	{
+		int32_t aValue = theInt;
+		SyncInt32(aValue);
+		if (mReading)
+			theInt = aValue;
+	}
 	void			SyncReanimationDef(ReanimatorDefinition*& theDefinition);
 	void			SyncParticleDef(TodParticleDefinition*& theDefinition);
 	void			SyncTrailDef(TrailDefinition*& theDefinition);
@@ -2654,11 +2661,11 @@ void SaveGameContext::SyncBytes(void* theDest, int theReadSize)
 			mFailed = true;
 		}
 
-		aReadSize = mFailed ? 0 : mBuffer.ReadLong();
+		aReadSize = mFailed ? 0 : mBuffer.ReadInt32();
 	}
 	else
 	{
-		mBuffer.WriteLong(theReadSize);
+		mBuffer.WriteInt32(theReadSize);
 	}
 
 	if (mReading)
@@ -2683,7 +2690,7 @@ void SaveGameContext::SyncBytes(void* theDest, int theReadSize)
 	}
 }
 
-void SaveGameContext::SyncInt(int& theInt)
+void SaveGameContext::SyncInt32(int32_t& theInt32)
 {
 	if (mReading)
 	{
@@ -2692,11 +2699,28 @@ void SaveGameContext::SyncInt(int& theInt)
 			mFailed = true;
 		}
 
-		theInt = mFailed ? 0 : mBuffer.ReadLong();
+		theInt32 = mFailed ? 0 : mBuffer.ReadInt32();
 	}
 	else
 	{
-		mBuffer.WriteLong(theInt);
+		mBuffer.WriteInt32(theInt32);
+	}
+}
+
+void SaveGameContext::SyncUInt32(uint32_t& theUInt32)
+{
+	if (mReading)
+	{
+		if (ByteLeftToRead() < 4)
+		{
+			mFailed = true;
+		}
+
+		theUInt32 = mFailed ? 0 : mBuffer.ReadUInt32();
+	}
+	else
+	{
+		mBuffer.WriteUInt32(theUInt32);
 	}
 }
 
@@ -2969,9 +2993,9 @@ static void SyncTrail(Board* theBoard, Trail* theTrail, SaveGameContext& theCont
 
 template <typename T> inline static void SyncDataArray(SaveGameContext& theContext, DataArray<T>& theDataArray)
 {
-	theContext.SyncUint(theDataArray.mFreeListHead);
-	theContext.SyncUint(theDataArray.mMaxUsedCount);
-	theContext.SyncUint(theDataArray.mSize);
+	theContext.SyncUInt32(theDataArray.mFreeListHead);
+	theContext.SyncUInt32(theDataArray.mMaxUsedCount);
+	theContext.SyncUInt32(theDataArray.mSize);
 	theContext.SyncBytes(theDataArray.mBlock, theDataArray.mMaxUsedCount * sizeof(*theDataArray.mBlock));
 }
 
@@ -3030,14 +3054,14 @@ static void SyncBoard(SaveGameContext& theContext, Board* theBoard)
 			theContext.mFailed = true;
 		}
 
-		if (theContext.mFailed || static_cast<uint32_t>(theContext.mBuffer.ReadLong()) != SAVE_FILE_MAGIC_NUMBER)
+		if (theContext.mFailed || theContext.mBuffer.ReadUInt32() != SAVE_FILE_MAGIC_NUMBER)
 		{
 			theContext.mFailed = true;
 		}
 	}
 	else
 	{
-		theContext.mBuffer.WriteLong(SAVE_FILE_MAGIC_NUMBER);
+		theContext.mBuffer.WriteUInt32(SAVE_FILE_MAGIC_NUMBER);
 	}
 }
 

--- a/src/Lawn/Widget/ChallengeScreen.cpp
+++ b/src/Lawn/Widget/ChallengeScreen.cpp
@@ -770,10 +770,10 @@ void ChallengeScreen::MouseDown(int x, int y, int theClickCount)
 	if (mLimboPageUnlocked)
 		return;
 
-	constexpr int MAX_GAP_TICKS = 20; // 200 ms at 100 update ticks/sec
+	constexpr uint MAX_GAP_TICKS = 20; // 200 ms at 100 update ticks/sec
 	constexpr int CLICKS_NEEDED = 5;
 
-	int aNow = mApp->mUpdateCount;
+	uint aNow = mApp->mUpdateCount;
 	if (aNow - mLastClickUpdateCnt > MAX_GAP_TICKS)
 		mClickCount = 0;
 	mLastClickUpdateCnt = aNow;

--- a/src/Lawn/Widget/ChallengeScreen.h
+++ b/src/Lawn/Widget/ChallengeScreen.h
@@ -56,7 +56,7 @@ public:
     float                       mLockShakeY;
     bool                        mLimboPageUnlocked;
     int                         mClickCount;
-    int                         mLastClickUpdateCnt;
+    uint                        mLastClickUpdateCnt;
 
 public:
     ChallengeScreen(LawnApp* theApp, ChallengePage thePage);

--- a/src/Lawn/Widget/LawnDialog.cpp
+++ b/src/Lawn/Widget/LawnDialog.cpp
@@ -205,7 +205,7 @@ void LawnDialog::ButtonPress(int theId)
 
 void LawnDialog::ButtonDepress(int theId)
 {
-    if (mUpdateCnt > mButtonDelay)
+    if (mButtonDelay < 0 || mUpdateCnt > static_cast<uint>(mButtonDelay))
     {
         Dialog::ButtonDepress(theId);
     }

--- a/src/Lawn/Widget/StoreScreen.cpp
+++ b/src/Lawn/Widget/StoreScreen.cpp
@@ -217,7 +217,7 @@ bool StoreScreen::IsItemSoldOut(StoreItem theStoreItem)
     else if (theStoreItem == STORE_ITEM_BONUS_LAWN_MOWER)
         return aPlayer->mPurchases[STORE_ITEM_BONUS_LAWN_MOWER] >= 2;
     else if (IsPottedPlant(theStoreItem))
-        return mApp->mZenGarden->IsZenGardenFull(true) || aPlayer->mPurchases[theStoreItem] == GetCurrentDaysSince2000(mApp->GetNowTime());
+        return mApp->mZenGarden->IsZenGardenFull(true) || aPlayer->mPurchases[theStoreItem] == static_cast<uint32_t>(GetCurrentDaysSince2000(mApp->GetNowTime()));
     else return aPlayer->mPurchases[theStoreItem];
 
     unreachable();
@@ -657,7 +657,7 @@ void StoreScreen::Update()
     if (mApp->mCrazyDaveState == CRAZY_DAVE_OFF)
     {
         // demo sessions preload by update tick instead of the frame-scheduled mDrawnOnce
-        bool aShouldPreload = mApp->IsInDemoMode() ? (mApp->mUpdateCount - mAddedAtUpdateCount >= 2) : mDrawnOnce;
+        bool aShouldPreload = mApp->IsInDemoMode() ? (mApp->mUpdateCount - mAddedAtUpdateCount >= 2U) : mDrawnOnce;
         if (aShouldPreload)
         {
             StorePreload();

--- a/src/Lawn/Widget/StoreScreen.h
+++ b/src/Lawn/Widget/StoreScreen.h
@@ -70,7 +70,7 @@ public:
     PottedPlant                 mPottedPlantSpecs;
     DataArray<Coin>             mCoins;
     bool                        mDrawnOnce;
-    int                         mAddedAtUpdateCount; // tick snapshot for demo-mode preload timing
+    uint                        mAddedAtUpdateCount; // tick snapshot for demo-mode preload timing
     bool                        mGoToTreeNow;
     bool                        mPurchasedFullVersion;
     bool                        mTrialLockedWhenStoreOpened;

--- a/src/Sexy.TodLib/TodDebug.cpp
+++ b/src/Sexy.TodLib/TodDebug.cpp
@@ -20,7 +20,7 @@
  */
 
 #include <time.h>
-#include <inttypes.h>
+#include <cinttypes>
 #include <stdarg.h>
 #include <stdexcept>
 #include <fstream>

--- a/src/Sexy.TodLib/TodFoley.cpp
+++ b/src/Sexy.TodLib/TodFoley.cpp
@@ -205,7 +205,7 @@ bool SoundSystemHasFoleyPlayedTooRecently(TodFoley* theSoundSystem, FoleyType th
 	for (int i = 0; i < MAX_FOLEY_INSTANCES; i++)
 	{
 		FoleyInstance* aFoleyInstance = &aFoleyData->mFoleyInstances[i];
-		if (aFoleyInstance->mRefCount != 0 && gSexyAppBase->mUpdateCount - aFoleyInstance->mStartTime < 10)  // 若同种音效存在近 10 cs 内播放的实例
+		if (aFoleyInstance->mRefCount != 0 && gSexyAppBase->mUpdateCount - aFoleyInstance->mStartTime < 10U)  // 若同种音效存在近 10 cs 内播放的实例
 			return true;
 	}
 	return false;

--- a/src/Sexy.TodLib/TodFoley.h
+++ b/src/Sexy.TodLib/TodFoley.h
@@ -191,7 +191,7 @@ public:
     SoundInstance*      mInstance;
     int                 mRefCount;
     bool                mPaused;
-    int                 mStartTime;
+    uint                mStartTime;
     int                 mPauseOffset;
 
 public:

--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -33,6 +33,7 @@
 #include <math.h>
 #include <vector>
 #include <algorithm>
+#include <cinttypes>
 #include <cstdlib>
 #include <cstring>
 #include <chrono>
@@ -320,11 +321,6 @@ SexyAppBase::SexyAppBase()
 	mAutoMuteCount = 0;
 	mDemoMute = false;
 	mMuteOnLostFocus = false;
-	mFPSTime = 0;
-	mFPSStartTick = SDL_GetTicks();
-	mFPSFlipCount = 0;
-	mFPSCount = 0;
-	mFPSDirtyCount = 0;
 	mShowFPS = false;
 	mShowFPSMode = FPS_ShowFPS;
 	mDrawTime = 0;
@@ -399,12 +395,11 @@ SexyAppBase::SexyAppBase()
 	mDemoTimeZoneOffset = 0;
 	mDemoNeedsCommand = true;
 	mDemoLoadingComplete = false;
-	mDemoLength = 0;
 	mDemoCmdNum = 0;
-	mDemoCmdOrder = -1; // Means we haven't processed any demo commands yet
 	mDemoCmdBitPos = 0;
 	mDemoCmdUpdateCnt = 0;
-	mDemoQueuedSince = -1;
+	mDemoQueuedSince = 0;
+	mDemoCommandQueued = false;
 
 	mWidgetManager = new WidgetManager(this);
 	mResourceManager = new ResourceManager(this);
@@ -569,14 +564,14 @@ bool SexyAppBase::ReadDemoBuffer(std::string &theError)
 		aMarkerBuffer.WriteBytes(aBuffer, aSize);
 		aMarkerBuffer.SeekFront();
 
-		int aNumItems = aMarkerBuffer.ReadLong();
-		int i;
+		uint32_t aNumItems = aMarkerBuffer.ReadUInt32();
+		uint32_t i;
 		for (i=0; i<aNumItems && !aMarkerBuffer.AtEnd(); i++)
 		{
 			mDemoMarkerList.push_back(DemoMarker());
 			DemoMarker &aMarker = mDemoMarkerList.back();
 			aMarker.first = aMarkerBuffer.ReadString();
-			aMarker.second = aMarkerBuffer.ReadLong();
+			aMarker.second = aMarkerBuffer.ReadUInt32();
 		}
 
 		if (i!=aNumItems)
@@ -591,8 +586,8 @@ bool SexyAppBase::ReadDemoBuffer(std::string &theError)
 	}
 
 	// Read demo commands
-	if (!aFile.read(reinterpret_cast<char*>(&mDemoLength), sizeof(mDemoLength))) return false;
-	mDemoLength = static_cast<int>(FromLE32(static_cast<uint32_t>(mDemoLength)));
+	uint32_t aDemoLengthLE; // unused by playback; consumed only to keep the stream aligned
+	if (!aFile.read(reinterpret_cast<char*>(&aDemoLengthLE), sizeof(aDemoLengthLE))) return false;
 	aBytesLeft -= 4;
 	
 	if (aBytesLeft <= 0)
@@ -683,11 +678,11 @@ void SexyAppBase::WriteDemoBuffer()
 			aFile.write(mProductVersion.c_str(), static_cast<std::streamsize>(mProductVersion.length()));
 
 			Buffer aMarkerBuffer;
-			aMarkerBuffer.WriteLong(mDemoMarkerList.size());
+			aMarkerBuffer.WriteUInt32(static_cast<uint32_t>(mDemoMarkerList.size()));
 			for (DemoMarkerList::iterator aMarkerItr = mDemoMarkerList.begin(); aMarkerItr != mDemoMarkerList.end(); ++aMarkerItr)
 			{
 				aMarkerBuffer.WriteString(aMarkerItr->first);
-				aMarkerBuffer.WriteLong(aMarkerItr->second);
+				aMarkerBuffer.WriteUInt32(aMarkerItr->second);
 			}
 			int aMarkerBufferSize = aMarkerBuffer.GetDataLen();
 			uint32_t aMarkerBufferSizeLE = ToLE32(static_cast<uint32_t>(aMarkerBufferSize));
@@ -726,7 +721,7 @@ void SexyAppBase::DemoSyncBuffer(Buffer* theBuffer)
 		DBG_ASSERTE(!mDemoIsShortCmd);
 		DBG_ASSERTE(mDemoCmdNum == DEMO_SYNC);
 
-		uint32_t aLen = mDemoBuffer.ReadLong();
+		uint32_t aLen = mDemoBuffer.ReadUInt32();
 		
 		theBuffer->Clear();
 		for (int i = 0; i < static_cast<int>(aLen); i++)
@@ -737,7 +732,7 @@ void SexyAppBase::DemoSyncBuffer(Buffer* theBuffer)
 		WriteDemoTimingBlock();
 		mDemoBuffer.WriteNumBits(0, 1);
 		mDemoBuffer.WriteNumBits(DEMO_SYNC, 5);		
-		mDemoBuffer.WriteLong(theBuffer->GetDataLen());
+		mDemoBuffer.WriteUInt32(static_cast<uint32_t>(theBuffer->GetDataLen()));
 		mDemoBuffer.WriteBytes(theBuffer->GetDataPtr(), theBuffer->GetDataLen());
 	}
 }
@@ -753,9 +748,9 @@ void SexyAppBase::DemoSyncString(std::string* theString)
 void SexyAppBase::DemoSyncInt(int* theInt)
 {
 	Buffer aBuffer;
-	aBuffer.WriteLong(*theInt);
+	aBuffer.WriteInt32(*theInt);
 	DemoSyncBuffer(&aBuffer);
-	*theInt = aBuffer.ReadLong();
+	*theInt = aBuffer.ReadInt32();
 }
 
 void SexyAppBase::DemoSyncBool(bool* theBool)
@@ -799,7 +794,7 @@ void SexyAppBase::DemoAddMarker(const std::string& theString)
 	}
 	else if (mRecordingDemoBuffer)
 	{
-		mDemoMarkerList.push_back(DemoMarker(theString,mUpdateCount));
+		mDemoMarkerList.push_back(DemoMarker(theString, static_cast<uint32_t>(mUpdateCount)));
 	}
 }
 
@@ -816,7 +811,7 @@ void SexyAppBase::DemoAssertIntEqual(int theInt)
 		DBG_ASSERTE(!mDemoIsShortCmd);
 		DBG_ASSERTE(mDemoCmdNum == DEMO_ASSERT_INT_EQUAL);
 
-		int anInt = mDemoBuffer.ReadLong();
+		int anInt = mDemoBuffer.ReadInt32();
 		(void)anInt; // unused in Release mode
 		DBG_ASSERTE(anInt == theInt);
 	}
@@ -825,7 +820,7 @@ void SexyAppBase::DemoAssertIntEqual(int theInt)
 		WriteDemoTimingBlock();
 		mDemoBuffer.WriteNumBits(0, 1);
 		mDemoBuffer.WriteNumBits(DEMO_ASSERT_INT_EQUAL, 5);				
-		mDemoBuffer.WriteLong(theInt);
+		mDemoBuffer.WriteInt32(theInt);
 	}
 }
 
@@ -1223,16 +1218,16 @@ bool SexyAppBase::RegistryReadKey(const std::string& theValueName, uint32_t* the
 		if (!success)
 			return false;
 
-		*theType = mDemoBuffer.ReadLong();
+		*theType = mDemoBuffer.ReadUInt32();
 
-		uint32_t aLen = mDemoBuffer.ReadLong();
+		uint32_t aLen = mDemoBuffer.ReadUInt32();
 		*theLength = aLen;
 
 		if (*theLength >= aLen)
 		{
 			if ((*theType == regemu::REGEMU_DWORD) && (aLen == sizeof(uint32_t)))
 			{
-				uint32_t aValue = static_cast<uint32_t>(mDemoBuffer.ReadLong()); // stream stores DWORDs little-endian
+				uint32_t aValue = mDemoBuffer.ReadUInt32();
 				memcpy(theValue, &aValue, sizeof(aValue));
 			}
 			else
@@ -1270,13 +1265,13 @@ bool SexyAppBase::RegistryReadKey(const std::string& theValueName, uint32_t* the
 				mDemoBuffer.WriteNumBits(0, 1);
 				mDemoBuffer.WriteNumBits(DEMO_REGISTRY_READ, 5);
 				mDemoBuffer.WriteNumBits(1, 1); // success
-				mDemoBuffer.WriteLong(*theType);
-				mDemoBuffer.WriteLong(*theLength);
+				mDemoBuffer.WriteUInt32(*theType);
+				mDemoBuffer.WriteUInt32(*theLength);
 				if ((*theType == regemu::REGEMU_DWORD) && (*theLength == sizeof(uint32_t)))
 				{
 					uint32_t aValue;
 					memcpy(&aValue, theValue, sizeof(aValue));
-					mDemoBuffer.WriteLong(aValue); // WriteLong serializes little-endian
+					mDemoBuffer.WriteUInt32(aValue);
 				}
 				else
 					mDemoBuffer.WriteBytes(theValue, *theLength);
@@ -1466,7 +1461,7 @@ bool SexyAppBase::ReadBufferFromFile(const std::string& theFileName, Buffer* the
 		if (!success)
 			return false;
 
-		uint32_t aLen = mDemoBuffer.ReadLong();		
+		uint32_t aLen = mDemoBuffer.ReadUInt32();
 				
 		theBuffer->Clear();
 		for (int i = 0; i < static_cast<int>(aLen); i++)
@@ -1509,7 +1504,7 @@ bool SexyAppBase::ReadBufferFromFile(const std::string& theFileName, Buffer* the
 			mDemoBuffer.WriteNumBits(0, 1);
 			mDemoBuffer.WriteNumBits(DEMO_FILE_READ, 5);
 			mDemoBuffer.WriteNumBits(1, 1); // success			
-			mDemoBuffer.WriteLong(aFileSize);
+			mDemoBuffer.WriteUInt32(static_cast<uint32_t>(aFileSize));
 			mDemoBuffer.WriteBytes(aData, aFileSize);
 		}
 
@@ -1691,10 +1686,7 @@ void SexyAppBase::UpdateFrames()
 	mUpdateCount++;	
 
 	if (!mMinimized)
-	{		
-		if (mWidgetManager->UpdateFrame())
-			++mFPSDirtyCount;
-	}
+		mWidgetManager->UpdateFrame();
 
 	mMusicInterface->Update();	
 	CleanSharedImages();
@@ -1724,7 +1716,7 @@ bool SexyAppBase::DoUpdateFrames()
 		}
 
 		// a queued command waits on game logic; let the tick advance so it can be claimed or judged diverged
-		if ((mLoaded == mDemoLoadingComplete) && ((mUpdateCount != mLastDemoUpdateCnt) || (mDemoQueuedSince >= 0)))
+		if ((mLoaded == mDemoLoadingComplete) && ((mUpdateCount != mLastDemoUpdateCnt) || mDemoCommandQueued))
 		{
 			UpdateFrames();
 			return true;
@@ -1769,8 +1761,6 @@ void SexyAppBase::Redraw(Rect* theClipRect)
 		return;
 
 	mGLInterface->Redraw(theClipRect);
-
-	mFPSFlipCount++;
 }
 
 ///////////////////////////// FPS Stuff
@@ -1876,9 +1866,6 @@ bool SexyAppBase::DrawDirtyStuff()
 		mDrawCount++;
 
 		uint32_t aMidTime = SDL_GetTicks();
-
-		mFPSCount++;
-		mFPSTime += aMidTime - aStartTime;
 
 		mDrawTime += aMidTime - aStartTime;
 
@@ -2101,12 +2088,10 @@ void SexyAppBase::WriteDemoTimingBlock()
 
 		mDemoBuffer.WriteNumBits(0, 1);
 		mDemoBuffer.WriteNumBits(DEMO_IDLE, 5);
-		mDemoCmdOrder++;
 	}
 	
 	mDemoBuffer.WriteNumBits(mUpdateCount - mLastDemoUpdateCnt, 4);
 	mLastDemoUpdateCnt = mUpdateCount;
-	mDemoCmdOrder++;
 }
 
 int aNumBigMoveMessages = 0;
@@ -2121,7 +2106,7 @@ bool SexyAppBase::PrepareDemoCommand([[maybe_unused]] bool required)
 		mDemoCmdBitPos = mDemoBuffer.mReadBitPos;
 		mDemoCmdUpdateCnt = mLastDemoUpdateCnt;
 		if (required) // a game-logic call site claimed the queued command
-			mDemoQueuedSince = -1;
+			mDemoCommandQueued = false;
 
 		mLastDemoUpdateCnt += mDemoBuffer.ReadNumBits(4, false);
 
@@ -2133,8 +2118,6 @@ bool SexyAppBase::PrepareDemoCommand([[maybe_unused]] bool required)
 			mDemoCmdNum = mDemoBuffer.ReadNumBits(5, false);
 
 		mDemoNeedsCommand = false;
-
-		mDemoCmdOrder++;
 	}
 
 	DBG_ASSERTE((mUpdateCount >= mLastDemoUpdateCnt) || (!required));
@@ -2294,12 +2277,13 @@ void SexyAppBase::ProcessDemo()
 					case DEMO_SYNC:
 					case DEMO_ASSERT_STRING_EQUAL:
 					case DEMO_ASSERT_INT_EQUAL:
-						if (mDemoQueuedSince >= 0 && mUpdateCount > mDemoQueuedSince) // queued across a tick with no claim: the replay has diverged
+						if (mDemoCommandQueued && mUpdateCount != mDemoQueuedSince) // queued across a tick with no claim: the replay has diverged
 						{
 							Shutdown();
 							return;
 						}
 						mDemoQueuedSince = mUpdateCount;
+						mDemoCommandQueued = true;
 						mDemoBuffer.mReadBitPos = mDemoCmdBitPos; // leave queued for the game-logic call site to consume
 						mLastDemoUpdateCnt = mDemoCmdUpdateCnt;
 						mDemoNeedsCommand = true;
@@ -2650,7 +2634,7 @@ bool SexyAppBase::Process(bool allowSleep)
 			while (mUpdateCount < mFastForwardToUpdateNum || mFastForwardToMarker)
 			{
 				ClearUpdateBacklog();
-				int aLastUpdateCount = mUpdateCount;
+				uint aLastUpdateCount = mUpdateCount;
 								
 				// Actual updating code below
 				//////////////////////////////////////////////////////////////////////////
@@ -2991,7 +2975,7 @@ bool SexyAppBase::UpdateAppStep(bool* updated)
 		}
 		else
 		{
-			int anOldUpdateCnt = mUpdateCount;
+			uint anOldUpdateCnt = mUpdateCount;
 			Process();		
 			if (updated != nullptr)
 				*updated = mUpdateCount != anOldUpdateCnt;			
@@ -3072,14 +3056,14 @@ void SexyAppBase::Start()
 
 	Sexy::PrintF("Seconds       = %g\r\n", (SDL_GetTicks() - aStartTime) / 1000.0);
 	//Sexy::PrintF("Count         = %d\r\n", aCount);
-	Sexy::PrintF("Sleep Count   = %d\r\n", mSleepCount);
-	Sexy::PrintF("Update Count  = %d\r\n", mUpdateCount);
-	Sexy::PrintF("Draw Count    = %d\r\n", mDrawCount);
-	Sexy::PrintF("Draw Time     = %d\r\n", mDrawTime);
-	Sexy::PrintF("Screen Blt    = %d\r\n", mScreenBltTime);
+	Sexy::PrintF("Sleep Count   = %u\r\n", mSleepCount);
+	Sexy::PrintF("Update Count  = %u\r\n", mUpdateCount);
+	Sexy::PrintF("Draw Count    = %u\r\n", mDrawCount);
+	Sexy::PrintF("Draw Time     = %" PRIu64 "\r\n", mDrawTime);
+	Sexy::PrintF("Screen Blt    = %u\r\n", mScreenBltTime);
 	if (mDrawTime+mScreenBltTime > 0)
 	{
-		Sexy::PrintF("Avg FPS       = %d\r\n", (mDrawCount*1000)/(mDrawTime+mScreenBltTime));
+		Sexy::PrintF("Avg FPS       = %" PRIu64 "\r\n", static_cast<uint64_t>(mDrawCount) * 1000 / (mDrawTime+mScreenBltTime));
 	}
 
 	//timeEndPeriod(1);	

--- a/src/SexyAppFramework/SexyAppBase.h
+++ b/src/SexyAppFramework/SexyAppBase.h
@@ -242,14 +242,14 @@ public:
 	time_t					mLastTime;
 	uint32_t				mLastUserInputTick;
 
-	int						mSleepCount;
-	int						mDrawCount;
-	int						mUpdateCount;
+	uint					mSleepCount;
+	uint					mDrawCount;
+	uint					mUpdateCount;
 	int						mUpdateAppState;
 	int						mUpdateAppDepth;
 	double					mUpdateMultiplier;		
 	bool					mPaused;
-	int						mFastForwardToUpdateNum;
+	uint					mFastForwardToUpdateNum;
 	bool					mFastForwardToMarker;
 	bool					mFastForwardStep;
 	uint32_t				mLastDrawTick;
@@ -270,15 +270,10 @@ public:
 	bool					mPhysMinimized;
 	bool					mIsDisabled;
 	bool					mHasFocus;
-	int						mDrawTime;
-	uint32_t				mFPSStartTick;
-	int						mFPSFlipCount;
-	int						mFPSDirtyCount;
-	int						mFPSTime;
-	int						mFPSCount;
+	uint64_t				mDrawTime;
 	bool					mShowFPS;
 	int						mShowFPSMode;
-	int						mScreenBltTime;
+	uint					mScreenBltTime;
 	bool					mAutoStartLoadingThread;
 	bool					mLoadingThreadStarted;
 	bool					mLoadingThreadCompleted;
@@ -306,22 +301,21 @@ public:
 	bool					mHasCustomDemoFile; // an explicit -demofile overrides automatic demo file selection
 	uint					mDemoRecordFileLimit;
 	Buffer					mDemoBuffer;
-	int						mDemoLength;
 	int						mLastDemoMouseX;
 	int						mLastDemoMouseY;
-	int						mLastDemoUpdateCnt;
+	uint					mLastDemoUpdateCnt;
 	uint64_t				mDemoStartTime; // wall clock at session start, base of the demo-synced clock
 	int32_t					mDemoTimeZoneOffset; // recorder's local time minus UTC in seconds, for demo-synced local time
 	bool					mDemoNeedsCommand;
 	bool					mDemoIsShortCmd;
 	int						mDemoCmdNum;
-	int						mDemoCmdOrder;
 	int						mDemoCmdBitPos;
-	int						mDemoCmdUpdateCnt; // update tick before the current command header was read
-	int						mDemoQueuedSince; // tick when a game-logic-owned command was queued; -1 = none
+	uint					mDemoCmdUpdateCnt; // update tick before the current command header was read
+	uint					mDemoQueuedSince; // tick when a game-logic-owned command was queued
+	bool					mDemoCommandQueued;
 	bool					mDemoLoadingComplete;
 
-	typedef std::pair<std::string, int> DemoMarker;
+	typedef std::pair<std::string, uint32_t> DemoMarker;
 	typedef std::list<DemoMarker> DemoMarkerList;
 	DemoMarkerList			mDemoMarkerList;
 

--- a/src/SexyAppFramework/misc/Buffer.cpp
+++ b/src/SexyAppFramework/misc/Buffer.cpp
@@ -25,6 +25,7 @@
 #include "Buffer.h"
 #include <SDL_stdinc.h>
 #include <array>
+#include <bit>
 #define POLYNOMIAL 0x04c11db7L
 
 using namespace Sexy;
@@ -322,12 +323,17 @@ void Buffer::WriteShort(short theShort)
 	WriteByte((uchar)(theShort >> 8));
 }
 
-void Buffer::WriteLong(int32_t theLong)
+void Buffer::WriteUInt32(uint32_t theValue)
 {
-	WriteByte((uchar)theLong);
-	WriteByte((uchar)(theLong >> 8));
-	WriteByte((uchar)(theLong >> 16));
-	WriteByte((uchar)(theLong >> 24));
+	WriteByte(static_cast<uchar>(theValue));
+	WriteByte(static_cast<uchar>(theValue >> 8));
+	WriteByte(static_cast<uchar>(theValue >> 16));
+	WriteByte(static_cast<uchar>(theValue >> 24));
+}
+
+void Buffer::WriteInt32(int32_t theValue)
+{
+	WriteUInt32(std::bit_cast<uint32_t>(theValue));
 }
 
 void Buffer::WriteString(const std::string& theString)
@@ -344,9 +350,9 @@ void Buffer::WriteLine(const std::string& theString)
 
 void Buffer::WriteBuffer(const ByteVector& theBuffer)
 {
-	WriteLong((short) theBuffer.size());
-	for (int i = 0; i < (int)theBuffer.size(); i++)
-		WriteByte(theBuffer[i]);
+	WriteUInt32(static_cast<uint32_t>(theBuffer.size()));
+	for (uchar aByte : theBuffer)
+		WriteByte(aByte);
 }
 
 void Buffer::WriteBytes(const uchar* theByte, int theCount)
@@ -434,14 +440,19 @@ short Buffer::ReadShort() const
 	return aShort;	
 }
 
-int32_t Buffer::ReadLong() const
+uint32_t Buffer::ReadUInt32() const
 {
-	int32_t aLong = ReadByte();
-	aLong |= ((int32_t) ReadByte()) << 8;
-	aLong |= ((int32_t) ReadByte()) << 16;
-	aLong |= ((int32_t) ReadByte()) << 24;
+	uint32_t aValue = ReadByte();
+	aValue |= static_cast<uint32_t>(ReadByte()) << 8;
+	aValue |= static_cast<uint32_t>(ReadByte()) << 16;
+	aValue |= static_cast<uint32_t>(ReadByte()) << 24;
 
-	return aLong;
+	return aValue;
+}
+
+int32_t Buffer::ReadInt32() const
+{
+	return std::bit_cast<int32_t>(ReadUInt32());
 }
 
 std::string	Buffer::ReadString() const
@@ -483,9 +494,9 @@ void Buffer::ReadBuffer(ByteVector* theByteVector) const
 {
 	theByteVector->clear();
 	
-	uint32_t aLength = ReadLong();
+	uint32_t aLength = ReadUInt32();
 	theByteVector->resize(aLength);
-	ReadBytes(&(*theByteVector)[0], aLength);
+	ReadBytes(theByteVector->data(), static_cast<int>(aLength));
 }
 
 const uchar* Buffer::GetDataPtr() const

--- a/src/SexyAppFramework/misc/Buffer.h
+++ b/src/SexyAppFramework/misc/Buffer.h
@@ -54,7 +54,8 @@ public:
 	static int				GetBitsRequired(int theNum, bool isSigned);
 	void					WriteBoolean(bool theBool);
 	void					WriteShort(short theShort);
-	void					WriteLong(int32_t theLong);
+	void					WriteUInt32(uint32_t theValue);
+	void					WriteInt32(int32_t theValue);
 	void					WriteString(const std::string& theString);
 	void					WriteLine(const std::string& theString);	
 	void					WriteBuffer(const ByteVector& theBuffer);
@@ -68,7 +69,8 @@ public:
 	int						ReadNumBits(int theBits, bool isSigned) const;
 	bool					ReadBoolean() const;
 	short					ReadShort() const;
-	int32_t					ReadLong() const;
+	uint32_t				ReadUInt32() const;
+	int32_t					ReadInt32() const;
 	std::string				ReadString() const;	
 	std::string				ReadLine() const;
 	void					ReadBytes(uchar* theData, int theLen) const;

--- a/src/SexyAppFramework/sound/SDLSoundInstance.cpp
+++ b/src/SexyAppFramework/sound/SDLSoundInstance.cpp
@@ -216,7 +216,7 @@ bool SDLSoundInstance::Play(bool looping, bool autoRelease)
 	{
 		mDemoLooping = looping;
 		mDemoEndUpdateCount = gSexyAppBase->mUpdateCount +
-			static_cast<int>(GetChunkDurationMS(mMixChunk != nullptr ? mMixChunk->alen : 0) / (10.0 * mPitch)) + 1;
+			static_cast<uint>(GetChunkDurationMS(mMixChunk != nullptr ? mMixChunk->alen : 0) / (10.0 * mPitch)) + 1;
 	}
 
 	if (!mMixChunk)

--- a/src/SexyAppFramework/sound/SDLSoundInstance.h
+++ b/src/SexyAppFramework/sound/SDLSoundInstance.h
@@ -75,7 +75,7 @@ protected:
 
 	uint32_t				mDefaultFrequency;
 
-	int						mDemoEndUpdateCount; // demo sessions: first update tick at which playback is considered finished; 0 = not playing
+	uint					mDemoEndUpdateCount; // demo sessions: first update tick at which playback is considered finished; 0 = not playing
 	bool					mDemoLooping; // demo sessions: looping flag of the current playback
 
 protected:

--- a/src/SexyAppFramework/widget/WidgetContainer.cpp
+++ b/src/SexyAppFramework/widget/WidgetContainer.cpp
@@ -515,7 +515,7 @@ void WidgetContainer::UpdateAll(ModalFlags* theFlags)
 
 	if (theFlags->GetFlags() & WIDGETFLAGS_UPDATE)
 	{	
-		if (mLastWMUpdateCount != (ulong)mWidgetManager->mUpdateCnt)
+		if (mLastWMUpdateCount != mWidgetManager->mUpdateCnt)
 		{
 			mLastWMUpdateCount = mWidgetManager->mUpdateCnt;
 			Update();

--- a/src/SexyAppFramework/widget/WidgetContainer.h
+++ b/src/SexyAppFramework/widget/WidgetContainer.h
@@ -48,8 +48,8 @@ public:
 
 	bool					mUpdateIteratorModified;
 	WidgetList::iterator	mUpdateIterator;
-	ulong					mLastWMUpdateCount;
-	int						mUpdateCnt;
+	uint					mLastWMUpdateCount;
+	uint					mUpdateCnt;
 	bool					mDirty;
 	int						mX;
 	int						mY;

--- a/src/SexyAppFramework/widget/WidgetManager.cpp
+++ b/src/SexyAppFramework/widget/WidgetManager.cpp
@@ -585,8 +585,6 @@ void WidgetManager::RehupMouse()
 
 bool WidgetManager::MouseUp(int x, int y, int theClickCount)
 {	
-	mLastInputUpdateCnt = mUpdateCnt;
-	
 	int aMask;
 	
 	if (theClickCount < 0)
@@ -620,8 +618,6 @@ bool WidgetManager::MouseUp(int x, int y, int theClickCount)
 
 bool WidgetManager::MouseDown(int x, int y, int theClickCount) 
 {	
-	mLastInputUpdateCnt = mUpdateCnt;
-
 	if (theClickCount < 0)
 		mActualDownButtons |= 0x02;
 	else if (theClickCount == 3)
@@ -673,8 +669,6 @@ bool WidgetManager::MouseDown(int x, int y, int theClickCount)
 
 bool WidgetManager::MouseMove(int x, int y) 
 {	
-	mLastInputUpdateCnt = mUpdateCnt;
-
 	if (mDownButtons)
 		return MouseDrag(x,y);
 
@@ -686,8 +680,6 @@ bool WidgetManager::MouseMove(int x, int y)
 
 bool WidgetManager::MouseDrag(int x, int y) 
 {	
-	mLastInputUpdateCnt = mUpdateCnt;
-
 	mMouseIn = true;
 	mLastMouseX = x;
 	mLastMouseY = y;
@@ -734,7 +726,6 @@ bool WidgetManager::MouseDrag(int x, int y)
 bool WidgetManager::MouseExit(int x, int y)
 {
 	(void)x;(void)y;
-	mLastInputUpdateCnt = mUpdateCnt;
 
 	mMouseIn = false;
 
@@ -749,16 +740,12 @@ bool WidgetManager::MouseExit(int x, int y)
 
 void WidgetManager::MouseWheel(int theDelta)
 {
-	mLastInputUpdateCnt = mUpdateCnt;
-
 	if (mFocusWidget != nullptr)
 		mFocusWidget->MouseWheel(theDelta);
 }
 
 bool WidgetManager::KeyChar(char theChar)
 {
-	mLastInputUpdateCnt = mUpdateCnt;
-
 	if (theChar == KEYCODE_TAB)
 	{
 		//TODO: Check thing
@@ -780,8 +767,6 @@ bool WidgetManager::KeyChar(char theChar)
 
 bool WidgetManager::KeyText(std::string_view theText)
 {
-	mLastInputUpdateCnt = mUpdateCnt;
-
 	if (mFocusWidget != nullptr)
 		mFocusWidget->KeyText(theText);
 
@@ -790,8 +775,6 @@ bool WidgetManager::KeyText(std::string_view theText)
 
 bool WidgetManager::KeyDown(KeyCode key)
 {
-	mLastInputUpdateCnt = mUpdateCnt;
-
 	if ((key >= 0) && (key < 0xFF))
 		mKeyDown[key] = true;
 
@@ -803,8 +786,6 @@ bool WidgetManager::KeyDown(KeyCode key)
 
 bool WidgetManager::KeyUp(KeyCode key)
 {
-	mLastInputUpdateCnt = mUpdateCnt;
-
 	if ((key >= 0) && (key < 0xFF))
 		mKeyDown[key] = false;
 

--- a/src/SexyAppFramework/widget/WidgetManager.h
+++ b/src/SexyAppFramework/widget/WidgetManager.h
@@ -91,8 +91,6 @@ public:
 	int						mLastMouseY;
 	int						mDownButtons;
 	int						mActualDownButtons;
-	int						mLastInputUpdateCnt;
-	
 	bool					mKeyDown[0xFF];
 	int						mLastDownButtonId;	
 	


### PR DESCRIPTION
Use unsigned types for runtime counters and fixed-width types at serialized boundaries. Remove unused counters, preserve demo/save byte layouts, and keep signed sentinel semantics explicit.