### PR TITLE
Feat: sign Android release APKs with a CI-provided keystore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,12 +335,29 @@ jobs:
         echo "Collected .so files:"
         ls -lh $JNILIBS/
 
+    - name: Decode release keystore
+      env:
+        PVZP_KEYSTORE_BASE64: ${{ secrets.PVZP_KEYSTORE_BASE64 }}
+        PVZP_KEYSTORE_PASSWORD: ${{ secrets.PVZP_KEYSTORE_PASSWORD }}
+        PVZP_KEY_ALIAS: ${{ secrets.PVZP_KEY_ALIAS }}
+        PVZP_KEY_PASSWORD: ${{ secrets.PVZP_KEY_PASSWORD }}
+      run: |
+        # Secrets are empty on fork PRs; the build then falls back to debug signing.
+        if [ -n "$PVZP_KEYSTORE_BASE64" ] && [ -n "$PVZP_KEYSTORE_PASSWORD" ] && [ -n "$PVZP_KEY_ALIAS" ] && [ -n "$PVZP_KEY_PASSWORD" ]; then
+          echo "$PVZP_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/pvzp-release.keystore"
+          echo "PVZP_KEYSTORE_FILE=$RUNNER_TEMP/pvzp-release.keystore" >> "$GITHUB_ENV"
+        fi
+
     - name: Build APK with Gradle
+      env:
+        PVZP_KEYSTORE_PASSWORD: ${{ secrets.PVZP_KEYSTORE_PASSWORD }}
+        PVZP_KEY_ALIAS: ${{ secrets.PVZP_KEY_ALIAS }}
+        PVZP_KEY_PASSWORD: ${{ secrets.PVZP_KEY_PASSWORD }}
       run: |
         cd android
         echo "sdk.dir=$ANDROID_HOME" > local.properties
 
-        # Use gradle wrapper; package pre-built native libraries into a release APK (debug-signed)
+        # Use gradle wrapper; package pre-built native libraries into a release APK
         gradle wrapper
         ./gradlew assembleRelease -PusePrebuiltLibs=true --no-daemon
 

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -7,3 +7,4 @@
 /app/build
 /captures
 .externalNativeBuild
+*.keystore

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -39,11 +39,23 @@ android {
         }
     }
 
+    signingConfigs {
+        release {
+            // Keystore is injected via env vars by CI; absent (e.g. local builds) falls back to debug signing.
+            def storeFilePath = System.getenv('PVZP_KEYSTORE_FILE')
+            if (storeFilePath) {
+                storeFile file(storeFilePath)
+                storePassword System.getenv('PVZP_KEYSTORE_PASSWORD')
+                keyAlias System.getenv('PVZP_KEY_ALIAS')
+                keyPassword System.getenv('PVZP_KEY_PASSWORD')
+            }
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled false
-            // Debug-signed so the APK installs without a release keystore
-            signingConfig signingConfigs.debug
+            signingConfig System.getenv('PVZP_KEYSTORE_FILE') ? signingConfigs.release : signingConfigs.debug
         }
     }
 


### PR DESCRIPTION
CI decodes a base64 keystore from repo secrets and exports it via env vars; app/build.gradle picks it up when present and falls back to debug signing otherwise (local builds, fork PRs). A stable certificate makes APK upgrades installable over previous releases.