### PR TITLE
Fix: make Android CI builds derive the version from git tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Check git version derivation
+      run: |
+        git config --global --add safe.directory '*'
+        git describe --tags
+
     - name: Set up JDK
       uses: actions/setup-java@v5
       with:


### PR DESCRIPTION
The Android artifact from the e5a591c run still reported version 0.1: git refused to work in the CI checkout and the Gradle derivation silently fell back. Configure safe.directory in the android job and run git describe as an explicit check, so a broken derivation fails the job loudly instead of shipping a silent 0.1 fallback.