### PR TITLE
Fix: derive the Android version with providers.exec for Gradle 9

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -14,13 +14,11 @@ def prebuilt = project.hasProperty('usePrebuiltLibs') && project.usePrebuiltLibs
 // Version from git, mirroring archlinux/PKGBUILD's pkgver(); fall back to 0.1/1 without git or tags.
 def gitVersionName = {
     try {
-        def out = new ByteArrayOutputStream()
-        exec {
+        // providers.exec: plain exec is rejected at configuration time by Gradle 9's configuration cache.
+        def text = providers.exec {
             commandLine 'git', 'describe', '--tags', '--abbrev=12'
-            standardOutput = out
-            errorOutput = new ByteArrayOutputStream()
-        }
-        return out.toString().trim().replaceFirst(/^v/, '').replace('-', '.')
+        }.standardOutput.asText.get().trim()
+        return text.replaceFirst(/^v/, '').replace('-', '.')
     } catch (Exception ignored) {
         return '0.1'
     }
@@ -28,13 +26,10 @@ def gitVersionName = {
 
 def gitVersionCode = {
     try {
-        def out = new ByteArrayOutputStream()
-        exec {
+        def text = providers.exec {
             commandLine 'git', 'rev-list', '--count', 'HEAD'
-            standardOutput = out
-            errorOutput = new ByteArrayOutputStream()
-        }
-        return out.toString().trim().toInteger()
+        }.standardOutput.asText.get().trim()
+        return text.toInteger()
     } catch (Exception ignored) {
         return 1
     }


### PR DESCRIPTION
CI regenerates the wrapper with the runner's preinstalled Gradle (currently 9.6.1), which enables the configuration cache by default. Plain exec {} at configuration time is rejected there, and the swallowed exception made every CI build fall back to version 0.1. providers.exec is the configuration-cache-compatible API.