### PR TITLE
Fix: correct several behaviors that differ from the original GOTY

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -5054,7 +5054,7 @@ void Board::SpawnZombieWave()
 
 	if (mCurrentWave == mNumWaves - 1 && !mApp->IsContinuousChallenge())
 	{
-		mRiseFromGraveCounter = 210;
+		mRiseFromGraveCounter = 200;
 	}
 	if (IsFlagWave(mCurrentWave))
 	{

--- a/src/Lawn/Challenge.cpp
+++ b/src/Lawn/Challenge.cpp
@@ -2995,7 +2995,8 @@ void Challenge::SpawnZombieWave()
 	if (mApp->IsSurvivalMode() && mBoard->mBackground == BACKGROUND_2_NIGHT && mBoard->mCurrentWave == mBoard->mNumWaves - 1)
 	{
 		int aNumGraves = mBoard->GetGraveStonesCount();
-		if ((mApp->IsSurvivalNormal(mApp->mGameMode) && aNumGraves < 8) || aNumGraves < 12)
+		int aGraveLimit = mApp->IsSurvivalNormal(mApp->mGameMode) ? 8 : 12;
+		if (aNumGraves < aGraveLimit)
 		{
 			GraveDangerSpawnRandomGrave();
 		}

--- a/src/Lawn/Plant.cpp
+++ b/src/Lawn/Plant.cpp
@@ -879,7 +879,7 @@ bool Plant::FindStarFruitTarget()
             else
             {
                 if (aZombie->mZombieType == ZombieType::ZOMBIE_DIGGER)
-                    aZombieRect.mX += 10;
+                    aZombieRect.mWidth += 10;
 
                 float aProjectileTime = Distance2D(aCenterStarX, aCenterStarY, aZombieRect.mX + aZombieRect.mWidth / 2, aZombieRect.mY + aZombieRect.mHeight / 2) / 3.33f;
                 int aZombieHitX = aZombie->ZombieTargetLeadX(aProjectileTime) - aZombieRect.mWidth / 2;
@@ -1287,7 +1287,7 @@ void Plant::UpdateSpikeweed()
         }
         else if (mSeedType == SeedType::SEED_SPIKEROCK)
         {
-            if (mStateCountdown == 69 || mStateCountdown == 33)
+            if (mStateCountdown == 70 || mStateCountdown == 32)
             {
                 DoRowAreaDamage(20, 33U);
             }

--- a/src/Lawn/Projectile.cpp
+++ b/src/Lawn/Projectile.cpp
@@ -286,7 +286,7 @@ void Projectile::CheckForCollision()
 		return;
 	}
 
-	if (mProjectileType == ProjectileType::PROJECTILE_STAR && (mPosY > 600.0f || mPosY < 0.0f))
+	if (mProjectileType == ProjectileType::PROJECTILE_STAR && (mPosY > 600.0f || mPosY < 40.0f))
 	{
 		Die();
 		return;

--- a/src/Lawn/Projectile.cpp
+++ b/src/Lawn/Projectile.cpp
@@ -232,7 +232,7 @@ Zombie* Projectile::FindCollisionTarget()
 	{
 		if ((aZombie->mZombieType == ZombieType::ZOMBIE_BOSS || aZombie->mRow == mRow) && aZombie->EffectedByDamage(static_cast<unsigned int>(mDamageRangeFlags)))
 		{
-			if (aZombie->mZombiePhase == ZombiePhase::PHASE_SNORKEL_WALKING_IN_POOL && mPosZ >= 45.0f)
+			if (aZombie->mZombiePhase == ZombiePhase::PHASE_SNORKEL_WALKING_IN_POOL && mPosZ <= 45.0f)
 			{
 				continue;
 			}

--- a/src/Lawn/Projectile.cpp
+++ b/src/Lawn/Projectile.cpp
@@ -83,7 +83,7 @@ void Projectile::ProjectileInitialize(int theX, int theY, int theRenderOrder, in
 	mCobTargetRow = 0;
 	mTargetZombieID = ZombieID::ZOMBIEID_NULL;
 	mOnHighGround = mBoard->mGridSquareType[aGridX][theRow] == GridSquareType::GRIDSQUARE_HIGH_GROUND;
-	if (mBoard->StageHasRoof())
+	if (mBoard->StageHasRoof() && theX < 480)
 	{
 		mShadowY -= 12.0f;
 	}

--- a/src/Lawn/Projectile.cpp
+++ b/src/Lawn/Projectile.cpp
@@ -243,7 +243,7 @@ Zombie* Projectile::FindCollisionTarget()
 			}
 
 			Rect aZombieRect = aZombie->GetZombieRect();
-			if (GetRectOverlap(aProjectileRect, aZombieRect) > 0)
+			if (GetRectOverlap(aProjectileRect, aZombieRect) >= 0)
 			{
 				if (aBestZombie == nullptr || aZombie->mX < aMinX)
 				{

--- a/src/Lawn/Zombie.cpp
+++ b/src/Lawn/Zombie.cpp
@@ -6435,7 +6435,7 @@ Zombie* Zombie::FindZombieTarget()
         {
             Rect aZombieRect = aZombie->GetZombieRect();
             int aOverlap = GetRectOverlap(aAttackRect, aZombieRect);
-            if (aOverlap >= 20 || (aOverlap > 0 && aZombie->mIsEating))
+            if (aOverlap >= 20 || (aOverlap >= 0 && aZombie->mIsEating))
             {
                 return aZombie;
             }
@@ -7449,7 +7449,7 @@ void Zombie::StopZombieSound()
 {
     if (mZombieType == ZombieType::ZOMBIE_DANCER || mZombieType == ZombieType::ZOMBIE_BACKUP_DANCER)
     {
-        bool aStopSound = false;
+        bool aStopSound = true;
 
         if (mBoard)
         {
@@ -7459,7 +7459,7 @@ void Zombie::StopZombieSound()
                 if (aZombie->mHasHead && !aZombie->IsDeadOrDying() && aZombie->IsOnBoard() && 
                     (aZombie->mZombieType == ZombieType::ZOMBIE_DANCER || aZombie->mZombieType == ZombieType::ZOMBIE_BACKUP_DANCER))
                 {
-                    aStopSound = true;
+                    aStopSound = false;
                     break;
                 }
             }


### PR DESCRIPTION
In this PR, I fixed issues left over from the project to make this project more consistent with the original version.
Fix list:
· Fixed the conditions for reducing roof shadows
· Fixed the conditions for Snorkel Zombies to skip hits
· Fixed the destruction position of star bullets
· Fixed the conditions for projectiles to overlap horizontally with zombies
· Fixed the conditions for stopping the Dancing Zombie / Backup Dancer Zombie music
· Fixed the edge-clipping conditions when Charmed Zombies attack and bite their targets
· Fixed the damage frames for the Spikerock and the special handling of Starfruit against Digger Zombies
· Fixed the cap on the number of new tombstones added during the final wave of Survival: Night
· Fixed the constant for the final wave ambush countdown