### PR TITLE
Refactor: split GameSelector slide displacement from button layout offset

### DIFF
--- a/src/Lawn/Widget/GameButton.cpp
+++ b/src/Lawn/Widget/GameButton.cpp
@@ -318,6 +318,8 @@ NewLawnButton::NewLawnButton(Image* theComponentImage, int theId, ButtonListener
 	mTextDownOffsetY = 0;
 	mButtonOffsetX = 0;
 	mButtonOffsetY = 0;
+	mSlideOffsetX = 0;
+	mSlideOffsetY = 0;
 	mUsePolygonShape = false;
 	SetColor(ButtonWidget::COLOR_BKG, Color::White);
 }
@@ -335,6 +337,8 @@ void NewLawnButton::Draw(Graphics* g)
 		return;
 
 	bool isDown = (mIsDown && mIsOver && !mDisabled) ^ mInverted;
+	int aOffsetX = GetDrawOffsetX();
+	int aOffsetY = GetDrawOffsetY();
 	int aFontX = mTextOffsetX + mTranslateX;
 	int aFontY = mTextOffsetY + mTranslateY;
 	if (mFont)
@@ -352,19 +356,19 @@ void NewLawnButton::Draw(Graphics* g)
 	{
 		g->SetColor(mColors[ButtonWidget::COLOR_BKG]);
 		if (mDisabled && HaveButtonImage(mDisabledImage, mDisabledRect))
-			DrawButtonImage(g, mDisabledImage, mDisabledRect, mButtonOffsetX, mButtonOffsetY);
+			DrawButtonImage(g, mDisabledImage, mDisabledRect, aOffsetX, aOffsetY);
 		else if (mOverAlpha > 0.0f && HaveButtonImage(mOverImage, mOverRect))
 		{
 			if (HaveButtonImage(mButtonImage, mNormalRect) && mOverAlpha < 1.0f)  // 未完全过渡结束
-				DrawButtonImage(g, mButtonImage, mNormalRect, mButtonOffsetX, mButtonOffsetY);
+				DrawButtonImage(g, mButtonImage, mNormalRect, aOffsetX, aOffsetY);
 
 			g->mColor.mAlpha = mOverAlpha * 255;
-			DrawButtonImage(g, mOverImage, mOverRect, mButtonOffsetX, mButtonOffsetY);
+			DrawButtonImage(g, mOverImage, mOverRect, aOffsetX, aOffsetY);
 		}
 		else if ((mIsOver || mIsDown) && HaveButtonImage(mOverImage, mOverRect))
-			DrawButtonImage(g, mOverImage, mOverRect, mButtonOffsetX, mButtonOffsetY);
+			DrawButtonImage(g, mOverImage, mOverRect, aOffsetX, aOffsetY);
 		else if (HaveButtonImage(mButtonImage, mNormalRect))
-			DrawButtonImage(g, mButtonImage, mNormalRect, mButtonOffsetX, mButtonOffsetY);
+			DrawButtonImage(g, mButtonImage, mNormalRect, aOffsetX, aOffsetY);
 
 		g->SetColorizeImages(false);
 		if (mIsOver)
@@ -383,11 +387,11 @@ void NewLawnButton::Draw(Graphics* g)
 	{
 		g->SetColor(mColors[ButtonWidget::COLOR_BKG]);
 		if (HaveButtonImage(mDownImage, mDownRect))
-			DrawButtonImage(g, mDownImage, mDownRect, mButtonOffsetX + mTranslateX, mButtonOffsetY + mTranslateY);
+			DrawButtonImage(g, mDownImage, mDownRect, aOffsetX + mTranslateX, aOffsetY + mTranslateY);
 		else if (HaveButtonImage(mOverImage, mOverRect))
-			DrawButtonImage(g, mOverImage, mOverRect, mButtonOffsetX + mTranslateX, mButtonOffsetY + mTranslateY);
+			DrawButtonImage(g, mOverImage, mOverRect, aOffsetX + mTranslateX, aOffsetY + mTranslateY);
 		else
-			DrawButtonImage(g, mButtonImage, mNormalRect, mButtonOffsetX + mTranslateX, mButtonOffsetY + mTranslateY);
+			DrawButtonImage(g, mButtonImage, mNormalRect, aOffsetX + mTranslateX, aOffsetY + mTranslateY);
 
 		g->SetColorizeImages(false);
 		g->SetFont(mHiliteFont ? mHiliteFont : mFont);
@@ -423,9 +427,4 @@ NewLawnButton* MakeNewButton(int theId, ButtonListener* theListener, std::string
 	aButton->mTranslateY = 1;
 
 	return aButton;
-}
-
-void NewLawnButton::SetOffset(int theX, int theY) {
-	this->mButtonOffsetX = theX;
-	this->mButtonOffsetY = theY;
 }

--- a/src/Lawn/Widget/GameButton.h
+++ b/src/Lawn/Widget/GameButton.h
@@ -116,8 +116,10 @@ public:
     _Font*					mHiliteFont;
     int						mTextDownOffsetX;
     int						mTextDownOffsetY;
-	int						mButtonOffsetX;
+	int						mButtonOffsetX;		// static layout offset, set once at creation
 	int						mButtonOffsetY;
+	int						mSlideOffsetX;		// displacement from GameSelector's slide animation
+	int						mSlideOffsetY;
 	bool					mUsePolygonShape;
 	SexyVector2				mPolygonShape[4];
 
@@ -128,8 +130,9 @@ public:
     void					Draw(Graphics* g) override;
 	bool					IsPointVisible(int x, int y) override;
     void					SetLabel(std::string_view theLabel);
-	// @Patoke: user defined
-	void					SetOffset(int theX, int theY);
+	void					SetSlideOffset(int theX, int theY) { mSlideOffsetX = theX; mSlideOffsetY = theY; }
+	int						GetDrawOffsetX() const { return mButtonOffsetX + mSlideOffsetX; }
+	int						GetDrawOffsetY() const { return mButtonOffsetY + mSlideOffsetY; }
 };
 
 LawnStoneButton*			MakeButton(int theId, ButtonListener* theListener, std::string_view theText);

--- a/src/Lawn/Widget/GameSelector.cpp
+++ b/src/Lawn/Widget/GameSelector.cpp
@@ -362,6 +362,23 @@ GameSelector::GameSelector(LawnApp* theApp)
 	mAchievementsWidget = new AchievementsWidget(this->mApp);
 	mAchievementsWidget->Move(0, mApp->mHeight);
 
+	mSlidingButtons = {
+		mAdventureButton,
+		mMinigameButton,
+		mPuzzleButton,
+		mOptionsButton,
+		mQuitButton,
+		mHelpButton,
+		mStoreButton,
+		mAlmanacButton,
+		mZenGardenButton,
+		mSurvivalButton,
+		mChangeUserButton,
+		mZombatarButton,
+		mAchievementsButton,
+		mQuickPlayButton
+	};
+
 	TodHesitationTrace("gameselectorinit");
 }
 
@@ -602,18 +619,18 @@ void GameSelector::Draw(Graphics* g)
 		float aFractionalOffsetY = fmod(aTransform.mTransY, 1.0f);
 		g->DrawImageF(
 			mOptionsButton->mButtonImage,
-			mOptionsButton->mX + mOptionsButton->mButtonOffsetX + aFractionalOffsetX,
-			mOptionsButton->mY + mOptionsButton->mButtonOffsetY + aFractionalOffsetY
+			mOptionsButton->mX + mOptionsButton->GetDrawOffsetX() + aFractionalOffsetX,
+			mOptionsButton->mY + mOptionsButton->GetDrawOffsetY() + aFractionalOffsetY
 		);
 		g->DrawImageF(
 			mQuitButton->mButtonImage,
-			mQuitButton->mX + mQuitButton->mButtonOffsetX + aFractionalOffsetX,
-			mQuitButton->mY + mQuitButton->mButtonOffsetY + aFractionalOffsetY
+			mQuitButton->mX + mQuitButton->GetDrawOffsetX() + aFractionalOffsetX,
+			mQuitButton->mY + mQuitButton->GetDrawOffsetY() + aFractionalOffsetY
 		);
 		g->DrawImageF(
 			mHelpButton->mButtonImage, 
-			mHelpButton->mX + mHelpButton->mButtonOffsetX + aFractionalOffsetX, 
-			mHelpButton->mY + mHelpButton->mButtonOffsetY + aFractionalOffsetY
+			mHelpButton->mX + mHelpButton->GetDrawOffsetX() + aFractionalOffsetX, 
+			mHelpButton->mY + mHelpButton->GetDrawOffsetY() + aFractionalOffsetY
 		);
 	}
 
@@ -794,20 +811,8 @@ void GameSelector::Update()
 		mOverlayWidget->Move(aNewX, aNewY);
 		mZombatarWidget->Move(aNewX + BOARD_WIDTH, aNewY);
 		mAchievementsWidget->mY = aNewY + mApp->mHeight;
-		mAdventureButton->SetOffset(aNewX, aNewY);
-		mMinigameButton->SetOffset(aNewX, aNewY);
-		mPuzzleButton->SetOffset(aNewX, aNewY);
-		mOptionsButton->SetOffset(aNewX, aNewY + 15);
-		mQuitButton->SetOffset(aNewX, aNewY + 5);
-		mHelpButton->SetOffset(aNewX, aNewY + 30);
-		mStoreButton->SetOffset(aNewX, aNewY);
-		mAlmanacButton->SetOffset(aNewX, aNewY);
-		mZenGardenButton->SetOffset(aNewX, aNewY);
-		mSurvivalButton->SetOffset(aNewX, aNewY);
-		mChangeUserButton->SetOffset(aNewX, aNewY);
-		mZombatarButton->SetOffset(aNewX, aNewY);
-		mAchievementsButton->SetOffset(aNewX, aNewY);
-		mQuickPlayButton->SetOffset(aNewX, aNewY);
+		for (NewLawnButton* aButton : mSlidingButtons)
+			aButton->SetSlideOffset(aNewX, aNewY);
 
 		// Make sure these are drawn even outside of bounds (force redraw)
 		mAchievementsButton->MarkDirty();

--- a/src/Lawn/Widget/GameSelector.h
+++ b/src/Lawn/Widget/GameSelector.h
@@ -22,6 +22,7 @@
 #ifndef __GAMESELECTOR_H__
 #define __GAMESELECTOR_H__
 
+#include <vector>
 #include "../../ConstEnums.h"
 #include "widget/Widget.h"
 #include "widget/ButtonListener.h"
@@ -84,6 +85,7 @@ public:
     NewLawnButton*              mZombatarButton;             //+GOTY @Patoke: 0xC0
     NewLawnButton*              mAchievementsButton;        //+GOTY @Patoke: 0xC4
     NewLawnButton*              mQuickPlayButton;           //+GOTY @Patoke: 0xC8
+    std::vector<NewLawnButton*> mSlidingButtons;            // buttons that follow the slide animation
     Widget*                     mOverlayWidget;
     bool                        mStartingGame;
     int                         mStartingGameCounter;


### PR DESCRIPTION
The slide animation overwrote each button's base layout offset via SetOffset, forcing the slide code to restate per-button magic numbers and dropping the quit button's X offset after visiting Zombatar. Keep the base offset immutable and drive the slide through a separate mSlideOffset applied uniformly to all sliding buttons.

Close #405.