### PR TITLE
Fix: add missing widget background in Zombatar list screen

### DIFF
--- a/src/Lawn/Widget/ZombatarWidget.cpp
+++ b/src/Lawn/Widget/ZombatarWidget.cpp
@@ -1039,6 +1039,8 @@ void ZombatarWidget::DrawMainBackground(Graphics* g)
 
 void ZombatarWidget::DrawList(Graphics* g)
 {
+	g->DrawImage(IMAGE_ZOMBATAR_WIDGET_BG, ZOMBATAR_PANEL_X, ZOMBATAR_PANEL_Y);
+
 	int aCount = GetHeadCount();
 	ClampCurrentIndex();
 	if (aCount <= 0)


### PR DESCRIPTION
In this PR, I added the missing `DrawImage` function call to the `ZombatarWidget::DrawList` function to ensure visual consistency with the original Zombatar list interface.

Original:
<img width="1920" height="1080" alt="屏幕截图 2026-08-03 205641" src="https://github.com/user-attachments/assets/ff710bf2-d48d-4386-bd7d-bfdefdf4349f" />

Before the fix:
<img width="1920" height="1080" alt="屏幕截图 2026-08-03 205736" src="https://github.com/user-attachments/assets/d72e7e9e-79e8-441a-8617-1868085dba44" />

After the fix:
<img width="1920" height="1080" alt="屏幕截图 2026-08-03 210114" src="https://github.com/user-attachments/assets/db616609-b547-44da-a6e3-d5f27e79a6d7" />
