### PR TITLE
Fix: keep iOS vcpkg ports on the declared deployment target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: vcpkg-cache
-        key: vcpkg-ios-${{ env.VCPKG_TC }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+        key: vcpkg-ios-${{ env.VCPKG_TC }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'CMake/triplets/arm64-ios.cmake') }}
         restore-keys: |
           vcpkg-ios-${{ env.VCPKG_TC }}-
           vcpkg-ios-
@@ -502,6 +502,7 @@ jobs:
 
         cmake -B $BUILD_DIR \
           -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+          -DVCPKG_OVERLAY_TRIPLETS=$GITHUB_WORKSPACE/CMake/triplets \
           -DVCPKG_TARGET_TRIPLET=arm64-ios \
           -DCMAKE_SYSTEM_NAME=iOS \
           -DCMAKE_OSX_DEPLOYMENT_TARGET=$IOS_DEPLOY_TARGET \

--- a/CMake/triplets/arm64-ios.cmake
+++ b/CMake/triplets/arm64-ios.cmake
@@ -1,0 +1,7 @@
+# Community arm64-ios triplet with the deployment target pinned, so vcpkg
+# ports inherit the main project's baseline instead of the build SDK's.
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME iOS)
+set(VCPKG_OSX_DEPLOYMENT_TARGET "15.0")

--- a/ios/build-ios.sh
+++ b/ios/build-ios.sh
@@ -29,6 +29,7 @@ mkdir -p "$BUILD_DIR"
 echo "--- Building PvZ-Portable ---"
 cmake -B "$BUILD_DIR/game" -S "$PROJECT_ROOT" \
     -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+    -DVCPKG_OVERLAY_TRIPLETS="$PROJECT_ROOT/CMake/triplets" \
     -DVCPKG_TARGET_TRIPLET=arm64-ios \
     -DCMAKE_SYSTEM_NAME=iOS \
     -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \


### PR DESCRIPTION
Close #418