### PR TITLE
Fix: remove non-original button sounds in Zombatar screens

### DIFF
--- a/src/Lawn/Widget/ZombatarTOS.cpp
+++ b/src/Lawn/Widget/ZombatarTOS.cpp
@@ -174,8 +174,7 @@ void ZombatarTOS::Update()
 
 void ZombatarTOS::ButtonPress(int theId)
 {
-	if (theId == ZombatarTOS::ZombatarTOS_Accept || theId == ZombatarTOS::ZombatarTOS_Back)
-		mApp->PlaySample(SOUND_BUTTONCLICK);
+	(void)theId;
 }
 
 void ZombatarTOS::ButtonDepress(int theId)
@@ -226,6 +225,7 @@ void ZombatarTOS::MouseWheel(int theDelta)
 
 void ZombatarTOS::CheckboxChecked(int theId, bool checked)
 {
+	mApp->PlaySample(SOUND_BUTTONCLICK);
 	if (theId == ZombatarTOS::ZombatarTOS_Checkbox && checked)
 	{
 		mFlashArrow = false;

--- a/src/Lawn/Widget/ZombatarWidget.cpp
+++ b/src/Lawn/Widget/ZombatarWidget.cpp
@@ -1439,7 +1439,6 @@ void ZombatarWidget::MouseUp(int x, int y)
 void ZombatarWidget::ButtonPress(int theId)
 {
 	(void)theId;
-	mApp->PlaySample(SOUND_GRAVEBUTTON);
 }
 
 void ZombatarWidget::ButtonDepress(int theId)


### PR DESCRIPTION
The port played SOUND_GRAVEBUTTON on every ZombatarWidget button press and SOUND_BUTTONCLICK on Zombatar TOS Accept/Back, neither of which exists in the original game. The original only plays SOUND_BUTTONCLICK on TOS checkbox toggles and slider value changes, which the port was missing.

Close #423