### PR TITLE
Fix: don't blow away balloon zombies that are still falling

### DIFF
--- a/src/Lawn/Plant.cpp
+++ b/src/Lawn/Plant.cpp
@@ -4262,9 +4262,8 @@ void Plant::BlowAwayFliers()
 			continue;
 		if (!aZombie->IsDeadOrDying())
 		{
-			// Verified as a pure function, safe to remove
-			// Rect aZombieRect = aZombie->GetZombieRect();
-			if (aZombie->IsFlying())
+			// Blow away only flying balloons here; balloons mid-pop are excluded
+			if (aZombie->mZombiePhase == ZombiePhase::PHASE_BALLOON_FLYING)
 			{
 				aZombie->mBlowingAway = true;
 			}


### PR DESCRIPTION
In the original game, planting a Blover while a popped balloon zombie is still falling does nothing to it — it lands and starts walking. Only airborne balloons are blown away. Match that behavior.