### PR TITLE
Fix: prevent negative zombie rect height during grave emergence

### DIFF
--- a/src/Lawn/Zombie.cpp
+++ b/src/Lawn/Zombie.cpp
@@ -8309,6 +8309,7 @@ Rect Zombie::GetZombieRect()
 	if (aDrawPos.mClipHeight > CLIP_HEIGHT_LIMIT)
 	{
 		aZombieRect.mHeight -= aDrawPos.mClipHeight;
+		aZombieRect.mHeight = std::max(aZombieRect.mHeight, 0);
 	}
 
 	return aZombieRect;


### PR DESCRIPTION
GetZombieRect() could return a Rect with negative mHeight when a zombie's clip height exceeded its body height (e.g. while still rising out of a grave in Whack-a-Zombie). This made GetCircleRectOverlap() call std::clamp(y, rect.mY, rect.mY + rect.mHeight) with hi < lo, triggering a libstdc++ assertion abort.

Clamp mHeight to 0 as a floor after the clip subtraction to fix whacking a zombie mid-emergence crashing the game.