### PR TITLE
Refactor: hold resource containers and font define maps in std::unique_ptr

### DIFF
--- a/src/PvzpLib/PvzpCommon.cpp
+++ b/src/PvzpLib/PvzpCommon.cpp
@@ -1074,10 +1074,10 @@ void PvzpResourceManager::AddImageToMap(SharedImageRef* theImage, const std::str
 {
 	PVZP_ASSERT(mImageMap.find(thePath) == mImageMap.end());
 
-	ImageRes* aImageRes = new ImageRes();
+	auto aImageRes = std::make_unique<ImageRes>();
 	aImageRes->mImage = *theImage;
 	aImageRes->mPath = thePath;
-	mImageMap.insert(ResMap::value_type(thePath, aImageRes));
+	mImageMap.insert(ResMap::value_type(thePath, std::move(aImageRes)));
 }
 
 bool PvzpLoadNextResource()
@@ -1171,7 +1171,7 @@ bool PvzpResourceManager::FindFontPath(_Font* theFont, std::string* thePath)
 {
 	for (auto anItr = mFontMap.begin(); anItr != mFontMap.end(); anItr++)
 	{
-		FontRes* aFontRes = (FontRes*)anItr->second;
+		FontRes* aFontRes = (FontRes*)anItr->second.get();
 		_Font* aFont = (_Font*)aFontRes->mFont.get();
 		if (aFont == theFont)
 		{
@@ -1186,7 +1186,7 @@ bool PvzpResourceManager::FindImagePath(Image* theImage, std::string* thePath)
 {
 	for (auto anItr = mImageMap.begin(); anItr != mImageMap.end(); anItr++)
 	{
-		ImageRes* aImageRes = (ImageRes*)anItr->second;
+		ImageRes* aImageRes = (ImageRes*)anItr->second.get();
 		Image* aImage = (Image*)aImageRes->mImage;
 		if (aImage == theImage)
 		{

--- a/src/SexyAppFramework/graphics/ImageFont.cpp
+++ b/src/SexyAppFramework/graphics/ImageFont.cpp
@@ -65,17 +65,13 @@ ListDataElement::ListDataElement()
 	mIsList = true;
 }
 
-ListDataElement::~ListDataElement()
-{
-	for (uint32_t i = 0; i < mElementVector.size(); i++)
-		delete mElementVector[i];
-}
+ListDataElement::~ListDataElement() = default;
 
 ListDataElement::ListDataElement(const ListDataElement& theListDataElement)
 {
 	mIsList = true;
 	for (uint32_t i = 0; i < theListDataElement.mElementVector.size(); i++)
-		mElementVector.push_back(theListDataElement.mElementVector[i]->Duplicate());
+		mElementVector.emplace_back(theListDataElement.mElementVector[i]->Duplicate());
 }
 
 ListDataElement& ListDataElement::operator=(const ListDataElement& theListDataElement)
@@ -83,14 +79,10 @@ ListDataElement& ListDataElement::operator=(const ListDataElement& theListDataEl
 	if (this == &theListDataElement)
 		return *this;
 
-	uint32_t i;
-
-	for (i = 0; i < mElementVector.size(); i++)
-		delete mElementVector[i];
 	mElementVector.clear();
 
-	for (i = 0; i < theListDataElement.mElementVector.size(); i++)
-		mElementVector.push_back(theListDataElement.mElementVector[i]->Duplicate());
+	for (uint32_t i = 0; i < theListDataElement.mElementVector.size(); i++)
+		mElementVector.emplace_back(theListDataElement.mElementVector[i]->Duplicate());
 
 	return *this;
 }
@@ -174,18 +166,7 @@ FontData::FontData()
 	mDefaultPointSize = 0;
 }
 
-FontData::~FontData()
-{
-	DataElementMap::iterator anItr = mDefineMap.begin();
-	while (anItr != mDefineMap.end())
-	{
-		std::string aDefineName = anItr->first;
-		DataElement* aDataElement = anItr->second;
-
-		delete aDataElement;
-		anItr++;
-	}
-}
+FontData::~FontData() = default;
 
 void FontData::Ref()
 {
@@ -286,7 +267,7 @@ static bool UTF8PairToUTF32Pair(const std::string& theString, char32_t& firstCha
 
 bool FontData::HandleCommand(const ListDataElement& theParams)
 {
-	std::string aCmd = ((SingleDataElement*)theParams.mElementVector[0])->mString;
+	std::string aCmd = ((SingleDataElement*)theParams.mElementVector[0].get())->mString;
 
 	bool invalidNumParams = false;
 	bool invalidParamFormat = false;
@@ -299,28 +280,25 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 		{
 			if (!theParams.mElementVector[1]->mIsList)
 			{
-				std::string aDefineName = StringToUpper(((SingleDataElement*)theParams.mElementVector[1])->mString);
+				std::string aDefineName = StringToUpper(((SingleDataElement*)theParams.mElementVector[1].get())->mString);
 
 				if (!IsImmediate(aDefineName))
 				{
 					DataElementMap::iterator anItr = mDefineMap.find(aDefineName);
 					if (anItr != mDefineMap.end())
-					{
-						delete anItr->second;
 						mDefineMap.erase(anItr);
-					}
 
 					if (theParams.mElementVector[2]->mIsList)
 					{
 						auto aValues = std::make_unique<ListDataElement>();
-						if (!GetValues(((ListDataElement*)theParams.mElementVector[2]), aValues.get()))
+						if (!GetValues(((ListDataElement*)theParams.mElementVector[2].get()), aValues.get()))
 							return false;
 
-						mDefineMap.insert(DataElementMap::value_type(aDefineName, aValues.release()));
+						mDefineMap.insert(DataElementMap::value_type(aDefineName, std::move(aValues)));
 					}
 					else
 					{
-						SingleDataElement* aDefParam = (SingleDataElement*)theParams.mElementVector[2];
+						SingleDataElement* aDefParam = (SingleDataElement*)theParams.mElementVector[2].get();
 
 						DataElement* aDerefVal = Dereference(aDefParam->mString);
 
@@ -347,46 +325,43 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 			std::vector<int> aWidthsVector;
 
 			if ((!theParams.mElementVector[1]->mIsList) &&
-				(DataToIntVector(theParams.mElementVector[2], &aRectIntVector)) &&
+				(DataToIntVector(theParams.mElementVector[2].get(), &aRectIntVector)) &&
 				(aRectIntVector.size() == 4) &&
-				(DataToIntVector(theParams.mElementVector[3], &aWidthsVector)))
+				(DataToIntVector(theParams.mElementVector[3].get(), &aWidthsVector)))
 			{
-				std::string aDefineName = StringToUpper(((SingleDataElement*)theParams.mElementVector[1])->mString);
+				std::string aDefineName = StringToUpper(((SingleDataElement*)theParams.mElementVector[1].get())->mString);
 
 				int aXPos = 0;
 
-				ListDataElement* aRectList = new ListDataElement();
+				auto aRectList = std::make_unique<ListDataElement>();
 
 				for (uint32_t aWidthNum = 0; aWidthNum < aWidthsVector.size(); aWidthNum++)
 				{
 					ListDataElement* aRectElement = new ListDataElement();
-					aRectList->mElementVector.push_back(aRectElement);
+					aRectList->mElementVector.emplace_back(aRectElement);
 
 					char aStr[256];
 
 					snprintf(aStr, sizeof(aStr), "%d", aRectIntVector[0] + aXPos);
-					aRectElement->mElementVector.push_back(new SingleDataElement(aStr));
+					aRectElement->mElementVector.push_back(std::make_unique<SingleDataElement>(aStr));
 
 					snprintf(aStr, sizeof(aStr), "%d", aRectIntVector[1]);
-					aRectElement->mElementVector.push_back(new SingleDataElement(aStr));
+					aRectElement->mElementVector.push_back(std::make_unique<SingleDataElement>(aStr));
 
 					snprintf(aStr, sizeof(aStr), "%d", aWidthsVector[aWidthNum]);
-					aRectElement->mElementVector.push_back(new SingleDataElement(aStr));
+					aRectElement->mElementVector.push_back(std::make_unique<SingleDataElement>(aStr));
 
 					snprintf(aStr, sizeof(aStr), "%d", aRectIntVector[3]);
-					aRectElement->mElementVector.push_back(new SingleDataElement(aStr));
+					aRectElement->mElementVector.push_back(std::make_unique<SingleDataElement>(aStr));
 
 					aXPos += aWidthsVector[aWidthNum];
 				}
 
 				DataElementMap::iterator anItr = mDefineMap.find(aDefineName);
 				if (anItr != mDefineMap.end())
-				{
-					delete anItr->second;
 					mDefineMap.erase(anItr);
-				}
 
-				mDefineMap.insert(DataElementMap::value_type(aDefineName, aRectList));
+				mDefineMap.insert(DataElementMap::value_type(aDefineName, std::move(aRectList)));
 			}
 			else
 				invalidParamFormat = true;
@@ -401,7 +376,7 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 			int aPointSize;
 
 			if ((!theParams.mElementVector[1]->mIsList) &&
-				(StringToInt(((SingleDataElement*)theParams.mElementVector[1])->mString, &aPointSize)))
+				(StringToInt(((SingleDataElement*)theParams.mElementVector[1].get())->mString, &aPointSize)))
 			{
 				mDefaultPointSize = aPointSize;
 			}
@@ -418,8 +393,8 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 			std::vector<std::string> aFromVector;
 			std::vector<std::string> aToVector;
 
-			if ((DataToStringVector(theParams.mElementVector[1], &aFromVector)) &&
-				(DataToStringVector(theParams.mElementVector[2], &aToVector)))
+			if ((DataToStringVector(theParams.mElementVector[1].get(), &aFromVector)) &&
+				(DataToStringVector(theParams.mElementVector[2].get(), &aToVector)))
 			{
 				if (aFromVector.size() == aToVector.size())
 				{
@@ -448,7 +423,7 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 		{
 			if (!theParams.mElementVector[1]->mIsList)
 			{
-				std::string aLayerName = StringToUpper(((SingleDataElement*)theParams.mElementVector[1])->mString);
+				std::string aLayerName = StringToUpper(((SingleDataElement*)theParams.mElementVector[1].get())->mString);
 
 				mFontLayerList.push_back(FontLayer(this));
 				FontLayer* aFontLayer = &mFontLayerList.back();
@@ -470,9 +445,9 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 		{
 			FontLayer* aSourceLayer;
 
-			if ((!theParams.mElementVector[1]->mIsList) && (DataToLayer(theParams.mElementVector[2], &aSourceLayer)))
+			if ((!theParams.mElementVector[1]->mIsList) && (DataToLayer(theParams.mElementVector[2].get(), &aSourceLayer)))
 			{
-				std::string aLayerName = StringToUpper(((SingleDataElement*)theParams.mElementVector[1])->mString);
+				std::string aLayerName = StringToUpper(((SingleDataElement*)theParams.mElementVector[1].get())->mString);
 
 				mFontLayerList.push_back(FontLayer(*aSourceLayer));
 				FontLayer* aFontLayer = &mFontLayerList.back();
@@ -495,8 +470,8 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 			FontLayer* aLayer;
 			std::vector<std::string> aStringVector;
 
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
-				(DataToStringVector(theParams.mElementVector[2], &aStringVector)))
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
+				(DataToStringVector(theParams.mElementVector[2].get(), &aStringVector)))
 			{
 				for (uint32_t i = 0; i < aStringVector.size(); i++)
 					aLayer->mRequiredTags.push_back(StringToUpper(aStringVector[i]));
@@ -514,8 +489,8 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 			FontLayer* aLayer;
 			std::vector<std::string> aStringVector;
 
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
-				(DataToStringVector(theParams.mElementVector[2], &aStringVector)))
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
+				(DataToStringVector(theParams.mElementVector[2].get(), &aStringVector)))
 			{
 				for (uint32_t i = 0; i < aStringVector.size(); i++)
 					aLayer->mExcludedTags.push_back(StringToUpper(aStringVector[i]));
@@ -531,15 +506,15 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 		if (theParams.mElementVector.size() == 4)
 		{
 			FontLayer* aLayer;
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
 				(!theParams.mElementVector[2]->mIsList) &&
 				(!theParams.mElementVector[3]->mIsList))
 			{
 				int aMinPointSize;
 				int aMaxPointSize;
 
-				if ((StringToInt(((SingleDataElement*)theParams.mElementVector[2])->mString, &aMinPointSize)) &&
-					(StringToInt(((SingleDataElement*)theParams.mElementVector[3])->mString, &aMaxPointSize)))
+				if ((StringToInt(((SingleDataElement*)theParams.mElementVector[2].get())->mString, &aMinPointSize)) &&
+					(StringToInt(((SingleDataElement*)theParams.mElementVector[3].get())->mString, &aMaxPointSize)))
 				{
 					aLayer->mMinPointSize = aMinPointSize;
 					aLayer->mMaxPointSize = aMaxPointSize;
@@ -558,11 +533,11 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 		if (theParams.mElementVector.size() == 3)
 		{
 			FontLayer* aLayer;
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
 				(!theParams.mElementVector[2]->mIsList))
 			{
 				int aPointSize;
-				if (StringToInt(((SingleDataElement*)theParams.mElementVector[2])->mString, &aPointSize))
+				if (StringToInt(((SingleDataElement*)theParams.mElementVector[2].get())->mString, &aPointSize))
 				{
 					aLayer->mPointSize = aPointSize;
 				}
@@ -580,11 +555,11 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 		if (theParams.mElementVector.size() == 3)
 		{
 			FontLayer* aLayer;
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
 				(!theParams.mElementVector[2]->mIsList))
 			{
 				int aHeight;
-				if (StringToInt(((SingleDataElement*)theParams.mElementVector[2])->mString, &aHeight))
+				if (StringToInt(((SingleDataElement*)theParams.mElementVector[2].get())->mString, &aHeight))
 				{
 					aLayer->mHeight = aHeight;
 				}
@@ -604,8 +579,8 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 			FontLayer* aLayer;
 			std::string aFileNameString;
 
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
-				(DataToString(theParams.mElementVector[2], &aFileNameString)))
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
+				(DataToString(theParams.mElementVector[2].get(), &aFileNameString)))
 			{
 				std::string aFileName = GetPathFrom(aFileNameString, GetFileDir(mSourceFile));
 
@@ -635,10 +610,10 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 		if (theParams.mElementVector.size() == 3)
 		{
 			FontLayer* aLayer;
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) && (!theParams.mElementVector[2]->mIsList))
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) && (!theParams.mElementVector[2]->mIsList))
 			{
 				int anDrawMode;
-				if ((StringToInt(((SingleDataElement*)theParams.mElementVector[2])->mString, &anDrawMode)) &&
+				if ((StringToInt(((SingleDataElement*)theParams.mElementVector[2].get())->mString, &anDrawMode)) &&
 					(anDrawMode >= 0) && (anDrawMode <= 1))
 				{
 					aLayer->mDrawMode = anDrawMode;
@@ -657,9 +632,9 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 		if (theParams.mElementVector.size() == 3)
 		{
 			FontLayer* aLayer;
-			if (DataToLayer(theParams.mElementVector[1], &aLayer))
+			if (DataToLayer(theParams.mElementVector[1].get(), &aLayer))
 			{
-				if (!GetColorFromDataElement(theParams.mElementVector[2], aLayer->mColorMult))
+				if (!GetColorFromDataElement(theParams.mElementVector[2].get(), aLayer->mColorMult))
 					invalidParamFormat = true;
 			}
 			else
@@ -673,9 +648,9 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 		if (theParams.mElementVector.size() == 3)
 		{
 			FontLayer* aLayer;
-			if (DataToLayer(theParams.mElementVector[1], &aLayer))
+			if (DataToLayer(theParams.mElementVector[1].get(), &aLayer))
 			{
-				if (!GetColorFromDataElement(theParams.mElementVector[2], aLayer->mColorAdd))
+				if (!GetColorFromDataElement(theParams.mElementVector[2].get(), aLayer->mColorAdd))
 					invalidParamFormat = true;
 			}
 			else
@@ -689,11 +664,11 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 		if (theParams.mElementVector.size() == 3)
 		{
 			FontLayer* aLayer;
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
 				(!theParams.mElementVector[2]->mIsList))
 			{
 				int anAscent;
-				if (StringToInt(((SingleDataElement*)theParams.mElementVector[2])->mString, &anAscent))
+				if (StringToInt(((SingleDataElement*)theParams.mElementVector[2].get())->mString, &anAscent))
 				{
 					aLayer->mAscent = anAscent;
 				}
@@ -711,11 +686,11 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 		if (theParams.mElementVector.size() == 3)
 		{
 			FontLayer* aLayer;
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
 				(!theParams.mElementVector[2]->mIsList))
 			{
 				int anAscent;
-				if (StringToInt(((SingleDataElement*)theParams.mElementVector[2])->mString, &anAscent))
+				if (StringToInt(((SingleDataElement*)theParams.mElementVector[2].get())->mString, &anAscent))
 				{
 					aLayer->mAscentPadding = anAscent;
 				}
@@ -733,11 +708,11 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 		if (theParams.mElementVector.size() == 3)
 		{
 			FontLayer* aLayer;
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
 				(!theParams.mElementVector[2]->mIsList))
 			{
 				int anAscent;
-				if (StringToInt(((SingleDataElement*)theParams.mElementVector[2])->mString, &anAscent))
+				if (StringToInt(((SingleDataElement*)theParams.mElementVector[2].get())->mString, &anAscent))
 				{
 					aLayer->mLineSpacingOffset = anAscent;
 				}
@@ -757,7 +732,7 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 			FontLayer* aLayer;
 			std::vector<int> anOffset;
 
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) && (DataToIntVector(theParams.mElementVector[2], &anOffset)) && (anOffset.size() == 2))
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) && (DataToIntVector(theParams.mElementVector[2].get(), &anOffset)) && (anOffset.size() == 2))
 			{
 				aLayer->mOffset.mX = anOffset[0];
 				aLayer->mOffset.mY = anOffset[1];
@@ -776,9 +751,9 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 			std::vector<std::string> aCharsVector;
 			std::vector<int> aCharWidthsVector;
 
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
-				(DataToStringVector(theParams.mElementVector[2], &aCharsVector)) &&
-				(DataToIntVector(theParams.mElementVector[3], &aCharWidthsVector)))
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
+				(DataToStringVector(theParams.mElementVector[2].get(), &aCharsVector)) &&
+				(DataToIntVector(theParams.mElementVector[3].get(), &aCharWidthsVector)))
 			{
 				if (aCharsVector.size() == aCharWidthsVector.size())
 				{
@@ -804,12 +779,12 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 			FontLayer* aLayer;
 			std::vector<int> anOffset;
 
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
 				(!theParams.mElementVector[2]->mIsList))
 			{
 				int aSpacing;
 
-				if (StringToInt(((SingleDataElement*)theParams.mElementVector[2])->mString, &aSpacing))
+				if (StringToInt(((SingleDataElement*)theParams.mElementVector[2].get())->mString, &aSpacing))
 				{
 					aLayer->mSpacing = aSpacing;
 				}
@@ -830,9 +805,9 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 			std::vector<std::string> aCharsVector;
 			ListDataElement aRectList;
 
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
-				(DataToStringVector(theParams.mElementVector[2], &aCharsVector)) &&
-				(DataToList(theParams.mElementVector[3], &aRectList)))
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
+				(DataToStringVector(theParams.mElementVector[2].get(), &aCharsVector)) &&
+				(DataToList(theParams.mElementVector[3].get(), &aRectList)))
 			{
 				if (aCharsVector.size() == aRectList.mElementVector.size())
 				{
@@ -846,7 +821,7 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 							std::vector<int> aRectElement;
 							char32_t first_char = UTF8CharToUTF32Char(aCharsVector[i]);
 
-							if ((DataToIntVector(aRectList.mElementVector[i], &aRectElement)) &&
+							if ((DataToIntVector(aRectList.mElementVector[i].get(), &aRectElement)) &&
 								(aRectElement.size() == 4))
 
 							{
@@ -895,9 +870,9 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 			std::vector<std::string> aCharsVector = std::vector<std::string>();
 			ListDataElement aRectList = ListDataElement();
 
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
-				(DataToStringVector(theParams.mElementVector[2], &aCharsVector)) &&
-				(DataToList(theParams.mElementVector[3], &aRectList)))
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
+				(DataToStringVector(theParams.mElementVector[2].get(), &aCharsVector)) &&
+				(DataToList(theParams.mElementVector[3].get(), &aRectList)))
 			{
 				if (aCharsVector.size() == aRectList.mElementVector.size())
 				{
@@ -906,7 +881,7 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 						std::vector<int> aRectElement = std::vector<int>();
 						char32_t first_char = UTF8CharToUTF32Char(aCharsVector[i]);
 
-						if ((DataToIntVector(aRectList.mElementVector[i], &aRectElement)) &&
+						if ((DataToIntVector(aRectList.mElementVector[i].get(), &aRectElement)) &&
 							(aRectElement.size() == 2))
 						{
 							aLayer->GetCharData(first_char)->mOffset = Point(aRectElement[0], aRectElement[1]);
@@ -933,9 +908,9 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 			std::vector<std::string> aPairsVector;
 			std::vector<int> anOffsetsVector;
 
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
-				(DataToStringVector(theParams.mElementVector[2], &aPairsVector)) &&
-				(DataToIntVector(theParams.mElementVector[3], &anOffsetsVector)))
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
+				(DataToStringVector(theParams.mElementVector[2].get(), &aPairsVector)) &&
+				(DataToIntVector(theParams.mElementVector[3].get(), &anOffsetsVector)))
 			{
 				if (aPairsVector.size() == anOffsetsVector.size())
 				{
@@ -965,11 +940,11 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 		if (theParams.mElementVector.size() == 3)
 		{
 			FontLayer* aLayer;
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
 				(!theParams.mElementVector[2]->mIsList))
 			{
 				int aBaseOrder;
-				if (StringToInt(((SingleDataElement*)theParams.mElementVector[2])->mString, &aBaseOrder))
+				if (StringToInt(((SingleDataElement*)theParams.mElementVector[2].get())->mString, &aBaseOrder))
 				{
 					aLayer->mBaseOrder = aBaseOrder;
 				}
@@ -990,9 +965,9 @@ bool FontData::HandleCommand(const ListDataElement& theParams)
 			std::vector<std::string> aCharsVector;
 			std::vector<int> aCharOrdersVector;
 
-			if ((DataToLayer(theParams.mElementVector[1], &aLayer)) &&
-				(DataToStringVector(theParams.mElementVector[2], &aCharsVector)) &&
-				(DataToIntVector(theParams.mElementVector[3], &aCharOrdersVector)))
+			if ((DataToLayer(theParams.mElementVector[1].get(), &aLayer)) &&
+				(DataToStringVector(theParams.mElementVector[2].get(), &aCharsVector)) &&
+				(DataToIntVector(theParams.mElementVector[3].get(), &aCharOrdersVector)))
 			{
 				if (aCharsVector.size() == aCharOrdersVector.size())
 				{
@@ -1140,16 +1115,17 @@ bool FontData::LoadLegacy(Image* theFontImage, const std::string& theFontDescFil
 ActiveFontLayer::ActiveFontLayer()
 {
 	mScaledImage = nullptr;
-	mOwnsImage = false;
 }
 
 ActiveFontLayer::ActiveFontLayer(const ActiveFontLayer& theActiveFontLayer) :
 	mBaseFontLayer(theActiveFontLayer.mBaseFontLayer),
-	mScaledImage(theActiveFontLayer.mScaledImage),
-	mOwnsImage(theActiveFontLayer.mOwnsImage)
+	mScaledImage(theActiveFontLayer.mScaledImage)
 {
-	if (mOwnsImage)
-		mScaledImage = mBaseFontLayer->mFontData->mApp->CopyImage(mScaledImage);
+	if (theActiveFontLayer.mOwnedScaledImage != nullptr)
+	{
+		mOwnedScaledImage.reset(mBaseFontLayer->mFontData->mApp->CopyImage(mScaledImage));
+		mScaledImage = mOwnedScaledImage.get();
+	}
 
 	for (auto anItr = theActiveFontLayer.mScaledCharImageRects.begin(); anItr != theActiveFontLayer.mScaledCharImageRects.end(); anItr++)
 	{
@@ -1157,11 +1133,7 @@ ActiveFontLayer::ActiveFontLayer(const ActiveFontLayer& theActiveFontLayer) :
 	}
 }
 
-ActiveFontLayer::~ActiveFontLayer()
-{
-	if (mOwnsImage)
-		delete mScaledImage;
-}
+ActiveFontLayer::~ActiveFontLayer() = default;
 
 ImageFont::ImageFont(SexyAppBase* theSexyApp, const std::string& theFontDescFileName)
 {
@@ -1278,7 +1250,6 @@ void ImageFont::GenerateActiveFontLayers()
 				if ((mScale == 1.0) && ((aFontLayer->mPointSize == 0) || (mPointSize == aFontLayer->mPointSize)))
 				{
 					anActiveFontLayer->mScaledImage = aFontLayer->mImage;
-					anActiveFontLayer->mOwnsImage = false;
 
 					for (auto anItr = aFontLayer->mCharDataMap.begin(); anItr != aFontLayer->mCharDataMap.end(); anItr++)
 					{
@@ -1294,7 +1265,8 @@ void ImageFont::GenerateActiveFontLayers()
 					}
 
 					// Resize font elements
-					MemoryImage* aMemoryImage = new MemoryImage(mFontData->mApp);
+					anActiveFontLayer->mOwnedScaledImage = std::make_unique<MemoryImage>(mFontData->mApp);
+					MemoryImage* aMemoryImage = (MemoryImage*)anActiveFontLayer->mOwnedScaledImage.get();
 
 					int aCurX = 0;
 					int aMaxHeight = 0;
@@ -1315,7 +1287,6 @@ void ImageFont::GenerateActiveFontLayers()
 					}
 
 					anActiveFontLayer->mScaledImage = aMemoryImage;
-					anActiveFontLayer->mOwnsImage = true;
 
 					// Create the image now
 					aMemoryImage->Create(aCurX, aMaxHeight);

--- a/src/SexyAppFramework/graphics/ImageFont.h
+++ b/src/SexyAppFramework/graphics/ImageFont.h
@@ -134,7 +134,7 @@ public:
 	FontLayer*				mBaseFontLayer;
 
 	Image*					mScaledImage;
-	bool					mOwnsImage;
+	std::unique_ptr<Image>	mOwnedScaledImage;
 	CharRectMap				mScaledCharImageRects;
 
 public:

--- a/src/SexyAppFramework/misc/DescParser.cpp
+++ b/src/SexyAppFramework/misc/DescParser.cpp
@@ -48,7 +48,7 @@ DataElement* DescParser::Dereference(const std::string& theString)
 
 	DataElementMap::iterator anItr = mDefineMap.find(aDefineName);
 	if (anItr != mDefineMap.end())
-		return anItr->second;
+		return anItr->second.get();
 	else
 		return nullptr;
 }
@@ -98,25 +98,25 @@ bool DescParser::GetValues(ListDataElement* theSource, ListDataElement* theValue
 		if (theSource->mElementVector[aSourceNum]->mIsList)
 		{
 			ListDataElement* aChildList = new ListDataElement();
-			theValues->mElementVector.push_back(aChildList);
+			theValues->mElementVector.emplace_back(aChildList);
 
-			if (!GetValues((ListDataElement*) theSource->mElementVector[aSourceNum], aChildList))
+			if (!GetValues((ListDataElement*) theSource->mElementVector[aSourceNum].get(), aChildList))
 				return false;
 		}
 		else
 		{
-			std::string aString = ((SingleDataElement*) theSource->mElementVector[aSourceNum])->mString;
+			std::string aString = ((SingleDataElement*) theSource->mElementVector[aSourceNum].get())->mString;
 
 			if (aString.length() > 0)
 			{
 				if ((aString[0] == '\'') || (aString[0] == '"'))
 				{
 					SingleDataElement* aChildData = new SingleDataElement(Unquote(aString));
-					theValues->mElementVector.push_back(aChildData);
+					theValues->mElementVector.emplace_back(aChildData);
 				}
 				else if (IsImmediate(aString))
 				{
-					theValues->mElementVector.push_back(new SingleDataElement(aString));
+					theValues->mElementVector.push_back(std::make_unique<SingleDataElement>(aString));
 				}
 				else
 				{
@@ -130,7 +130,7 @@ bool DescParser::GetValues(ListDataElement* theSource, ListDataElement* theValue
 						return false;
 					}
 
-					theValues->mElementVector.push_back(anItr->second->Duplicate());
+					theValues->mElementVector.emplace_back(anItr->second->Duplicate());
 				}
 			}
 
@@ -154,7 +154,7 @@ std::string DescParser::DataElementToString(DataElement* theDataElement)
 			if (i != 0)
 				aString += ", ";
 
-			aString += DataElementToString(aListDataElement->mElementVector[i]);
+			aString += DataElementToString(aListDataElement->mElementVector[i].get());
 		}
 
 		aString += ")";
@@ -246,7 +246,7 @@ bool DescParser::DataToStringVector(DataElement* theSource, std::vector<std::str
 			return false;
 		}
 
-		SingleDataElement* aSingleDataElement = (SingleDataElement*) aValues->mElementVector[i];
+		SingleDataElement* aSingleDataElement = (SingleDataElement*) aValues->mElementVector[i].get();
 
 		theStringVector->push_back(aSingleDataElement->mString);
 	}
@@ -370,12 +370,12 @@ bool DescParser::ParseToList(const std::string& theString, ListDataElement* theL
 					}
 					else
 					{
-						ListDataElement* aChildList = new ListDataElement();
+						auto aChildList = std::make_unique<ListDataElement>();
 
-						if (!ParseToList(theString, aChildList, true, theStringPos))
+						if (!ParseToList(theString, aChildList.get(), true, theStringPos))
 							return false;
 
-						theList->mElementVector.push_back(aChildList);
+						theList->mElementVector.push_back(std::move(aChildList));
 					}
 				}
 				else if (isSeperator)
@@ -395,7 +395,7 @@ bool DescParser::ParseToList(const std::string& theString, ListDataElement* theL
 			if (aCurSingleDataElement == nullptr)
 			{
 				aCurSingleDataElement = new SingleDataElement();
-				theList->mElementVector.push_back(aCurSingleDataElement);
+				theList->mElementVector.emplace_back(aCurSingleDataElement);
 			}
 
 			aCurSingleDataElement->mString += aChar;

--- a/src/SexyAppFramework/misc/DescParser.h
+++ b/src/SexyAppFramework/misc/DescParser.h
@@ -26,6 +26,7 @@
 #define __DESCPARSER_H__
 
 #include "Common.h"
+#include <memory>
 
 namespace Sexy
 {
@@ -55,7 +56,7 @@ public:
 	DataElement*			Duplicate() override;
 };
 
-typedef std::vector<DataElement*> ElementVector;
+typedef std::vector<std::unique_ptr<DataElement>> ElementVector;
 
 class ListDataElement : public DataElement
 {
@@ -72,7 +73,7 @@ public:
 	DataElement*			Duplicate() override;
 };
 
-typedef std::map<std::string, DataElement*> DataElementMap;
+typedef std::map<std::string, std::unique_ptr<DataElement>> DataElementMap;
 typedef std::vector<double> DoubleVector;
 
 class DescParser

--- a/src/SexyAppFramework/misc/ResourceManager.cpp
+++ b/src/SexyAppFramework/misc/ResourceManager.cpp
@@ -85,12 +85,7 @@ bool ResourceManager::IsGroupLoaded(const std::string &theGroup)
 void ResourceManager::DeleteMap(ResMap &theMap)
 {
 	for (ResMap::iterator anItr = theMap.begin(); anItr != theMap.end(); ++anItr)
-	{
 		anItr->second->DeleteResource();
-		delete anItr->second;
-	}
-
-	theMap.clear();
 }
 
 void ResourceManager::DeleteResources(ResMap &theMap, const std::string &theGroup)
@@ -130,7 +125,7 @@ void ResourceManager::DeleteExtraImageBuffers(const std::string &theGroup)
 	{
 		if (theGroup.empty() || anItr->second->mResGroup==theGroup)
 		{
-			ImageRes *aRes = (ImageRes*)anItr->second;
+			ImageRes *aRes = (ImageRes*)anItr->second.get();
 			MemoryImage *anImage = (MemoryImage*)aRes->mImage;
 			if (anImage != nullptr)
 				anImage->DeleteExtraBuffers();
@@ -176,7 +171,7 @@ bool ResourceManager::Fail(const std::string& theErrorText)
 	return false;
 }
 
-bool ResourceManager::ParseCommonResource(XMLElement &theElement, BaseRes *theRes, ResMap &theMap)
+bool ResourceManager::ParseCommonResource(XMLElement &theElement, std::unique_ptr<BaseRes> &theRes, ResMap &theMap)
 {
 	mHadAlreadyDefinedError = false;
 
@@ -206,40 +201,38 @@ bool ResourceManager::ParseCommonResource(XMLElement &theElement, BaseRes *theRe
 	theRes->mResGroup = mCurResGroup;
 	theRes->mId = anId;
 
-	std::pair<ResMap::iterator,bool> aRet = theMap.insert(ResMap::value_type(anId,theRes));
+	std::pair<ResMap::iterator,bool> aRet = theMap.try_emplace(anId, std::move(theRes));
 	if (!aRet.second)
 	{
 		mHadAlreadyDefinedError = true;
 		return Fail("Resource already defined.");
 	}
 
-	mCurResGroupList->push_back(theRes);
+	mCurResGroupList->push_back(aRet.first->second.get());
 	return true;
 }
 
 bool ResourceManager::ParseSoundResource(XMLElement &theElement)
 {
-	auto aNewRes = std::make_unique<SoundRes>();
-	SoundRes *aRes = aNewRes.get();
+	std::unique_ptr<BaseRes> aNewRes = std::make_unique<SoundRes>();
+	SoundRes *aRes = (SoundRes*)aNewRes.get();
 	aRes->mSoundId = -1;
 	aRes->mVolume = -1;
 	aRes->mPanning = 0;
 
-	if (!ParseCommonResource(theElement, aRes, mSoundMap))
+	if (!ParseCommonResource(theElement, aNewRes, mSoundMap))
 	{
 		if (mHadAlreadyDefinedError && mAllowAlreadyDefinedResources)
 		{
 			mError = "";
 			mHasFailed = false;
-			aRes = (SoundRes*)mSoundMap[aRes->mId];
+			aRes = (SoundRes*)mSoundMap[aRes->mId].get();
 			aRes->mPath = aNewRes->mPath;
 			aRes->mXMLAttributes = aNewRes->mXMLAttributes;
 		}
 		else
 			return false;
 	}
-	else
-		aNewRes.release();
 
 	XMLParamMap::iterator anItr;
 
@@ -272,23 +265,21 @@ static void ReadIntVector(const std::string &theVal, std::vector<int> &theVector
 
 bool ResourceManager::ParseImageResource(XMLElement &theElement)
 {
-	auto aNewRes = std::make_unique<ImageRes>();
-	ImageRes *aRes = aNewRes.get();
-	if (!ParseCommonResource(theElement, aRes, mImageMap))
+	std::unique_ptr<BaseRes> aNewRes = std::make_unique<ImageRes>();
+	ImageRes *aRes = (ImageRes*)aNewRes.get();
+	if (!ParseCommonResource(theElement, aNewRes, mImageMap))
 	{
 		if (mHadAlreadyDefinedError && mAllowAlreadyDefinedResources)
 		{
 			mError = "";
 			mHasFailed = false;
-			aRes = (ImageRes*)mImageMap[aRes->mId];
+			aRes = (ImageRes*)mImageMap[aRes->mId].get();
 			aRes->mPath = aNewRes->mPath;
 			aRes->mXMLAttributes = aNewRes->mXMLAttributes;
 		}
 		else
 			return false;
 	}
-	else
-		aNewRes.release();
 
 	aRes->mPalletize = theElement.mAttributes.find("nopal") == theElement.mAttributes.end();
 	aRes->mA4R4G4B4 = theElement.mAttributes.find("a4r4g4b4") != theElement.mAttributes.end();
@@ -387,24 +378,22 @@ bool ResourceManager::ParseImageResource(XMLElement &theElement)
 
 bool ResourceManager::ParseFontResource(XMLElement &theElement)
 {
-	auto aNewRes = std::make_unique<FontRes>();
-	FontRes *aRes = aNewRes.get();
+	std::unique_ptr<BaseRes> aNewRes = std::make_unique<FontRes>();
+	FontRes *aRes = (FontRes*)aNewRes.get();
 
-	if (!ParseCommonResource(theElement, aRes, mFontMap))
+	if (!ParseCommonResource(theElement, aNewRes, mFontMap))
 	{
 		if (mHadAlreadyDefinedError && mAllowAlreadyDefinedResources)
 		{
 			mError = "";
 			mHasFailed = false;
-			aRes = (FontRes*)mFontMap[aRes->mId];
+			aRes = (FontRes*)mFontMap[aRes->mId].get();
 			aRes->mPath = aNewRes->mPath;
 			aRes->mXMLAttributes = aNewRes->mXMLAttributes;
 		}
 		else
 			return false;
 	}
-	else
-		aNewRes.release();
 
 
 	XMLParamMap::iterator anItr;
@@ -773,7 +762,7 @@ SharedImageRef ResourceManager::LoadImage(const std::string &theName)
 	if (anItr == mImageMap.end())
 		return nullptr;
 
-	ImageRes *aRes = (ImageRes*)anItr->second;
+	ImageRes *aRes = (ImageRes*)anItr->second.get();
 	if ((GLImage*) aRes->mImage != nullptr)
 		return aRes->mImage;
 
@@ -879,7 +868,7 @@ _Font* ResourceManager::LoadFont(const std::string &theName)
 	if (anItr == mFontMap.end())
 		return nullptr;
 
-	FontRes *aRes = (FontRes*)anItr->second;
+	FontRes *aRes = (FontRes*)anItr->second.get();
 	if (aRes->mFont != nullptr)
 		return aRes->mFont.get();
 
@@ -1013,7 +1002,7 @@ int	ResourceManager::GetNumResources(const std::string &theGroup, ResMap &theMap
 	int aCount = 0;
 	for (ResMap::iterator anItr = theMap.begin(); anItr != theMap.end(); ++anItr)
 	{
-		BaseRes *aRes = anItr->second;
+		BaseRes *aRes = anItr->second.get();
 		if (aRes->mResGroup==theGroup && !aRes->mFromProgram)
 			++aCount;
 	}
@@ -1045,7 +1034,7 @@ SharedImageRef ResourceManager::GetImage(const std::string &theId)
 {
 	ResMap::iterator anItr = mImageMap.find(theId);
 	if (anItr != mImageMap.end())
-		return ((ImageRes*)anItr->second)->mImage;
+		return ((ImageRes*)anItr->second.get())->mImage;
 	else
 		return nullptr;
 }
@@ -1054,7 +1043,7 @@ intptr_t	ResourceManager::GetSound(const std::string &theId)
 {
 	ResMap::iterator anItr = mSoundMap.find(theId);
 	if (anItr != mSoundMap.end())
-		return ((SoundRes*)anItr->second)->mSoundId;
+		return ((SoundRes*)anItr->second.get())->mSoundId;
 	else
 		return -1;
 }
@@ -1063,7 +1052,7 @@ _Font* ResourceManager::GetFont(const std::string &theId)
 {
 	ResMap::iterator anItr = mFontMap.find(theId);
 	if (anItr != mFontMap.end())
-		return ((FontRes*)anItr->second)->mFont.get();
+		return ((FontRes*)anItr->second.get())->mFont.get();
 	else
 		return nullptr;
 }
@@ -1073,7 +1062,7 @@ SharedImageRef ResourceManager::GetImageThrow(const std::string &theId)
 	ResMap::iterator anItr = mImageMap.find(theId);
 	if (anItr != mImageMap.end())
 	{
-		ImageRes *aRes = (ImageRes*)anItr->second;
+		ImageRes *aRes = (ImageRes*)anItr->second.get();
 		if ((MemoryImage*) aRes->mImage != nullptr)
 			return aRes->mImage;
 
@@ -1091,7 +1080,7 @@ intptr_t	ResourceManager::GetSoundThrow(const std::string &theId)
 	ResMap::iterator anItr = mSoundMap.find(theId);
 	if (anItr != mSoundMap.end())
 	{
-		SoundRes *aRes = (SoundRes*)anItr->second;
+		SoundRes *aRes = (SoundRes*)anItr->second.get();
 		if (aRes->mSoundId!=-1)
 			return aRes->mSoundId;
 
@@ -1109,7 +1098,7 @@ _Font* ResourceManager::GetFontThrow(const std::string &theId)
 	ResMap::iterator anItr = mFontMap.find(theId);
 	if (anItr != mFontMap.end())
 	{
-		FontRes *aRes = (FontRes*)anItr->second;
+		FontRes *aRes = (FontRes*)anItr->second.get();
 		if (aRes->mFont!=nullptr)
 			return aRes->mFont.get();
 
@@ -1132,8 +1121,8 @@ bool ResourceManager::ReplaceImage(const std::string &theId, Image *theImage)
 	if (anItr != mImageMap.end())
 	{
 		anItr->second->DeleteResource();
-		((ImageRes*)anItr->second)->mImage = (MemoryImage*) theImage;
-		((ImageRes*)anItr->second)->mImage.mOwnsUnshared = true;
+		((ImageRes*)anItr->second.get())->mImage = (MemoryImage*) theImage;
+		((ImageRes*)anItr->second.get())->mImage.mOwnsUnshared = true;
 		return true;
 	}
 	else
@@ -1146,7 +1135,7 @@ bool ResourceManager::ReplaceSound(const std::string &theId, intptr_t theSound)
 	if (anItr != mSoundMap.end())
 	{
 		anItr->second->DeleteResource();
-		((SoundRes*)anItr->second)->mSoundId = theSound;
+		((SoundRes*)anItr->second.get())->mSoundId = theSound;
 		return true;
 	}
 	else
@@ -1159,7 +1148,7 @@ bool ResourceManager::ReplaceFont(const std::string &theId, _Font *theFont)
 	if (anItr != mFontMap.end())
 	{
 		anItr->second->DeleteResource();
-		((FontRes*)anItr->second)->mFont.reset(theFont);
+		((FontRes*)anItr->second.get())->mFont.reset(theFont);
 		return true;
 	}
 	else

--- a/src/SexyAppFramework/misc/ResourceManager.h
+++ b/src/SexyAppFramework/misc/ResourceManager.h
@@ -124,7 +124,7 @@ public: // TODO: revert to protected
 		void         DeleteResource() override;
 	};
 
-	typedef std::map<std::string,BaseRes*> ResMap;
+	typedef std::map<std::string,std::unique_ptr<BaseRes>> ResMap;
 	typedef std::list<BaseRes*> ResList;
 	typedef std::map<std::string,ResList,StringLessNoCase> ResGroupMap;
 
@@ -152,7 +152,7 @@ public: // TODO: revert to protected
 
 	bool					Fail(const std::string& theErrorText);
 
-	virtual bool			ParseCommonResource(XMLElement &theElement, BaseRes *theRes, ResMap &theMap);
+	virtual bool			ParseCommonResource(XMLElement &theElement, std::unique_ptr<BaseRes> &theRes, ResMap &theMap);
 	virtual bool			ParseSoundResource(XMLElement &theElement);
 	virtual bool			ParseImageResource(XMLElement &theElement);
 	virtual bool			ParseFontResource(XMLElement &theElement);


### PR DESCRIPTION
ResMap, ImageFont's mDefineMap, ListDataElement's element vector, and ActiveFontLayer's scaled image move to unique_ptr; DeleteMap and the delete-then-erase overwrite dances go away.

ParseCommonResource uses try_emplace because insert with a pre-constructed value_type moves from the argument even on duplicate keys, which would break the already-defined overwrite path on ReparseResourcesFile.

Also fixes a latent leak on DescParser::ParseToList's recursive failure path.