### PR TITLE
Refactor: replace #define constants with constexpr

### DIFF
--- a/src/Lawn/Board.h
+++ b/src/Lawn/Board.h
@@ -39,14 +39,14 @@
 
 using namespace Sexy;
 
-#define MAX_GRID_SIZE_X 9
-#define MAX_GRID_SIZE_Y 6
-#define MAX_ZOMBIES_IN_WAVE 50
-#define MAX_ZOMBIE_WAVES 100
-#define MAX_GRAVE_STONES MAX_GRID_SIZE_X * MAX_GRID_SIZE_Y
-#define MAX_POOL_GRID_SIZE 10
-#define MAX_RENDER_ITEMS 2048
-#define PROGRESS_METER_COUNTER 150
+constexpr const int MAX_GRID_SIZE_X = 9;
+constexpr const int MAX_GRID_SIZE_Y = 6;
+constexpr const int MAX_ZOMBIES_IN_WAVE = 50;
+constexpr const int MAX_ZOMBIE_WAVES = 100;
+constexpr const int MAX_GRAVE_STONES = MAX_GRID_SIZE_X * MAX_GRID_SIZE_Y;
+constexpr const int MAX_POOL_GRID_SIZE = 10;
+constexpr const int MAX_RENDER_ITEMS = 2048;
+constexpr const int PROGRESS_METER_COUNTER = 150;
 
 class LawnApp;
 class CursorObject;

--- a/src/Lawn/Challenge.h
+++ b/src/Lawn/Challenge.h
@@ -27,11 +27,12 @@
 #include "../GameConstants.h"
 #include "../PvzpLib/FilterEffect.h"
 #include "graphics/Graphics.h"
+#include "Board.h"
 
-#define BEGHOULED_MAX_GRIDSIZEX 8
-#define BEGHOULED_MAX_GRIDSIZEY 5
-#define ART_CHALLEGE_SIZE_X MAX_GRID_SIZE_X
-#define MAX_PICK_GRID_SIZE 50
+constexpr const int BEGHOULED_MAX_GRIDSIZEX = 8;
+constexpr const int BEGHOULED_MAX_GRIDSIZEY = 5;
+constexpr const int ART_CHALLEGE_SIZE_X = MAX_GRID_SIZE_X;
+constexpr const int MAX_PICK_GRID_SIZE = 50;
 
 using namespace Sexy;
 

--- a/src/Lawn/GridItem.h
+++ b/src/Lawn/GridItem.h
@@ -25,7 +25,7 @@
 #include <cstdint>
 #include "../ConstEnums.h"
 
-#define NUM_MOTION_TRAIL_FRAMES 12
+constexpr const int NUM_MOTION_TRAIL_FRAMES = 12;
 
 class LawnApp;
 class Board;

--- a/src/Lawn/MessageWidget.h
+++ b/src/Lawn/MessageWidget.h
@@ -27,8 +27,8 @@
 #include "../SexyAppFramework/Common.h"
 #include "../LawnApp.h"
 
-#define MAX_MESSAGE_LENGTH 128
-#define MAX_REANIM_LINES 5
+constexpr const int MAX_MESSAGE_LENGTH = 128;
+constexpr const int MAX_REANIM_LINES = 5;
 
 class LawnApp;
 namespace Sexy

--- a/src/Lawn/Plant.h
+++ b/src/Lawn/Plant.h
@@ -25,7 +25,7 @@
 #include <string>
 #include "GameObject.h"
 
-#define MAX_MAGNET_ITEMS 5
+constexpr const int MAX_MAGNET_ITEMS = 5;
 
 enum PlantSubClass : int32_t
 {

--- a/src/Lawn/System/PlayerInfo.h
+++ b/src/Lawn/System/PlayerInfo.h
@@ -22,10 +22,10 @@
 #ifndef __PLAYERINFO_H__
 #define __PLAYERINFO_H__
 
-#define MAX_POTTED_PLANTS 200
-#define PURCHASE_COUNT_OFFSET 1000
-#define ZOMBATAR_RECORD_SIZE 0x48
-#define MAX_ZOMBATAR_HEADS 100
+constexpr const int MAX_POTTED_PLANTS = 200;
+constexpr const int PURCHASE_COUNT_OFFSET = 1000;
+constexpr const int ZOMBATAR_RECORD_SIZE = 0x48;
+constexpr const int MAX_ZOMBATAR_HEADS = 100;
 
 #include <cstdint>
 #include <ctime>

--- a/src/Lawn/Widget/AlmanacDialog.h
+++ b/src/Lawn/Widget/AlmanacDialog.h
@@ -26,8 +26,8 @@
 #include <array>
 #include <memory>
 
-#define NUM_ALMANAC_SEEDS 49
-#define NUM_ALMANAC_ZOMBIES 26
+constexpr const int NUM_ALMANAC_SEEDS = 49;
+constexpr const int NUM_ALMANAC_ZOMBIES = 26;
 
 constexpr const float			ALMANAC_PLANT_POSITION_X		= 578.0f;
 constexpr const float			ALMANAC_PLANT_POSITION_Y		= 140.0f;

--- a/src/Lawn/Widget/ChallengeScreen.h
+++ b/src/Lawn/Widget/ChallengeScreen.h
@@ -28,7 +28,7 @@
 #include <memory>
 using namespace Sexy;
 
-#define NUM_CHALLENGE_MODES (static_cast<int>(GameMode::NUM_GAME_MODES) - 1)
+constexpr const int NUM_CHALLENGE_MODES = static_cast<int>(GameMode::NUM_GAME_MODES) - 1;
 
 class LawnApp;
 class ToolTipWidget;

--- a/src/Lawn/Widget/StoreScreen.h
+++ b/src/Lawn/Widget/StoreScreen.h
@@ -30,8 +30,8 @@
 //using namespace std;
 using namespace Sexy;
 
-#define MAX_PAGE_SPOTS 8
-#define MAX_PURCHASES 80
+constexpr const int MAX_PAGE_SPOTS = 8;
+constexpr const int MAX_PURCHASES = 80;
 
 class Coin;
 class LawnApp;

--- a/src/Lawn/ZenGarden.h
+++ b/src/Lawn/ZenGarden.h
@@ -29,8 +29,8 @@
 #include <stdint.h>
 #include <time.h>
 
-#define ZEN_MAX_GRIDSIZE_X 8
-#define ZEN_MAX_GRIDSIZE_Y 4
+constexpr const int ZEN_MAX_GRIDSIZE_X = 8;
+constexpr const int ZEN_MAX_GRIDSIZE_Y = 4;
 
 class LawnApp;
 class Board;

--- a/src/Lawn/Zombie.h
+++ b/src/Lawn/Zombie.h
@@ -26,10 +26,10 @@
 #include "GameObject.h"
 #include "../GameConstants.h"
 
-#define MAX_ZOMBIE_FOLLOWERS 4
-#define NUM_BOBSLED_FOLLOWERS 3
-#define NUM_BACKUP_DANCERS 4
-#define NUM_BOSS_BUNGEES 3
+constexpr const int MAX_ZOMBIE_FOLLOWERS = 4;
+constexpr const int NUM_BOBSLED_FOLLOWERS = 3;
+constexpr const int NUM_BACKUP_DANCERS = 4;
+constexpr const int NUM_BOSS_BUNGEES = 3;
 
 enum ZombieAttackType : int32_t
 {

--- a/src/PvzpLib/Attachment.h
+++ b/src/PvzpLib/Attachment.h
@@ -33,7 +33,7 @@ namespace Sexy
 }
 using namespace Sexy;
 
-#define MAX_EFFECTS_PER_ATTACHMENT 16
+constexpr const int MAX_EFFECTS_PER_ATTACHMENT = 16;
 
 class Trail;
 class Reanimation;

--- a/src/PvzpLib/EffectSystem.h
+++ b/src/PvzpLib/EffectSystem.h
@@ -30,7 +30,7 @@
 #include "graphics/Graphics.h"
 using namespace Sexy;
 
-#define MAX_TRIANGLES 256
+constexpr const int MAX_TRIANGLES = 256;
 
 class PvzpTriVertex
 {

--- a/src/PvzpLib/PvzpCommon.h
+++ b/src/PvzpLib/PvzpCommon.h
@@ -42,9 +42,9 @@ namespace Sexy
 //using namespace std;
 using namespace Sexy;
 
-#define RENDERIMAGEFLAG_SANDING 0x1000
-#define DEG_TO_RAD(deg) ((deg) * 0.017453292f)
-#define RAD_TO_DEG(rad) ((rad) * 57.29578f)
+constexpr const int RENDERIMAGEFLAG_SANDING = 0x1000;
+template <typename T> constexpr float DEG_TO_RAD(T deg) { return deg * 0.017453292f; }
+template <typename T> constexpr float RAD_TO_DEG(T rad) { return rad * 57.29578f; }
 
 struct PvzpWeightedArray
 {

--- a/src/PvzpLib/PvzpFoley.h
+++ b/src/PvzpLib/PvzpFoley.h
@@ -27,8 +27,8 @@
 #include "sound/SDLSoundInstance.h"
 using namespace Sexy;
 
-#define MAX_FOLEY_TYPES 110
-#define MAX_FOLEY_INSTANCES 8
+constexpr const int MAX_FOLEY_TYPES = 110;
+constexpr const int MAX_FOLEY_INSTANCES = 8;
 
 // Foley sound definitions
 

--- a/src/PvzpLib/PvzpList.h
+++ b/src/PvzpLib/PvzpList.h
@@ -22,7 +22,7 @@
 #ifndef __PVZPLIST_H__
 #define __PVZPLIST_H__
 
-#define MAX_GLOBAL_ALLOCATORS 128
+constexpr const int MAX_GLOBAL_ALLOCATORS = 128;
 
 #include "PvzpDebug.h"
 #include "PvzpCommon.h"

--- a/src/PvzpLib/PvzpParticle.h
+++ b/src/PvzpLib/PvzpParticle.h
@@ -35,8 +35,8 @@ namespace Sexy
 //using namespace std;
 using namespace Sexy;
 
-#define MAX_PARTICLES_SIZE 900
-#define MAX_PARTICLE_FIELDS 4
+constexpr const int MAX_PARTICLES_SIZE = 900;
+constexpr const int MAX_PARTICLE_FIELDS = 4;
 
 // Particle system definitions
 

--- a/src/PvzpLib/Trail.h
+++ b/src/PvzpLib/Trail.h
@@ -26,7 +26,7 @@
 #include <memory>
 #include "PvzpParticle.h"
 
-#define MAX_TRAIL_TRIANGLES 38
+constexpr const int MAX_TRAIL_TRIANGLES = 38;
 
 enum TrailType : int32_t
 {

--- a/src/SexyAppFramework/graphics/GLInterface.cpp
+++ b/src/SexyAppFramework/graphics/GLInterface.cpp
@@ -37,7 +37,7 @@
 #include <mutex>
 #include <vector>
 
-#define MAX_VERTICES 16384
+constexpr const int MAX_VERTICES = 16384;
 
 #ifndef GL_FRAMEBUFFER_SRGB
 #define GL_FRAMEBUFFER_SRGB 0x8DB9 // Not in GLES 2.0 headers, but needed to disable sRGB on Windows.
@@ -68,7 +68,7 @@ static inline uint32_t VertexColor(uint32_t triVertexColor, uint32_t fallback) n
 	return triVertexColor ? ArgbToRgba(triVertexColor) : fallback;
 }
 
-#define GetColorFromTriVertex(v, c) VertexColor((v).color, (c))
+static inline uint32_t GetColorFromTriVertex(const TriVertex& v, uint32_t c) noexcept { return VertexColor(v.color, c); }
 
 static int gMinTextureWidth;
 static int gMinTextureHeight;

--- a/src/SexyAppFramework/imagelib/ImageLib.cpp
+++ b/src/SexyAppFramework/imagelib/ImageLib.cpp
@@ -485,8 +485,8 @@ Image* GetGIFImage(const std::string& theFileName)
 
 		global_colormap.reset();
 
-#define MaxStackSize  4096
-#define NullCode  (-1)
+constexpr const int MaxStackSize = 4096;
+constexpr const int NullCode = -1;
 
 		int
 			available,
@@ -983,7 +983,7 @@ typedef struct {
 
 typedef pak_source_mgr * pak_src_ptr;
 
-#define INPUT_BUF_SIZE 4096
+constexpr const int INPUT_BUF_SIZE = 4096;
 
 METHODDEF(void) init_source (j_decompress_ptr cinfo)
 {

--- a/src/SexyAppFramework/misc/Buffer.cpp
+++ b/src/SexyAppFramework/misc/Buffer.cpp
@@ -26,7 +26,7 @@
 #include <SDL_stdinc.h>
 #include <array>
 #include <bit>
-#define POLYNOMIAL 0x04c11db7L
+constexpr const long POLYNOMIAL = 0x04c11db7L;
 
 using namespace Sexy;
 

--- a/src/SexyAppFramework/misc/KeyCodes.cpp
+++ b/src/SexyAppFramework/misc/KeyCodes.cpp
@@ -29,7 +29,7 @@
 
 using namespace Sexy;
 
-#define MAX_KEYNAME_LEN 12
+constexpr const int MAX_KEYNAME_LEN = 12;
 
 typedef struct
 {

--- a/src/SexyAppFramework/misc/MTRand.cpp
+++ b/src/SexyAppFramework/misc/MTRand.cpp
@@ -37,23 +37,24 @@ email: m-mat @ math.sci.hiroshima-u.ac.jp (remove space)
 
 #include "MTRand.h"
 #include "Debug.h"
+#include <cstdint>
 #include <stdio.h>
 
 using namespace Sexy;
 
 /* Period parameters */
-#define MTRAND_M 397
-#define MATRIX_A 0x9908b0dfUL   /* constant vector a */
-#define UPPER_MASK 0x80000000UL /* most significant w-r bits */
-#define LOWER_MASK 0x7fffffffUL /* least significant r bits */
+constexpr const int MTRAND_M = 397;
+constexpr const uint32_t MATRIX_A = 0x9908b0df;   /* constant vector a */
+constexpr const uint32_t UPPER_MASK = 0x80000000; /* most significant w-r bits */
+constexpr const uint32_t LOWER_MASK = 0x7fffffff; /* least significant r bits */
 
 /* Tempering parameters */
-#define TEMPERING_MASK_B 0x9d2c5680
-#define TEMPERING_MASK_C 0xefc60000
-#define TEMPERING_SHIFT_U(y)  (y >> 11)
-#define TEMPERING_SHIFT_S(y)  (y << 7)
-#define TEMPERING_SHIFT_T(y)  (y << 15)
-#define TEMPERING_SHIFT_L(y)  (y >> 18)
+constexpr const unsigned int TEMPERING_MASK_B = 0x9d2c5680;
+constexpr const unsigned int TEMPERING_MASK_C = 0xefc60000;
+constexpr uint32_t TEMPERING_SHIFT_U(uint32_t y) { return y >> 11; }
+constexpr uint32_t TEMPERING_SHIFT_S(uint32_t y) { return y << 7; }
+constexpr uint32_t TEMPERING_SHIFT_T(uint32_t y) { return y << 15; }
+constexpr uint32_t TEMPERING_SHIFT_L(uint32_t y) { return y >> 18; }
 
 
 MTRand::MTRand(const std::string& theSerialData)

--- a/src/SexyAppFramework/misc/MTRand.h
+++ b/src/SexyAppFramework/misc/MTRand.h
@@ -7,7 +7,7 @@
 namespace Sexy
 {
 
-#define MTRAND_N 624
+constexpr const int MTRAND_N = 624;
 
 class MTRand
 {

--- a/src/SexyAppFramework/misc/RegEmu.cpp
+++ b/src/SexyAppFramework/misc/RegEmu.cpp
@@ -33,7 +33,7 @@
 #include <fstream>
 #include <vector>
 
-#define REGEMU_VERSION 1
+constexpr const int REGEMU_VERSION = 1;
 
 struct RegValue
 {

--- a/src/SexyAppFramework/sound/SoundManager.h
+++ b/src/SexyAppFramework/sound/SoundManager.h
@@ -32,8 +32,8 @@ namespace Sexy
 
 class SoundInstance;
 
-#define MAX_SOURCE_SOUNDS	256
-#define MAX_CHANNELS		32
+constexpr const int MAX_SOURCE_SOUNDS = 256;
+constexpr const int MAX_CHANNELS = 32;
 
 class SoundManager
 {


### PR DESCRIPTION
Scalar constants and small function-like macros become constexpr, gaining types and scoping over textual substitution. MT word helpers use uint32_t to pin the 32-bit algorithm across ABIs; platform mirrors and .inc code generation stay macros by design.