### PR TITLE
 Fix: correct Plant behavior and spawning return type

### DIFF
--- a/src/Lawn/Challenge.cpp
+++ b/src/Lawn/Challenge.cpp
@@ -2898,7 +2898,7 @@ void Challenge::WhackAZombieSpawning()
 	}
 }
 
-int Challenge::UpdateZombieSpawning()
+bool Challenge::UpdateZombieSpawning()
 {
 	if (mApp->IsWhackAZombieLevel())
 	{

--- a/src/Lawn/Challenge.h
+++ b/src/Lawn/Challenge.h
@@ -131,7 +131,7 @@ public:
 	void                    DrawSlotMachine(Graphics* g);
 	int                    UpdateToolTip(int theX, int theY);
 	void                    WhackAZombieSpawning();
-	int                    UpdateZombieSpawning();
+	bool                   UpdateZombieSpawning();
 	void                    BeghouledClearCrater(int theCount);
 	void                    MouseDownWhackAZombie(int theX, int theY);
 	void                    DrawStormNight(Graphics* g);

--- a/src/Lawn/Plant.cpp
+++ b/src/Lawn/Plant.cpp
@@ -754,7 +754,7 @@ bool Plant::FindTargetAndFire(int theRow, PlantWeapon thePlantWeapon)
 		aHeadReanim->mAnimRate = 35.0f;
 		aHeadReanim->SetFramesForLayer("anim_shooting");
 
-		mShootingCounter = 33;
+		mShootingCounter = 35;
 		if (mSeedType == SeedType::SEED_REPEATER || mSeedType == SeedType::SEED_SPLITPEA || mSeedType == SeedType::SEED_LEFTPEATER)
 		{
 			aHeadReanim->mAnimRate = 45.0f;
@@ -1540,7 +1540,7 @@ void Plant::UpdateSquash()
 		}
 		else if (mState == PlantState::STATE_SQUASH_FALLING)
 		{
-			mY = PvzpAnimateCurve(10, 0, mStateCountdown, aDestY - 120, aDestY, PvzpCurves::CURVE_EASE_IN_OUT);
+			mY = PvzpAnimateCurve(10, 0, mStateCountdown, aDestY - 120, aDestY, PvzpCurves::CURVE_LINEAR);
 
 			if (mStateCountdown == 5)
 			{


### PR DESCRIPTION
In `Plant::FindTargetAndFire`, the default `mShootingCounter` for the `anim_shooting` head branch was 33 instead of 35, so regular head-shooting plants fired 2 centiseconds too early.

`Challenge::UpdateZombieSpawning`’s return type is `bool` instead of `int`.

In `Plant::UpdateSquash`, the `STATE_SQUASH_FALLING` branch now uses `PvzpCurves::CURVE_LINEAR` instead of `PvzpCurves::CURVE_EASE_IN_OUT`. This only changes the falling animation and does not affect when the damage is applied.