### PR TITLE
Refactor: cache GL state and remove per-frame redundant work

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -7011,9 +7011,9 @@ void Board::DrawDebugText(Graphics* g)
 	}
 
 	g->SetFont(FONT_PICO129);
-	g->SetColor(Color::Black);
 	if (!aText.empty())
 	{
+		g->SetColor(Color::Black);
 		g->DrawStringWordWrapped(aText, 10, 89);
 		g->DrawStringWordWrapped(aText, 11, 91);
 		g->DrawStringWordWrapped(aText, 9, 90);

--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -73,7 +73,6 @@ Board::Board(LawnApp* theApp)
 {
 	mApp = theApp;
 	mApp->mBoard = this;
-	PvzpHesitationTrace("preboard");
 
 	mZombies.DataArrayInitialize(1024U, "zombies");
 	mPlants.DataArrayInitialize(1024U, "plants");
@@ -81,7 +80,6 @@ Board::Board(LawnApp* theApp)
 	mCoins.DataArrayInitialize(1024U, "coins");
 	mLawnMowers.DataArrayInitialize(32U, "lawnmowers");
 	mGridItems.DataArrayInitialize(128U, "griditems");
-	PvzpHesitationTrace("board dataarrays");
 
 	mApp->mEffectSystem->EffectSystemFreeAll();
 	mBoardRandSeed = mApp->mAppRandSeed;
@@ -2155,16 +2153,16 @@ void Board::GetPlantsOnLawn(int theGridX, int theGridY, PlantsOnLawn* thePlantOn
 	{
 		if (aPlant->mDead)
 			continue;
+		if (aPlant->mRow != theGridY)
+		{
+			continue;
+		}
 		SeedType aSeedType = aPlant->mSeedType;
 		if (aSeedType == SeedType::SEED_IMITATER && aPlant->mImitaterType != SeedType::SEED_NONE)
 		{
 			aSeedType = aPlant->mImitaterType;
 		}
 
-		if (aPlant->mRow != theGridY)
-		{
-			continue;
-		}
 		if (aSeedType == SeedType::SEED_COBCANNON)
 		{
 			if (aPlant->mPlantCol < theGridX - 1 || aPlant->mPlantCol > theGridX)
@@ -2901,7 +2899,7 @@ PlantingReason Board::CanPlantAt(int theGridX, int theGridY, SeedType theSeedTyp
 	return PlantingReason::PLANTING_OK;
 }
 
-void Board::UpdateCursor()
+void Board::UpdateCursor(const HitResult* theHitResult)
 {
 	int aMouseX = mApp->mWidgetManager->mLastMouseX - mX;
 	int aMouseY = mApp->mWidgetManager->mLastMouseY - mY;
@@ -2921,9 +2919,13 @@ void Board::UpdateCursor()
 		return;
 	}
 
-	HitResult aHitResult;
-	MouseHitTest(aMouseX, aMouseY, &aHitResult);
-	switch (aHitResult.mObjectType)
+	HitResult aLocalHitResult;
+	if (theHitResult == nullptr)
+	{
+		MouseHitTest(aMouseX, aMouseY, &aLocalHitResult);
+		theHitResult = &aLocalHitResult;
+	}
+	switch (theHitResult->mObjectType)
 	{
 	case GameObjectType::OBJECT_TYPE_MENU_BUTTON:
 	case GameObjectType::OBJECT_TYPE_STORE_BUTTON:
@@ -2947,7 +2949,7 @@ void Board::UpdateCursor()
 		break;
 
 	case GameObjectType::OBJECT_TYPE_SEEDPACKET:
-		aShowFinger = ((SeedPacket*)aHitResult.mObject)->CanPickUp();
+		aShowFinger = ((SeedPacket*)theHitResult->mObject)->CanPickUp();
 		break;
 
 	case GameObjectType::OBJECT_TYPE_SCARY_POT:
@@ -2966,7 +2968,7 @@ void Board::UpdateCursor()
 		{
 			aShowFinger = true;
 		}
-		if (((Plant*)aHitResult.mObject)->mState == PlantState::STATE_COBCANNON_READY)
+		if (((Plant*)theHitResult->mObject)->mState == PlantState::STATE_COBCANNON_READY)
 		{
 			aShowFinger = true;
 		}
@@ -3057,7 +3059,7 @@ bool Board::IsPlantInGoldWateringCanRange(int theMouseX, int theMouseY, Plant* t
 	return false;
 }
 
-void Board::HighlightPlantsForMouse(int theMouseX, int theMouseY)
+void Board::HighlightPlantsForMouse(int theMouseX, int theMouseY, const HitResult* theHitResult)
 {
 	if (mCursorObject->mCursorType == CursorType::CURSOR_TYPE_WATERING_CAN && mApp->mPlayerInfo->mPurchases[StoreItem::STORE_ITEM_GOLD_WATERINGCAN])
 	{
@@ -3078,7 +3080,7 @@ void Board::HighlightPlantsForMouse(int theMouseX, int theMouseY)
 	}
 	else
 	{
-		Plant* aPlant = ToolHitTest(theMouseX, theMouseY);
+		Plant* aPlant = theHitResult->mObjectType == GameObjectType::OBJECT_TYPE_PLANT ? ToolHitTestHelper(theHitResult) : nullptr;
 		if (aPlant)
 		{
 			aPlant->mHighlighted = true;
@@ -3096,18 +3098,20 @@ void Board::HighlightPlantsForMouse(int theMouseX, int theMouseY)
 
 void Board::UpdateMousePosition()
 {
-	UpdateCursor();
-	UpdateToolTip();
+	SeedType aCursorSeedType = GetSeedTypeInCursor();
+	int aMouseX = mApp->mWidgetManager->mLastMouseX - mX;
+	int aMouseY = mApp->mWidgetManager->mLastMouseY - mY;
+	HitResult aHitResult;
+	MouseHitTest(aMouseX, aMouseY, &aHitResult);
+
+	UpdateCursor(&aHitResult);
+	UpdateToolTip(&aHitResult);
 	for (Plant* aPlant : mPlants)
 	{
 		if (aPlant->mDead)
 			continue;
 		aPlant->mHighlighted = false;
 	}
-
-	SeedType aCursorSeedType = GetSeedTypeInCursor();
-	int aMouseX = mApp->mWidgetManager->mLastMouseX - mX;
-	int aMouseY = mApp->mWidgetManager->mLastMouseY - mY;
 
 	if (mApp->IsScaryPotterLevel())
 	{
@@ -3121,8 +3125,6 @@ void Board::UpdateMousePosition()
 			}
 		}
 
-		HitResult aHitResult;
-		MouseHitTest(aMouseX, aMouseY, &aHitResult);
 		if (aHitResult.mObjectType == GameObjectType::OBJECT_TYPE_SCARY_POT)
 		{
 			GridItem* aScaryPot = (GridItem*)aHitResult.mObject;
@@ -3136,8 +3138,6 @@ void Board::UpdateMousePosition()
 		GridItem* aStinky = mApp->mZenGarden->GetStinky();
 		if (aStinky)
 		{
-			HitResult aHitResult;
-			MouseHitTest(aMouseX, aMouseY, &aHitResult);
 			aStinky->mHighlighted = aHitResult.mObjectType == GameObjectType::OBJECT_TYPE_STINKY;
 		}
 	}
@@ -3152,7 +3152,7 @@ void Board::UpdateMousePosition()
 		mCursorObject->mCursorType == CursorType::CURSOR_TYPE_MONEY_SIGN ||
 		(mCursorObject->mCursorType == CursorType::CURSOR_TYPE_WHEEELBARROW && !mApp->mZenGarden->GetPottedPlantInWheelbarrow()))
 	{
-		HighlightPlantsForMouse(aMouseX, aMouseY);
+		HighlightPlantsForMouse(aMouseX, aMouseY, &aHitResult);
 		return;
 	}
 
@@ -3192,7 +3192,7 @@ void Board::UpdateMousePosition()
 	}
 }
 
-void Board::UpdateToolTip()
+void Board::UpdateToolTip(const HitResult* theHitResult)
 {
 	if (!mApp->mWidgetManager->mMouseIn || !mApp->mActive || mTimeStopCounter > 0 || mApp->GetDialogCount() > 0 || mApp->mGameScene == GameScenes::SCENE_ZOMBIES_WON)
 	{
@@ -3283,15 +3283,19 @@ void Board::UpdateToolTip()
 	mToolTip->SetLabel("");
 	mToolTip->SetWarningText("");
 	mToolTip->mCenter = false;
-	if (mChallenge->UpdateToolTip(aMouseX, aMouseY))
+	if (mChallenge->UpdateToolTip(aMouseX, aMouseY, theHitResult))
 	{
 		return;
 	}
 
-	HitResult aHitResult;
-	MouseHitTest(aMouseX, aMouseY, &aHitResult);
+	HitResult aLocalHitResult;
+	if (theHitResult == nullptr)
+	{
+		MouseHitTest(aMouseX, aMouseY, &aLocalHitResult);
+		theHitResult = &aLocalHitResult;
+	}
 
-	switch (aHitResult.mObjectType)
+	switch (theHitResult->mObjectType)
 	{
 	case GameObjectType::OBJECT_TYPE_SHOVEL:
 	{
@@ -3349,10 +3353,10 @@ void Board::UpdateToolTip()
 		return;
 	}
 
-	if (aHitResult.mObjectType != GameObjectType::OBJECT_TYPE_SEEDPACKET)
+	if (theHitResult->mObjectType != GameObjectType::OBJECT_TYPE_SEEDPACKET)
 	{
 		Rect aButtonRect = GetShovelButtonRect();
-		GetZenButtonRect(aHitResult.mObjectType, aButtonRect);
+		GetZenButtonRect(theHitResult->mObjectType, aButtonRect);
 		this->mToolTip->mX = aButtonRect.mX + 35;
 		this->mToolTip->mY = aButtonRect.mY + 72;
 		this->mToolTip->mCenter = true;
@@ -3360,7 +3364,7 @@ void Board::UpdateToolTip()
 		return;
 	}
 
-	SeedPacket* aSeedPacket = (SeedPacket*)aHitResult.mObject;
+	SeedPacket* aSeedPacket = (SeedPacket*)theHitResult->mObject;
 	SeedType aUseSeedType = aSeedPacket->mPacketType;
 	if (aSeedPacket->mPacketType == SeedType::SEED_IMITATER && aSeedPacket->mImitaterType != SeedType::SEED_NONE)
 	{
@@ -3945,9 +3949,8 @@ void Board::MouseDownWithPlant(int x, int y, int theClickCount)
 	ClearCursor();
 }
 
-Plant* Board::ToolHitTestHelper(HitResult* theHitResult)
+Plant* Board::ToolHitTestHelper(const HitResult* theHitResult)
 {
-	theHitResult->mObjectType = GameObjectType::OBJECT_TYPE_PLANT;
 	Plant* aPlant = (Plant*)theHitResult->mObject;
 	return (aPlant->mSeedType != SeedType::SEED_GRAVEBUSTER || mApp->mGameMode == GameMode::GAMEMODE_CHALLENGE_ZEN_GARDEN) ? aPlant : nullptr;
 }
@@ -6070,8 +6073,6 @@ static inline void AddUIRenderItem(RenderItem* theRenderList, int& theCurRenderI
 
 void Board::DrawGameObjects(Graphics* g)
 {
-	PvzpHesitationTrace("creating render list");
-
 	RenderItem aRenderList[MAX_RENDER_ITEMS];
 	int aRenderItemCount = 0;
 
@@ -6281,10 +6282,8 @@ void Board::DrawGameObjects(Graphics* g)
 	}
 	AddGameObjectRenderItemCursorPreview(aRenderList, aRenderItemCount, RenderObjectType::RENDER_ITEM_CURSOR_PREVIEW, mCursorPreview.get());
 
-	PvzpHesitationTrace("start sort");
 	std::sort(aRenderList, aRenderList + aRenderItemCount, RenderItemSortFunc);
 
-	PvzpHesitationTrace("end sort, start draw");
 	for (int i = 0; i < aRenderItemCount; i++)
 	{
 		RenderItem& aRenderItem = aRenderList[i];
@@ -6484,7 +6483,6 @@ void Board::DrawGameObjects(Graphics* g)
 		}
 	}
 
-	PvzpHesitationTrace("end draw");
 }
 
 bool Board::HasProgressMeter()
@@ -7014,12 +7012,15 @@ void Board::DrawDebugText(Graphics* g)
 
 	g->SetFont(FONT_PICO129);
 	g->SetColor(Color::Black);
-	g->DrawStringWordWrapped(aText, 10, 89);
-	g->DrawStringWordWrapped(aText, 11, 91);
-	g->DrawStringWordWrapped(aText, 9, 90);
-	g->DrawStringWordWrapped(aText, 11, 90);
-	g->SetColor(Color(255, 255, 255));
-	g->DrawStringWordWrapped(aText, 10, 90);
+	if (!aText.empty())
+	{
+		g->DrawStringWordWrapped(aText, 10, 89);
+		g->DrawStringWordWrapped(aText, 11, 91);
+		g->DrawStringWordWrapped(aText, 9, 90);
+		g->DrawStringWordWrapped(aText, 11, 90);
+		g->SetColor(Color(255, 255, 255));
+		g->DrawStringWordWrapped(aText, 10, 90);
+	}
 }
 
 void Board::DrawDebugObjectRects(Graphics* g)
@@ -7318,7 +7319,12 @@ void Board::UpdateFog()
 
 void Board::DrawFog(Graphics* g)
 {
-	Image* aImageFog = mApp->Is3DAccelerated() ? Sexy::IMAGE_FOG : Sexy::IMAGE_FOG_SOFTWARE;
+	bool aIs3DAccelerated = mApp->Is3DAccelerated();
+	Image* aImageFog = aIs3DAccelerated ? Sexy::IMAGE_FOG : Sexy::IMAGE_FOG_SOFTWARE;
+	// the fog animation uses 900- and 500-frame periods; mod by their lcm (4500) to avoid float precision loss on large counters
+	constexpr uint32_t FOG_ANIM_PERIOD = 4500;
+	float aTime = static_cast<float>(mMainCounter % FOG_ANIM_PERIOD) * PI * 2;
+	g->SetColorizeImages(true);
 	for (int x = 0; x < MAX_GRID_SIZE_X; x++)
 	{
 		for (int y = 0; y < MAX_GRID_SIZE_Y + 1; y++)
@@ -7332,16 +7338,13 @@ void Board::DrawFog(Graphics* g)
 			int aCelCol = aCelLook % 8;
 			float aPosX = x * 80 + mFogOffset - 15;
 			float aPosY = y * 85 + 20;
-			// the fog animation uses 900- and 500-frame periods; mod by their lcm (4500) to avoid float precision loss on large counters
-			constexpr uint32_t FOG_ANIM_PERIOD = 4500;
-			float aTime = static_cast<float>(mMainCounter % FOG_ANIM_PERIOD) * PI * 2;
 			float aPhaseX = 6 * PI * x / MAX_GRID_SIZE_X;
 			float aPhaseY = 6 * PI * y / (MAX_GRID_SIZE_Y + 1);
 			float aMotion = 13 + 4 * sin(aTime / 900 + aPhaseY) + 8 * sin(aTime / 500 + aPhaseX);
 
 			int aColorVariant = 255 - aCelLook * 1.5 - aMotion * 1.5;
 			int aLightnessVariant = 255 - aCelLook - aMotion;
-			if (!mApp->Is3DAccelerated())
+			if (!aIs3DAccelerated)
 			{
 				aPosX += 10;
 				aPosY += 3;
@@ -7350,7 +7353,6 @@ void Board::DrawFog(Graphics* g)
 				aLightnessVariant = 255;
 			}
 
-			g->SetColorizeImages(true);
 			g->SetColor(Color(aColorVariant, aColorVariant, aLightnessVariant, aFadeAmount));
 			g->DrawImageCel(aImageFog, aPosX, aPosY, aCelCol, 0);
 
@@ -7358,9 +7360,9 @@ void Board::DrawFog(Graphics* g)
 			{
 				g->DrawImageCel(aImageFog, aPosX + 80, aPosY, aCelCol, 0);
 			}
-			g->SetColorizeImages(false);
 		}
 	}
+	g->SetColorizeImages(false);
 }
 
 bool Board::IsScaryPotterDaveTalking()

--- a/src/Lawn/Board.h
+++ b/src/Lawn/Board.h
@@ -326,7 +326,7 @@ public:
 //	inline void						MouseDownNormal(int x, int y, int theClickCount) { /* not found */; }
 	bool							CanInteractWithBoardButtons();
 	void							DrawProgressMeter(Graphics* g);
-	void							UpdateToolTip();
+	void							UpdateToolTip(const HitResult* theHitResult = nullptr);
 	Plant*							GetTopPlantAt(int theGridX, int theGridY, PlantPriority thePriority);
 	void							GetPlantsOnLawn(int theGridX, int theGridY, PlantsOnLawn* thePlantOnLawn);
 	int					CountSunFlowers();
@@ -401,14 +401,14 @@ public:
 	void							UpdateFwoosh();
 	Plant*							SpecialPlantHitTest(int x, int y);
 	void							UpdateMousePosition();
-	Plant*				ToolHitTestHelper(HitResult* theHitResult);
+	Plant*				ToolHitTestHelper(const HitResult* theHitResult);
 	Plant*				ToolHitTest(int theX, int theY);
 	bool							CanAddGraveStoneAt(int theGridX, int theGridY);
 	void							UpdateGridItems();
 	GridItem*			AddAGraveStone(int theGridX, int theGridY);
 	int								GetSurvivalFlagsCompleted();
 	bool							HasProgressMeter();
-	void							UpdateCursor();
+	void							UpdateCursor(const HitResult* theHitResult = nullptr);
 	void							UpdateTutorial();
 	SeedType						GetSeedTypeInCursor();
 	int					CountPlantByType(SeedType theSeedType);
@@ -453,7 +453,7 @@ public:
 	GridItem*			AddACrater(int theGridX, int theGridY);
 	void							InitLawnMowers();
 	bool					IsPlantInCursor();
-	void							HighlightPlantsForMouse(int theMouseX, int theMouseY);
+	void							HighlightPlantsForMouse(int theMouseX, int theMouseY, const HitResult* theHitResult);
 	void							ClearFogAroundPlant(Plant* thePlant, int theSize);
 	void					RemoveParticleByType(ParticleEffect theEffectType);
 	GridItem*			GetScaryPotAt(int theGridX, int theGridY);

--- a/src/Lawn/Challenge.cpp
+++ b/src/Lawn/Challenge.cpp
@@ -1168,14 +1168,18 @@ int Challenge::MouseMove(int x, int y)
 	return false;
 }
 
-int Challenge::UpdateToolTip(int theX, int theY)
+int Challenge::UpdateToolTip(int theX, int theY, const HitResult* theHitResult)
 {
 	if (!mApp->IsSlotMachineLevel())
 		return false;
 
-	HitResult aHitResult;
-	mBoard->MouseHitTest(theX, theY, &aHitResult);
-	if (aHitResult.mObjectType != GameObjectType::OBJECT_TYPE_SLOT_MACHINE_HANDLE ||
+	HitResult aLocalHitResult;
+	if (theHitResult == nullptr)
+	{
+		mBoard->MouseHitTest(theX, theY, &aLocalHitResult);
+		theHitResult = &aLocalHitResult;
+	}
+	if (theHitResult->mObjectType != GameObjectType::OBJECT_TYPE_SLOT_MACHINE_HANDLE ||
 		mBoard->mCursorObject->mCursorType != CursorType::CURSOR_TYPE_NORMAL ||
 		mChallengeState != ChallengeState::STATECHALLENGE_NORMAL)
 		return false;

--- a/src/Lawn/Challenge.h
+++ b/src/Lawn/Challenge.h
@@ -129,7 +129,7 @@ public:
 	Rect         SlotMachineGetHandleRect();
 	void                    UpdateSlotMachine();
 	void                    DrawSlotMachine(Graphics* g);
-	int                    UpdateToolTip(int theX, int theY);
+	int                    UpdateToolTip(int theX, int theY, const HitResult* theHitResult);
 	void                    WhackAZombieSpawning();
 	bool                   UpdateZombieSpawning();
 	void                    BeghouledClearCrater(int theCount);

--- a/src/Lawn/CutScene.cpp
+++ b/src/Lawn/CutScene.cpp
@@ -334,8 +334,6 @@ bool CutScene::Is2x2Zombie(ZombieType theZombieType)
 
 void CutScene::PreloadResources()
 {
-	PvzpHesitationTrace("pre-CutScene::PreloadResources()");
-
 	if (mPreloaded)
 	{
 		return;
@@ -498,7 +496,6 @@ void CutScene::PreloadResources()
 
 	mBoard->mPreloadTime = std::max(aTimer.GetDuration(), 0.0);
 	PvzpLogLn("preloading: {} ms", mBoard->mPreloadTime);
-	PvzpHesitationTrace("CutScene::PreloadResources");
 }
 
 void CutScene::PlaceStreetZombies()

--- a/src/Lawn/Plant.cpp
+++ b/src/Lawn/Plant.cpp
@@ -3537,6 +3537,7 @@ float PlantFlowerPotHeightOffset(SeedType theSeedType, float theFlowerPotScale)
 float PlantDrawHeightOffset(Board* theBoard, Plant* thePlant, SeedType theSeedType, int theCol, int theRow)
 {
 	float aHeightOffset = 0.0f;
+	Plant* aFlowerPot = theBoard ? theBoard->GetFlowerPotAt(theCol, theRow) : nullptr;
 
 	bool doFloating = false;
 	if (Plant::IsFlying(theSeedType))
@@ -3571,7 +3572,7 @@ float PlantDrawHeightOffset(Board* theBoard, Plant* thePlant, SeedType theSeedTy
 
 	if (theBoard && (thePlant == nullptr || !thePlant->mSquished))
 	{
-		Plant* aPot = theBoard->GetFlowerPotAt(theCol, theRow);
+		Plant* aPot = aFlowerPot;
 		if (aPot && !aPot->mSquished && theSeedType != SeedType::SEED_FLOWERPOT)
 		{
 			aHeightOffset += PlantFlowerPotHeightOffset(theSeedType, 1.0f);
@@ -3639,7 +3640,7 @@ float PlantDrawHeightOffset(Board* theBoard, Plant* thePlant, SeedType theSeedTy
 			aHeightOffset += 6.0f;
 		}
 
-		if (theBoard && theBoard->GetFlowerPotAt(theCol, theRow) && gLawnApp->mGameMode != GameMode::GAMEMODE_CHALLENGE_ZEN_GARDEN)
+		if (aFlowerPot && gLawnApp->mGameMode != GameMode::GAMEMODE_CHALLENGE_ZEN_GARDEN)
 		{
 			aHeightOffset += 5.0f;
 		}

--- a/src/Lawn/System/Music.cpp
+++ b/src/Lawn/System/Music.cpp
@@ -168,15 +168,10 @@ void Music::SetupVolumeForTune(MusicTune theMusicTune, float theDrumsVolume, flo
 
 void Music::LoadSong(MusicFile theMusicFile, std::string_view theFileName)
 {
-	PvzpHesitationTrace("preloadsong");
 	if (!PvzpLoadMusic(theMusicFile, theFileName))
 	{
 		PvzpLogLn("music failed to load");
 		mMusicDisabled = true;
-	}
-	else
-	{
-		PvzpHesitationTrace("song '{}'", theFileName);
 	}
 }
 

--- a/src/Lawn/ToolTipWidget.cpp
+++ b/src/Lawn/ToolTipWidget.cpp
@@ -43,12 +43,13 @@ ToolTipWidget::ToolTipWidget()
 	mMaxLinesWidth = 0;
 }
 
-void ToolTipWidget::GetLines(std::vector<std::string>& theLines)
+void ToolTipWidget::GetLines(std::vector<std::string_view>& theLines)
 {
 	int aLineWidth = 0;
 	size_t aLineStart = 0;
 	size_t aCurPos = 0;
 	char32_t aPrevChar = 0;
+	std::string_view aLabelView(mLabel);
 
 	int aBreakDrawLen = -1;
 	size_t aBreakResumePos = 0;
@@ -68,7 +69,7 @@ void ToolTipWidget::GetLines(std::vector<std::string>& theLines)
 
 		if (aChar == U'\n')
 		{
-			theLines.push_back(mLabel.substr(aLineStart, aCharStart - aLineStart));
+			theLines.push_back(aLabelView.substr(aLineStart, aCharStart - aLineStart));
 			aLineWidth = 0;
 			aLineStart = aCharEnd;
 			aBreakDrawLen = -1;
@@ -84,7 +85,7 @@ void ToolTipWidget::GetLines(std::vector<std::string>& theLines)
 			aBreakResumePos = aCharEnd;
 			if (aLineWidth >= mGetsLinesWidth)
 			{
-				theLines.push_back(mLabel.substr(aLineStart, aBreakDrawLen));
+				theLines.push_back(aLabelView.substr(aLineStart, aBreakDrawLen));
 				aCurPos = aBreakResumePos;
 				while (aCurPos < mLabel.size() && mLabel[aCurPos] == ' ')
 					aCurPos++;
@@ -104,7 +105,7 @@ void ToolTipWidget::GetLines(std::vector<std::string>& theLines)
 			aBreakResumePos = aCharStart;
 			if (aLineWidth >= mGetsLinesWidth)
 			{
-				theLines.push_back(mLabel.substr(aLineStart, aBreakDrawLen));
+				theLines.push_back(aLabelView.substr(aLineStart, aBreakDrawLen));
 				aCurPos = aBreakResumePos;
 				aLineStart = aCurPos;
 				aLineWidth = 0;
@@ -118,13 +119,13 @@ void ToolTipWidget::GetLines(std::vector<std::string>& theLines)
 
 	if (aLineStart < mLabel.size())
 	{
-		theLines.push_back(mLabel.substr(aLineStart));
+		theLines.push_back(aLabelView.substr(aLineStart));
 	}
 }
 
 void ToolTipWidget::CalculateSize()
 {
-	std::vector<std::string> aLines;
+	std::vector<std::string_view> aLines;
 
 	int aTitleWidth = FONT_TINYBOLD->StringWidth(mTitle);
 	int aWarningWidth = FONT_PICO129->StringWidth(mWarningText);
@@ -235,13 +236,13 @@ void ToolTipWidget::Draw(Graphics* g)
 		aPosY += FONT_PICO129->GetAscent() + 2;
 	}
 
-	std::vector<std::string> aLines;
+	std::vector<std::string_view> aLines;
 	GetLines(aLines);
 
 	g->SetFont(FONT_PICO129);
 	for (size_t i = 0; i < aLines.size(); i++)
 	{
-		std::string aLine = aLines[i];
+		std::string_view aLine = aLines[i];
 		g->DrawString(aLine, aPosX + (mWidth - FONT_PICO129->StringWidth(aLine)) / 2, aPosY + FONT_PICO129->GetAscent());
 		aPosY += FONT_PICO129->GetAscent() + 2;
 	}

--- a/src/Lawn/ToolTipWidget.h
+++ b/src/Lawn/ToolTipWidget.h
@@ -54,7 +54,7 @@ public:
 	void                SetTitle(std::string_view theTitle);
 	void                SetWarningText(std::string_view theWarningText);
 	void                CalculateSize();
-	void                GetLines(std::vector<std::string>& theLines);
+	void                GetLines(std::vector<std::string_view>& theLines);
 	inline void         FlashWarning() { mWarningFlashCounter = 70; }
 	inline void         Update() { if (mWarningFlashCounter > 0) mWarningFlashCounter--; }
 	inline void         SetPosition(int theX, int theY) { mX = theX; mY = theY; }

--- a/src/Lawn/Widget/GameSelector.cpp
+++ b/src/Lawn/Widget/GameSelector.cpp
@@ -62,7 +62,6 @@ GameSelectorOverlay::GameSelectorOverlay(GameSelector* theGameSelector)
 
 GameSelector::GameSelector(LawnApp* theApp)
 {
-	PvzpHesitationTrace("pregameselector");
 	mLoadedResourceNames.push_back("DelayLoad_Zombatar");
 	mLoadedResourceNames.push_back("DelayLoad_Almanac");
 
@@ -364,8 +363,6 @@ GameSelector::GameSelector(LawnApp* theApp)
 	AddWidget(mStoreButton);
 	AddWidget(mAlmanacButton);
 	AddWidget(mOverlayWidget);
-
-	PvzpHesitationTrace("gameselectorinit");
 }
 
 GameSelector::~GameSelector()

--- a/src/Lawn/Widget/TitleScreen.cpp
+++ b/src/Lawn/Widget/TitleScreen.cpp
@@ -94,7 +94,6 @@ void TitleScreen::Draw(Graphics* g)
 		if (!mDrawnYet)
 		{
 			PvzpLogLn("First Draw Time: {} ms", SDL_GetTicks() - mApp->mTimeLoaded);
-			PvzpHesitationTrace("TitleScreen First Draw");
 			mDrawnYet = true;
 		}
 

--- a/src/LawnApp.cpp
+++ b/src/LawnApp.cpp
@@ -1662,9 +1662,7 @@ void LawnApp::LoadingThreadProc()
 	PerfTimer aTimer;
 	aTimer.Start();
 
-	PvzpHesitationTrace("start loading");
 	PvzpHesitationBracket aHesitationResources("Resources");
-	PvzpHesitationTrace("loading thread start");
 
 	LoadGroup("LoadingImages", 9);
 	LoadGroup("LoadingFonts", 54);
@@ -1693,7 +1691,6 @@ void LawnApp::LoadingThreadProc()
 	TrailLoadDefinitions(gLawnTrailArray, LENGTH(gLawnTrailArray));
 	PvzpLogLn("loading '{}' {} ms", "trail", static_cast<int>(aTimer.GetDuration()));
 	aTimer.Start();
-	PvzpHesitationTrace("trail");
 
 	PvzpParticleLoadDefinitions(gLawnParticleArray, LENGTH(gLawnParticleArray));
 	//aDuration = max(aTimer.GetDuration(), 0.0);
@@ -1708,7 +1705,6 @@ void LawnApp::LoadingThreadProc()
 
 	GetNumPreloadingTasks();
 	LoadGroup("LoadingSounds", 54);
-	PvzpHesitationTrace("finished loading");
 }
 
 void LawnApp::FastLoad(GameMode theGameMode)

--- a/src/PvzpLib/Definition.cpp
+++ b/src/PvzpLib/Definition.cpp
@@ -353,7 +353,6 @@ bool DefinitionLoadImage(Image** theImage, const std::string& theName)
 			SharedImageRef aImageRef = gSexyAppBase->GetSharedImage(aPathToTry);
 			if ((Image*)aImageRef != nullptr)
 			{
-				PvzpHesitationTrace("Load Image '{}'", theName);
 				PvzpAddImageToMap(&aImageRef, theName);
 				PvzpMarkImageForSanding((Image*)aImageRef);
 				*theImage = (Image*)aImageRef;
@@ -1296,13 +1295,11 @@ bool DefinitionCompileAndLoad(const std::string& theXMLFilePath, const DefMap* t
 	const bool aRequireCompiledUpToDate = false;
 #endif
 
-	PvzpHesitationTrace("predef");
 	std::string aCompiledFilePath = DefinitionGetCompiledFilePathFromXMLFilePath(theXMLFilePath);
 
 	const bool aShouldTryCompiled = !aRequireCompiledUpToDate || DefinitionIsCompiled(theXMLFilePath);
 	if (aShouldTryCompiled && DefinitionReadCompiledFile(aCompiledFilePath, theDefMap, theDefinition))
 	{
-		PvzpHesitationTrace("loaded {}", aCompiledFilePath);
 		return true;
 	}
 
@@ -1310,7 +1307,6 @@ bool DefinitionCompileAndLoad(const std::string& theXMLFilePath, const DefMap* t
 	aTimer.Start();
 	bool aResult = DefinitionCompileFile(theXMLFilePath, aCompiledFilePath, theDefMap, theDefinition);
 	PvzpLogLn("compile {} ms:'{}'", (int)aTimer.GetDuration(), aCompiledFilePath);
-	PvzpHesitationTrace("compiled {}", aCompiledFilePath);
 	if (aResult)
 		return true;
 

--- a/src/PvzpLib/Definition.cpp
+++ b/src/PvzpLib/Definition.cpp
@@ -1321,32 +1321,6 @@ bool DefinitionCompileAndLoad(const std::string& theXMLFilePath, const DefMap* t
 	return false;
 }
 
-float FloatTrackEvaluate(FloatParameterTrack& theTrack, float theTimeValue, float theInterp)
-{
-	if (theTrack.mCountNodes == 0)
-		return 0.0f;
-
-	if (theTimeValue < theTrack.mNodes[0].mTime)
-		return PvzpCurveEvaluate(theInterp, theTrack.mNodes[0].mLowValue, theTrack.mNodes[0].mHighValue, theTrack.mNodes[0].mDistribution);
-
-	for (int i = 1; i < theTrack.mCountNodes; i++)
-	{
-		FloatParameterTrackNode* aNodeNxt = &theTrack.mNodes[i];
-		if (theTimeValue <= aNodeNxt->mTime)
-		{
-			FloatParameterTrackNode* aNodeCur = &theTrack.mNodes[i - 1];
-			// Progress of theTimeValue from the current node to the next
-			float aTimeFraction = (theTimeValue - aNodeCur->mTime) / (aNodeNxt->mTime - aNodeCur->mTime);
-			float aLeftValue = PvzpCurveEvaluate(theInterp, aNodeCur->mLowValue, aNodeCur->mHighValue, aNodeCur->mDistribution);
-			float aRightValue = PvzpCurveEvaluate(theInterp, aNodeNxt->mLowValue, aNodeNxt->mHighValue, aNodeNxt->mDistribution);
-			return PvzpCurveEvaluate(aTimeFraction, aLeftValue, aRightValue, aNodeCur->mCurveType);
-		}
-	}
-
-	FloatParameterTrackNode* aLastNode = &theTrack.mNodes[theTrack.mCountNodes - 1];  // theTimeValue is past the last node
-	return PvzpCurveEvaluate(theInterp, aLastNode->mLowValue, aLastNode->mHighValue, aLastNode->mDistribution);
-}
-
 void FloatTrackSetDefault(FloatParameterTrack& theTrack, float theValue)
 {
 	if (theTrack.mNodes == nullptr && theValue != 0.0f)
@@ -1364,19 +1338,9 @@ void FloatTrackSetDefault(FloatParameterTrack& theTrack, float theValue)
 	}
 }
 
-bool FloatTrackIsSet(const FloatParameterTrack& theTrack)
-{
-	return theTrack.mCountNodes != 0 && theTrack.mNodes[0].mCurveType != PvzpCurves::CURVE_CONSTANT;
-}
-
 bool FloatTrackIsConstantZero(FloatParameterTrack& theTrack)
 {
 	return theTrack.mCountNodes == 0 || (theTrack.mCountNodes == 1 && theTrack.mNodes[0].mLowValue == 0.0f && theTrack.mNodes[0].mHighValue == 0.0f);
-}
-
-float FloatTrackEvaluateFromLastTime(FloatParameterTrack& theTrack, float theTimeValue, float theInterp)
-{
-	return theTimeValue < 0.0f ? 0.0f : FloatTrackEvaluate(theTrack, theTimeValue, theInterp);
 }
 
 void DefinitionFreeArrayField(DefinitionArrayDef* theArray, const DefMap* theDefMap)

--- a/src/PvzpLib/Definition.h
+++ b/src/PvzpLib/Definition.h
@@ -24,6 +24,7 @@
 
 #include <string>
 #include <format>
+#include "PvzpCommon.h"
 #include "PvzpList.h"
 #include "PvzpDebug.h"
 #include "Reanimator.h"

--- a/src/PvzpLib/Definition.h
+++ b/src/PvzpLib/Definition.h
@@ -194,10 +194,44 @@ bool                    DefinitionLoadXML(const std::string& theFilename, const 
 void                    DefinitionFreeArrayField(DefinitionArrayDef* theArray, const DefMap* theDefMap);
 void                    DefinitionFreeMap(const DefMap* theDefMap, void* theDefinition);
 
-bool         FloatTrackIsSet(const FloatParameterTrack& theTrack);
+inline bool  FloatTrackIsSet(const FloatParameterTrack& theTrack)
+{
+	return theTrack.mCountNodes != 0 && theTrack.mNodes[0].mCurveType != PvzpCurves::CURVE_CONSTANT;
+}
+
 void         FloatTrackSetDefault(FloatParameterTrack& theTrack, float theValue);
-float                   FloatTrackEvaluate(FloatParameterTrack& theTrack, float theTimeValue, float theInterp);
-float                   FloatTrackEvaluateFromLastTime(FloatParameterTrack& theTrack, float theTimeValue, float theInterp);
+
+inline float FloatTrackEvaluate(FloatParameterTrack& theTrack, float theTimeValue, float theInterp)
+{
+	if (theTrack.mCountNodes == 0)
+		return 0.0f;
+
+	if (theTimeValue < theTrack.mNodes[0].mTime)
+		return PvzpCurveEvaluate(theInterp, theTrack.mNodes[0].mLowValue, theTrack.mNodes[0].mHighValue, theTrack.mNodes[0].mDistribution);
+
+	for (int i = 1; i < theTrack.mCountNodes; i++)
+	{
+		FloatParameterTrackNode* aNodeNxt = &theTrack.mNodes[i];
+		if (theTimeValue <= aNodeNxt->mTime)
+		{
+			FloatParameterTrackNode* aNodeCur = &theTrack.mNodes[i - 1];
+			// Progress of theTimeValue from the current node to the next
+			float aTimeFraction = (theTimeValue - aNodeCur->mTime) / (aNodeNxt->mTime - aNodeCur->mTime);
+			float aLeftValue = PvzpCurveEvaluate(theInterp, aNodeCur->mLowValue, aNodeCur->mHighValue, aNodeCur->mDistribution);
+			float aRightValue = PvzpCurveEvaluate(theInterp, aNodeNxt->mLowValue, aNodeNxt->mHighValue, aNodeNxt->mDistribution);
+			return PvzpCurveEvaluate(aTimeFraction, aLeftValue, aRightValue, aNodeCur->mCurveType);
+		}
+	}
+
+	FloatParameterTrackNode* aLastNode = &theTrack.mNodes[theTrack.mCountNodes - 1];  // theTimeValue is past the last node
+	return PvzpCurveEvaluate(theInterp, aLastNode->mLowValue, aLastNode->mHighValue, aLastNode->mDistribution);
+}
+
+inline float FloatTrackEvaluateFromLastTime(FloatParameterTrack& theTrack, float theTimeValue, float theInterp)
+{
+	return theTimeValue < 0.0f ? 0.0f : FloatTrackEvaluate(theTrack, theTimeValue, theInterp);
+}
+
 bool         FloatTrackIsConstantZero(FloatParameterTrack& theTrack);
 
 #endif

--- a/src/PvzpLib/EffectSystem.cpp
+++ b/src/PvzpLib/EffectSystem.cpp
@@ -357,10 +357,6 @@ bool gPvzpTriangleDrawAdditive = false;
 
 PvzpTriangleGroup::PvzpTriangleGroup()
 {
-	for (int i = 0; i < 256; i++)
-		for (int j = 0; j < 3; j++)
-			mVertArray[i][j].color = 0UL;
-
 	mImage = nullptr;
 	mTriangleCount = 0;
 	mDrawMode = Graphics::DRAWMODE_NORMAL;

--- a/src/PvzpLib/PvzpCommon.cpp
+++ b/src/PvzpLib/PvzpCommon.cpp
@@ -428,8 +428,6 @@ void PvzpDrawStringMatrix(Graphics* g, const _Font* theFont, const SexyMatrix3& 
 {
 	std::string_view aFinalString = PvzpStringTranslate(theString);
 
-	memset(gRenderTail, 0, sizeof(gRenderTail));
-	memset(gRenderHead, 0, sizeof(gRenderHead));
 	ImageFont* aFont = reinterpret_cast<ImageFont*>(const_cast<_Font*>(theFont));
 	if (!aFont->mFontData->mInitialized)
 		return;
@@ -559,6 +557,8 @@ void PvzpDrawStringMatrix(Graphics* g, const _Font* theFont, const SexyMatrix3& 
 	for (int aPoolIdx = 0; aPoolIdx < 256; aPoolIdx++)
 	{
 		RenderCommand* aRenderCommand = gRenderHead[aPoolIdx];
+		gRenderHead[aPoolIdx] = nullptr;
+		gRenderTail[aPoolIdx] = nullptr;
 
 		while (aRenderCommand)
 		{
@@ -1064,8 +1064,6 @@ bool PvzpLoadNextResource()
 
 bool PvzpResourceManager::PvzpLoadNextResource()
 {
-	PvzpHesitationTrace("preres");
-
 	while (mCurResGroupListItr != mCurResGroupList->end())
 	{
 		BaseRes* aRes = *mCurResGroupListItr;
@@ -1127,8 +1125,6 @@ bool PvzpResourceManager::PvzpLoadNextResource()
 			}
 		}
 
-		PvzpHesitationTrace("Loading: '{}'", aRes->mPath);
-		PvzpHesitationTrace("resource '{}'", aRes->mPath);
 		return true;
 	}
 

--- a/src/PvzpLib/PvzpCommon.cpp
+++ b/src/PvzpLib/PvzpCommon.cpp
@@ -428,6 +428,8 @@ void PvzpDrawStringMatrix(Graphics* g, const _Font* theFont, const SexyMatrix3& 
 {
 	std::string_view aFinalString = PvzpStringTranslate(theString);
 
+	memset(gRenderTail, 0, sizeof(gRenderTail));
+	memset(gRenderHead, 0, sizeof(gRenderHead));
 	ImageFont* aFont = reinterpret_cast<ImageFont*>(const_cast<_Font*>(theFont));
 	if (!aFont->mFontData->mInitialized)
 		return;
@@ -557,8 +559,6 @@ void PvzpDrawStringMatrix(Graphics* g, const _Font* theFont, const SexyMatrix3& 
 	for (int aPoolIdx = 0; aPoolIdx < 256; aPoolIdx++)
 	{
 		RenderCommand* aRenderCommand = gRenderHead[aPoolIdx];
-		gRenderHead[aPoolIdx] = nullptr;
-		gRenderTail[aPoolIdx] = nullptr;
 
 		while (aRenderCommand)
 		{

--- a/src/PvzpLib/PvzpCommon.cpp
+++ b/src/PvzpLib/PvzpCommon.cpp
@@ -333,29 +333,6 @@ float PvzpCurveInvCircle(float theTime)
 	return static_cast<float>(sqrt(1.0f - (theTime - 1.0f) * (theTime - 1.0f)));
 }
 
-float PvzpCurveEvaluate(float theTime, float thePositionStart, float thePositionEnd, PvzpCurves theCurve)
-{
-	float aWarpedTime = 0;
-	switch (theCurve)
-	{
-	case PvzpCurves::CURVE_CONSTANT:				aWarpedTime = 0;													break;
-	case PvzpCurves::CURVE_LINEAR:				aWarpedTime = theTime;												break;
-	case PvzpCurves::CURVE_EASE_IN:				aWarpedTime = PvzpCurveQuad(theTime);								break;
-	case PvzpCurves::CURVE_EASE_OUT:				aWarpedTime = PvzpCurveInvQuad(theTime);								break;
-	case PvzpCurves::CURVE_EASE_IN_OUT:			aWarpedTime = PvzpCurveS(PvzpCurveS(theTime));						break;
-	case PvzpCurves::CURVE_EASE_IN_OUT_WEAK:		aWarpedTime = PvzpCurveS(theTime);									break;
-	case PvzpCurves::CURVE_FAST_IN_OUT:			aWarpedTime = PvzpCurveInvQuadS(PvzpCurveInvQuadS(theTime));			break;
-	case PvzpCurves::CURVE_FAST_IN_OUT_WEAK:		aWarpedTime = PvzpCurveInvQuadS(theTime);							break;
-	case PvzpCurves::CURVE_BOUNCE:				aWarpedTime = PvzpCurveBounce(theTime);								break;
-	case PvzpCurves::CURVE_BOUNCE_FAST_MIDDLE:	aWarpedTime = PvzpCurveQuad(PvzpCurveBounce(theTime));				break;
-	case PvzpCurves::CURVE_BOUNCE_SLOW_MIDDLE:	aWarpedTime = PvzpCurveInvQuad(PvzpCurveBounce(theTime));				break;
-	case PvzpCurves::CURVE_SIN_WAVE:				aWarpedTime = sinf(2 * PI * theTime);								break;
-	case PvzpCurves::CURVE_EASE_SIN_WAVE:		aWarpedTime = sinf(2 * PI * PvzpCurveS(theTime));					break;
-	default:									PVZP_ASSERT(false);														break;
-	}
-	return (thePositionEnd - thePositionStart) * aWarpedTime + thePositionStart;
-}
-
 float PvzpCurveEvaluateClamped(float theTime, float thePositionStart, float thePositionEnd, PvzpCurves theCurve)
 {
 	if (theTime <= 0.0f)

--- a/src/PvzpLib/PvzpCommon.h
+++ b/src/PvzpLib/PvzpCommon.h
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <cfloat>
 #include "../ConstEnums.h"  // PvzpCurves, DrawStringJustification
+#include "../GameConstants.h"
 #include "../SexyAppFramework/Common.h"
 #include "PvzpDebug.h"
 #include "misc/ResourceManager.h"
@@ -113,7 +114,28 @@ float					PvzpCurveInvPoly(float theTime, float thePoly);
 float					PvzpCurvePolyS(float theTime, float thePoly);
 float					PvzpCurveCircle(float theTime);
 float					PvzpCurveInvCircle(float theTime);
-float					PvzpCurveEvaluate(float theTime, float thePositionStart, float thePositionEnd, PvzpCurves theCurve);
+inline float PvzpCurveEvaluate(float theTime, float thePositionStart, float thePositionEnd, PvzpCurves theCurve)
+{
+	float aWarpedTime = 0;
+	switch (theCurve)
+	{
+	case PvzpCurves::CURVE_CONSTANT:				aWarpedTime = 0;													break;
+	case PvzpCurves::CURVE_LINEAR:				aWarpedTime = theTime;												break;
+	case PvzpCurves::CURVE_EASE_IN:				aWarpedTime = PvzpCurveQuad(theTime);								break;
+	case PvzpCurves::CURVE_EASE_OUT:				aWarpedTime = PvzpCurveInvQuad(theTime);								break;
+	case PvzpCurves::CURVE_EASE_IN_OUT:			aWarpedTime = PvzpCurveS(PvzpCurveS(theTime));						break;
+	case PvzpCurves::CURVE_EASE_IN_OUT_WEAK:		aWarpedTime = PvzpCurveS(theTime);									break;
+	case PvzpCurves::CURVE_FAST_IN_OUT:			aWarpedTime = PvzpCurveInvQuadS(PvzpCurveInvQuadS(theTime));			break;
+	case PvzpCurves::CURVE_FAST_IN_OUT_WEAK:		aWarpedTime = PvzpCurveInvQuadS(theTime);							break;
+	case PvzpCurves::CURVE_BOUNCE:				aWarpedTime = PvzpCurveBounce(theTime);								break;
+	case PvzpCurves::CURVE_BOUNCE_FAST_MIDDLE:	aWarpedTime = PvzpCurveQuad(PvzpCurveBounce(theTime));				break;
+	case PvzpCurves::CURVE_BOUNCE_SLOW_MIDDLE:	aWarpedTime = PvzpCurveInvQuad(PvzpCurveBounce(theTime));				break;
+	case PvzpCurves::CURVE_SIN_WAVE:				aWarpedTime = sinf(2 * PI * theTime);								break;
+	case PvzpCurves::CURVE_EASE_SIN_WAVE:		aWarpedTime = sinf(2 * PI * PvzpCurveS(theTime));					break;
+	default:									PVZP_ASSERT(false);														break;
+	}
+	return (thePositionEnd - thePositionStart) * aWarpedTime + thePositionStart;
+}
 float					PvzpCurveEvaluateClamped(float theTime, float thePositionStart, float thePositionEnd, PvzpCurves theCurve);
 float					PvzpAnimateCurveFloatTime(float theTimeStart, float theTimeEnd, float theTimeAge, float thePositionStart, float thePositionEnd, PvzpCurves theCurve);
 float					PvzpAnimateCurveFloat(int theTimeStart, int theTimeEnd, int theTimeAge, float thePositionStart, float thePositionEnd, PvzpCurves theCurve);

--- a/src/PvzpLib/Reanimator.cpp
+++ b/src/PvzpLib/Reanimator.cpp
@@ -365,12 +365,10 @@ void ReanimationCreateAtlas(ReanimatorDefinition* theDefinition, ReanimationType
 
 	PerfTimer aTimer;
 	aTimer.Start();
-	PvzpHesitationTrace("preatlas");
 	ReanimAtlas* aAtlas = new ReanimAtlas();
 	theDefinition->mReanimAtlas = aAtlas;
 	aAtlas->ReanimAtlasCreate(theDefinition);
 
-	PvzpHesitationTrace("atlas '{}'", aParam.mReanimFileName);
 	int aDuration = std::max(aTimer.GetDuration(), 0.0);
 	if (aDuration > 20 && theReanimationType != ReanimationType::REANIM_NONE)  // report slow atlas creation
 		PvzpLogLn("LOADING:Long atlas '{}' {} ms on {}", aParam.mReanimFileName, aDuration, LawnGetCurrentLevelName());

--- a/src/PvzpLib/Reanimator.cpp
+++ b/src/PvzpLib/Reanimator.cpp
@@ -920,6 +920,8 @@ void Reanimation::DrawRenderGroup(Graphics* g, int theRenderGroup)
 {
 	if (mDead)
 		return;
+	if (mDefinition->mTracks.count == 0)
+		return;
 
 	PvzpTriangleGroup aTriangleGroup;
 	ReanimatorFrameTime aFrameTime;

--- a/src/PvzpLib/Reanimator.cpp
+++ b/src/PvzpLib/Reanimator.cpp
@@ -544,11 +544,15 @@ void BlendTransform(ReanimatorTransform* theResult, const ReanimatorTransform& t
 	theResult->mImage = theTransform1.mImage;
 }
 
-void Reanimation::GetCurrentTransform(int theTrackIndex, ReanimatorTransform* theTransformCurrent)
+void Reanimation::GetCurrentTransform(int theTrackIndex, ReanimatorTransform* theTransformCurrent, ReanimatorFrameTime* theFrameTime)
 {
 	ReanimatorFrameTime aFrameTime;
-	GetFrameTime(&aFrameTime);
-	GetTransformAtTime(theTrackIndex, theTransformCurrent, &aFrameTime);  // base transform interpolated between the two frames
+	if (theFrameTime == nullptr)
+	{
+		GetFrameTime(&aFrameTime);
+		theFrameTime = &aFrameTime;
+	}
+	GetTransformAtTime(theTrackIndex, theTransformCurrent, theFrameTime);  // base transform interpolated between the two frames
 
 	ReanimatorTrackInstance* aTrack = &mTrackInstances[theTrackIndex];
 	if (FloatRoundToInt(theTransformCurrent->mFrame) >= 0 && aTrack->mBlendCounter > 0)  // not a blank frame and a blend is in progress
@@ -633,11 +637,11 @@ void Reanimation::ReanimBltMatrix(Graphics* g, Image* theImage, SexyMatrix3& the
 		PvzpBltMatrix(g, theImage, theTransform, theClipRect, theColor, theDrawMode, theSrcRect);
 }
 
-bool Reanimation::DrawTrack(Graphics* g, int theTrackIndex, [[maybe_unused]] int theRenderGroup, PvzpTriangleGroup* theTriangleGroup)
+bool Reanimation::DrawTrack(Graphics* g, int theTrackIndex, [[maybe_unused]] int theRenderGroup, PvzpTriangleGroup* theTriangleGroup, ReanimatorFrameTime* theFrameTime)
 {
 	ReanimatorTransform aTransform;
 	ReanimatorTrackInstance* aTrackInstance = &mTrackInstances[theTrackIndex];
-	GetCurrentTransform(theTrackIndex, &aTransform);
+	GetCurrentTransform(theTrackIndex, &aTransform, theFrameTime);
 	int aImageFrame = FloatRoundToInt(aTransform.mFrame);  // cel index within the image
 	if (aImageFrame < 0)  // no image to draw
 		return false;
@@ -920,12 +924,14 @@ void Reanimation::DrawRenderGroup(Graphics* g, int theRenderGroup)
 		return;
 
 	PvzpTriangleGroup aTriangleGroup;
+	ReanimatorFrameTime aFrameTime;
+	GetFrameTime(&aFrameTime);
 	for (int aTrackIndex = 0; aTrackIndex < mDefinition->mTracks.count; aTrackIndex++)
 	{
 		ReanimatorTrackInstance* aTrackInstance = &mTrackInstances[aTrackIndex];
 		if (aTrackInstance->mRenderGroup == theRenderGroup)
 		{
-			bool aTrackDrawn = DrawTrack(g, aTrackIndex, theRenderGroup, &aTriangleGroup);
+			bool aTrackDrawn = DrawTrack(g, aTrackIndex, theRenderGroup, &aTriangleGroup, &aFrameTime);
 			if (aTrackInstance->mAttachmentID != AttachmentID::ATTACHMENTID_NULL)
 			{
 				aTriangleGroup.DrawGroup(g);

--- a/src/PvzpLib/Reanimator.h
+++ b/src/PvzpLib/Reanimator.h
@@ -221,8 +221,8 @@ public:
 	void                 Draw(Graphics* g);
 	void                            DrawAllRenderGroups(Graphics* g);
 	void                            DrawRenderGroup(Graphics* g, int theRenderGroup);
-	bool                            DrawTrack(Graphics* g, int theTrackIndex, int theRenderGroup, PvzpTriangleGroup* theTriangleGroup);
-	void                            GetCurrentTransform(int theTrackIndex, ReanimatorTransform* theTransformCurrent);
+	bool                            DrawTrack(Graphics* g, int theTrackIndex, int theRenderGroup, PvzpTriangleGroup* theTriangleGroup, ReanimatorFrameTime* theFrameTime = nullptr);
+	void                            GetCurrentTransform(int theTrackIndex, ReanimatorTransform* theTransformCurrent, ReanimatorFrameTime* theFrameTime = nullptr);
 	void                            GetTransformAtTime(int theTrackIndex, ReanimatorTransform* theTransform, ReanimatorFrameTime* theFrameTime);
 	void                            GetFrameTime(ReanimatorFrameTime* theFrameTime);
 	int                             FindTrackIndex(const char* theTrackName);

--- a/src/PvzpLib/Trail.cpp
+++ b/src/PvzpLib/Trail.cpp
@@ -211,13 +211,11 @@ void Trail::Draw(Graphics* g)
 		float aWidthOverLengthCur = FloatTrackEvaluate(mDefinition->mWidthOverLength, aUCur, mTrailInterp[TrailTracks::TRACK_WIDTH_OVER_LENGTH]);
 		float aWidthOverLengthNext = FloatTrackEvaluate(mDefinition->mWidthOverLength, aUNext, mTrailInterp[TrailTracks::TRACK_WIDTH_OVER_LENGTH]);
 		float aWidthOverTimeCur = FloatTrackEvaluate(mDefinition->mWidthOverTime, aTimeValue, mTrailInterp[TrailTracks::TRACK_WIDTH_OVER_TIME]);
-		float aWidthOverTimeNext = FloatTrackEvaluate(mDefinition->mWidthOverTime, aTimeValue, mTrailInterp[TrailTracks::TRACK_WIDTH_OVER_TIME]);
 		float aAlphaOverLengthCur = FloatTrackEvaluate(mDefinition->mAlphaOverLength, aUCur, mTrailInterp[TrailTracks::TRACK_ALPHA_OVER_LENGTH]);
 		float aAlphaOverLengthNext = FloatTrackEvaluate(mDefinition->mAlphaOverLength, aUNext, mTrailInterp[TrailTracks::TRACK_ALPHA_OVER_LENGTH]);
 		float aAlphaOverTimeCur = FloatTrackEvaluate(mDefinition->mAlphaOverTime, aTimeValue, mTrailInterp[TrailTracks::TRACK_ALPHA_OVER_TIME]);
-		float aAlphaOverTimeNext = FloatTrackEvaluate(mDefinition->mAlphaOverTime, aTimeValue, mTrailInterp[TrailTracks::TRACK_ALPHA_OVER_TIME]);
 		int anAlphaCur = std::clamp(FloatRoundToInt(aAlphaOverLengthCur * aAlphaOverTimeCur * mColorOverride.mAlpha), 0, 255);
-		int anAlphaNext = std::clamp(FloatRoundToInt(aAlphaOverLengthNext * aAlphaOverTimeNext * mColorOverride.mAlpha), 0, 255);
+		int anAlphaNext = std::clamp(FloatRoundToInt(aAlphaOverLengthNext * aAlphaOverTimeCur * mColorOverride.mAlpha), 0, 255);
 		Sexy::Color aColorCur = mColorOverride;
 		Sexy::Color aColorNext = mColorOverride;
 		aColorCur.mAlpha = anAlphaCur;
@@ -228,10 +226,10 @@ void Trail::Draw(Graphics* g)
 		aPosition[0].y = mTrailCenter.y + aPointCur.aPos.y + aNormalCur.y * aWidthOverLengthCur * aWidthOverTimeCur;
 		aPosition[1].x = mTrailCenter.x + aPointCur.aPos.x + -aNormalCur.x * aWidthOverLengthCur * aWidthOverTimeCur;
 		aPosition[1].y = mTrailCenter.y + aPointCur.aPos.y + -aNormalCur.y * aWidthOverLengthCur * aWidthOverTimeCur;
-		aPosition[2].x = mTrailCenter.x + aPointNext.aPos.x + aNormalNext.x * aWidthOverLengthNext * aWidthOverTimeNext;
-		aPosition[2].y = mTrailCenter.y + aPointNext.aPos.y + aNormalNext.y * aWidthOverLengthNext * aWidthOverTimeNext;
-		aPosition[3].x = mTrailCenter.x + aPointNext.aPos.x + -aNormalNext.x * aWidthOverLengthNext * aWidthOverTimeNext;
-		aPosition[3].y = mTrailCenter.y + aPointNext.aPos.y + -aNormalNext.y * aWidthOverLengthNext * aWidthOverTimeNext;
+		aPosition[2].x = mTrailCenter.x + aPointNext.aPos.x + aNormalNext.x * aWidthOverLengthNext * aWidthOverTimeCur;
+		aPosition[2].y = mTrailCenter.y + aPointNext.aPos.y + aNormalNext.y * aWidthOverLengthNext * aWidthOverTimeCur;
+		aPosition[3].x = mTrailCenter.x + aPointNext.aPos.x + -aNormalNext.x * aWidthOverLengthNext * aWidthOverTimeCur;
+		aPosition[3].y = mTrailCenter.y + aPointNext.aPos.y + -aNormalNext.y * aWidthOverLengthNext * aWidthOverTimeCur;
 
 		int aVertCur = i * 2;
 		int aVertNext = aVertCur + 1;

--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -4112,11 +4112,6 @@ void SexyAppBase::Remove3DData(MemoryImage* theMemoryImage)
 }
 
 
-bool SexyAppBase::Is3DAccelerated()
-{
-	return true;
-}
-
 bool SexyAppBase::Is3DAccelerationSupported()
 {
 	return true;

--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -1340,10 +1340,13 @@ void SexyAppBase::ReadFromRegistry()
 	if (RegistryReadInteger("Muted", &anInt))
 		mMuteCount = anInt;
 
-#if !defined(__IPHONEOS__) && (!defined(__ANDROID__) || defined(__TERMUX__)) && !defined(__SWITCH__) && !defined(__EMSCRIPTEN__)
+	// The read must happen on every platform to keep the demo command stream in sync
 	if (RegistryReadInteger("ScreenMode", &anInt))
+	{
+#if !defined(__IPHONEOS__) && (!defined(__ANDROID__) || defined(__TERMUX__)) && !defined(__SWITCH__) && !defined(__EMSCRIPTEN__)
 		mIsWindowed = anInt == 0;
 #endif
+	}
 
 	RegistryReadInteger("PreferredX", &mPreferredX);
 	RegistryReadInteger("PreferredY", &mPreferredY);

--- a/src/SexyAppFramework/SexyAppBase.cpp
+++ b/src/SexyAppFramework/SexyAppBase.cpp
@@ -241,6 +241,7 @@ SexyAppBase::SexyAppBase()
 	mDrawCount = 0;
 	mSleepCount = 0;
 	mUpdateCount = 0;
+	mStartTick = 0;
 	mUpdateAppState = 0;
 	mUpdateAppDepth = 0;
 	mPendingUpdatesAcc = 0.0;
@@ -2787,6 +2788,7 @@ void SexyAppBase::EmscriptenMainLoopCallback()
 		emscripten_cancel_main_loop();
 		app->ProcessSafeDeleteList();
 		app->mRunning = false;
+		app->LogPerfStats();
 		EM_ASM(
 			if (typeof FS !== 'undefined' && FS.syncfs) {
 				FS.syncfs(false, function(err) {
@@ -2924,6 +2926,20 @@ void SexyAppBase::PreTerminate()
 {
 }
 
+void SexyAppBase::LogPerfStats()
+{
+	Sexy::LogInfoLn("Seconds       = {:.6g}", (SDL_GetTicks() - mStartTick) / 1000.0);
+	Sexy::LogInfoLn("Sleep Count   = {}", mSleepCount);
+	Sexy::LogInfoLn("Update Count  = {}", mUpdateCount);
+	Sexy::LogInfoLn("Draw Count    = {}", mDrawCount);
+	Sexy::LogInfoLn("Draw Time     = {}", mDrawTime);
+	Sexy::LogInfoLn("Screen Blt    = {}", mScreenBltTime);
+	if (mDrawTime+mScreenBltTime > 0)
+	{
+		Sexy::LogInfoLn("Avg FPS       = {}", static_cast<uint64_t>(mDrawCount) * 1000 / (mDrawTime+mScreenBltTime));
+	}
+}
+
 void SexyAppBase::Start()
 {
 	if (mShutdown)
@@ -2937,6 +2953,7 @@ void SexyAppBase::Start()
 	uint32_t aStartTime = SDL_GetTicks();
 
 	mRunning = true;
+	mStartTick = aStartTime;
 	mLastTime = aStartTime;
 	mLastUserInputTick = aStartTime;
 	mLastTimerTime = aStartTime;
@@ -2949,16 +2966,7 @@ void SexyAppBase::Start()
 
 	WaitForLoadingThread();
 
-	Sexy::LogInfoLn("Seconds       = {:.6g}", (SDL_GetTicks() - aStartTime) / 1000.0);
-	Sexy::LogInfoLn("Sleep Count   = {}", mSleepCount);
-	Sexy::LogInfoLn("Update Count  = {}", mUpdateCount);
-	Sexy::LogInfoLn("Draw Count    = {}", mDrawCount);
-	Sexy::LogInfoLn("Draw Time     = {}", mDrawTime);
-	Sexy::LogInfoLn("Screen Blt    = {}", mScreenBltTime);
-	if (mDrawTime+mScreenBltTime > 0)
-	{
-		Sexy::LogInfoLn("Avg FPS       = {}", static_cast<uint64_t>(mDrawCount) * 1000 / (mDrawTime+mScreenBltTime));
-	}
+	LogPerfStats();
 
 	PreTerminate();
 

--- a/src/SexyAppFramework/SexyAppBase.h
+++ b/src/SexyAppFramework/SexyAppBase.h
@@ -538,7 +538,7 @@ public:
 	bool					StartTextInput(std::string& theInput); // set theInput and return true if using soft keyboard capability and user pressed OK (e.g. Switch libnx swkbd)
 	void					StopTextInput();
 	void					SetTextInputRect(const Rect& theRect); // caret rect in logical coords; anchors the IME UI (candidate window, keyboard pan)
-	bool					Is3DAccelerated();
+	bool					Is3DAccelerated() { return true; }
 	bool					Is3DAccelerationSupported();
 	bool					Is3DAccelerationRecommended();
 	void					DemoSyncRefreshRate();

--- a/src/SexyAppFramework/SexyAppBase.h
+++ b/src/SexyAppFramework/SexyAppBase.h
@@ -243,6 +243,7 @@ public:
 	uint					mSleepCount;
 	uint					mDrawCount;
 	uint					mUpdateCount;
+	uint32_t				mStartTick;
 	int						mUpdateAppState;
 	int						mUpdateAppDepth;
 	double					mUpdateMultiplier;
@@ -459,6 +460,7 @@ public:
 	virtual void			HandleGameAlreadyRunning();
 
 	virtual void			Start();
+	void					LogPerfStats();
 	virtual void			Init();
 	virtual void			PreGLInterfaceInitHook();
 	virtual void			PostGLInterfaceInitHook();

--- a/src/SexyAppFramework/graphics/GLInterface.cpp
+++ b/src/SexyAppFramework/graphics/GLInterface.cpp
@@ -92,6 +92,17 @@ static void GfxBegin(GLenum vertexMode)
 	gVertexMode = vertexMode;
 }
 
+static GLenum gBlendSrc = 0;
+static GLenum gBlendDst = 0;
+
+static void SetBlendFunc(GLenum theSrc, GLenum theDst)
+{
+	if (gBlendSrc == theSrc && gBlendDst == theDst) return;
+	glBlendFunc(theSrc, theDst);
+	gBlendSrc = theSrc;
+	gBlendDst = theDst;
+}
+
 static void GfxEnd()
 {
 	if (gVertexMode == (GLenum)-1) return;
@@ -100,25 +111,16 @@ static void GfxEnd()
 	{
 		glBindBuffer(GL_ARRAY_BUFFER, gVbo);
 		glBufferData(GL_ARRAY_BUFFER, sizeof(GLVertex) * gNumVertices, gVertices.data(), GL_DYNAMIC_DRAW);
-
-		glVertexAttribPointer(0, 3, GL_FLOAT,         GL_FALSE, sizeof(GLVertex), (const void*)0);
-		glEnableVertexAttribArray(0);
-		glVertexAttribPointer(1, 4, GL_UNSIGNED_BYTE,  GL_TRUE,  sizeof(GLVertex), (const void*)(sizeof(float)*3));
-		glEnableVertexAttribArray(1);
-		glVertexAttribPointer(2, 2, GL_FLOAT,         GL_FALSE, sizeof(GLVertex), (const void*)(sizeof(float)*3 + sizeof(uint32_t)));
-		glEnableVertexAttribArray(2);
-
 		glDrawArrays(gVertexMode, 0, gNumVertices);
 	}
 
 	gVertexMode = (GLenum)-1;
 	gNumVertices = 0;
-	gVertices.clear();
 }
 
-static void GfxFlushIfOverBudget()
+static void GfxEnsureSpace(int theAdditional)
 {
-	if (gVertexMode == (GLenum)-1 || gNumVertices < MAX_VERTICES) return;
+	if (gVertexMode == (GLenum)-1 || gNumVertices + theAdditional <= MAX_VERTICES) return;
 	GLenum oldMode = gVertexMode;
 	GfxEnd();
 	GfxBegin(oldMode);
@@ -129,12 +131,9 @@ static void GfxAddVertices(const GLVertex *arr, int arrCount)
 	if (gVertexMode == (GLenum)-1) return;
 	if (arrCount <= 0) return;
 
-	const int oldCount = gNumVertices;
+	GfxEnsureSpace(arrCount);
+	memcpy(gVertices.data() + gNumVertices, arr, sizeof(GLVertex) * arrCount);
 	gNumVertices += arrCount;
-	gVertices.resize(gNumVertices);
-	memcpy(gVertices.data() + oldCount, arr, sizeof(GLVertex) * arrCount);
-
-	GfxFlushIfOverBudget();
 }
 
 static void GfxAddVertices(VertexList &arr)
@@ -148,11 +147,9 @@ static void GfxAddVertices(const TriVertex arr[][3], int arrCount, unsigned int 
 	if (gVertexMode == (GLenum)-1) return;
 	if (arrCount <= 0) return;
 
-	const int oldCount = gNumVertices;
-	gNumVertices += arrCount * 3;
-	gVertices.resize(gNumVertices);
+	GfxEnsureSpace(arrCount * 3);
 
-	GLVertex* dst = gVertices.data() + oldCount;
+	GLVertex* dst = gVertices.data() + gNumVertices;
 	for (int tri = 0; tri < arrCount; tri++)
 	{
 		const TriVertex* v = arr[tri];
@@ -160,14 +157,14 @@ static void GfxAddVertices(const TriVertex arr[][3], int arrCount, unsigned int 
 		{
 			dst[i].sx    = v[i].x + tx;
 			dst[i].sy    = v[i].y + ty;
+			dst[i].sz    = 0;
 			dst[i].color = GetColorFromTriVertex(v[i], theColor);
 			dst[i].tu    = v[i].u * aMaxTotalU;
 			dst[i].tv    = v[i].v * aMaxTotalV;
 		}
 		dst += 3;
+		gNumVertices += 3;
 	}
-
-	GfxFlushIfOverBudget();
 }
 
 // Unified GLSL body; VERT_IN / V2F / FRAG_OUT / TEX2D macros from GLPlatform.h.
@@ -559,8 +556,24 @@ TextureData::~TextureData()
 	ReleaseTextures();
 }
 
+struct GfxTextureCache
+{
+	GLuint tex = 0;
+	int filter = 0;
+	int clampUv = -1;
+	float uvBounds[4] = {};
+	bool valid = false;
+};
+static GfxTextureCache gTextureCache;
+
+static void GfxInvalidateTextureCache()
+{
+	gTextureCache.valid = false;
+}
+
 void TextureData::ReleaseTextures()
 {
+	GfxInvalidateTextureCache();
 	for (auto &piece : mTextures)
 		glDeleteTextures(1, &piece.mTexture);
 	mTextures.clear();
@@ -666,6 +679,7 @@ void TextureData::CreateTextures(MemoryImage *theImage)
 	mHeight = theImage->mHeight;
 	mBitsChangedCount = theImage->mBitsChangedCount;
 	mPixelFormat = aFormat;
+	GfxInvalidateTextureCache();
 }
 
 void TextureData::CheckCreateTextures(MemoryImage *theImage)
@@ -734,12 +748,26 @@ static constexpr float kDefaultUvBounds[4] = { 0.f, 0.f, 1.f, 1.f };
 
 static void GfxBindTexture(GLuint tex, const float *uvBounds = kDefaultUvBounds, bool clampUv = true)
 {
-	glBindTexture(GL_TEXTURE_2D, tex);
 	int f = gLinearFilter ? GL_LINEAR : GL_NEAREST;
+	int c = clampUv ? 1 : 0;
+	if (gTextureCache.valid
+		&& gTextureCache.tex == tex
+		&& gTextureCache.filter == f
+		&& gTextureCache.clampUv == c
+		&& memcmp(gTextureCache.uvBounds, uvBounds, sizeof(gTextureCache.uvBounds)) == 0)
+		return;
+
+	glBindTexture(GL_TEXTURE_2D, tex);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, f);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, f);
-	glUniform1i(gUfClampUvEnabled, clampUv ? 1 : 0);
+	glUniform1i(gUfClampUvEnabled, c);
 	glUniform4fv(gUfUvBounds, 1, uvBounds);
+
+	gTextureCache.tex = tex;
+	gTextureCache.filter = f;
+	gTextureCache.clampUv = c;
+	memcpy(gTextureCache.uvBounds, uvBounds, sizeof(gTextureCache.uvBounds));
+	gTextureCache.valid = true;
 }
 
 void TextureData::Blt(float theX, float theY, const Rect& theSrcRect, const Color& theColor)
@@ -1070,8 +1098,7 @@ GLInterface::GLInterface(SexyAppBase* theApp)
 
 	gVertexMode  = (GLenum)-1;
 	gNumVertices = 0;
-	gVertices.clear();
-	gVertices.reserve(MAX_VERTICES);
+	gVertices.resize(MAX_VERTICES);
 }
 
 GLInterface::~GLInterface()
@@ -1088,9 +1115,9 @@ GLInterface::~GLInterface()
 void GLInterface::SetDrawMode(int theDrawMode)
 {
 	if (theDrawMode == Graphics::DRAWMODE_NORMAL)
-		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+		SetBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	else
-		glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+		SetBlendFunc(GL_SRC_ALPHA, GL_ONE);
 }
 
 void GLInterface::AddGLImage(GLImage* theGLImage)
@@ -1167,6 +1194,13 @@ int GLInterface::Init(bool IsWindowed)
 		glGenBuffers(1, &gVbo);
 		glBindBuffer(GL_ARRAY_BUFFER, gVbo);
 		glBufferData(GL_ARRAY_BUFFER, sizeof(GLVertex) * MAX_VERTICES, nullptr, GL_DYNAMIC_DRAW);
+
+		glVertexAttribPointer(0, 3, GL_FLOAT,         GL_FALSE, sizeof(GLVertex), (const void*)0);
+		glEnableVertexAttribArray(0);
+		glVertexAttribPointer(1, 4, GL_UNSIGNED_BYTE,  GL_TRUE,  sizeof(GLVertex), (const void*)(sizeof(float)*3));
+		glEnableVertexAttribArray(1);
+		glVertexAttribPointer(2, 2, GL_FLOAT,         GL_FALSE, sizeof(GLVertex), (const void*)(sizeof(float)*3 + sizeof(uint32_t)));
+		glEnableVertexAttribArray(2);
 	}
 
 	int aMaxSize;
@@ -1231,7 +1265,7 @@ void GLInterface::SetCursorPos(int x, int y)
 
 bool GLInterface::PreDraw()
 {
-	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+	SetBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	return true;
 }
 
@@ -1270,6 +1304,7 @@ bool GLInterface::CreateImageTexture(MemoryImage *theImage)
 
 bool GLInterface::RecoverBits(MemoryImage* theImage)
 {
+	GfxInvalidateTextureCache();
 	if (!theImage->mRenderData) return false;
 
 	TextureData* data = (TextureData*)theImage->mRenderData;

--- a/src/SexyAppFramework/graphics/GLInterface.cpp
+++ b/src/SexyAppFramework/graphics/GLInterface.cpp
@@ -132,6 +132,8 @@ static void GfxAddVertices(const GLVertex *arr, int arrCount)
 	if (arrCount <= 0) return;
 
 	GfxEnsureSpace(arrCount);
+	if (arrCount > MAX_VERTICES)
+		gVertices.resize(arrCount);
 	memcpy(gVertices.data() + gNumVertices, arr, sizeof(GLVertex) * arrCount);
 	gNumVertices += arrCount;
 }
@@ -148,6 +150,8 @@ static void GfxAddVertices(const TriVertex arr[][3], int arrCount, unsigned int 
 	if (arrCount <= 0) return;
 
 	GfxEnsureSpace(arrCount * 3);
+	if (arrCount * 3 > MAX_VERTICES)
+		gVertices.resize(arrCount * 3);
 
 	GLVertex* dst = gVertices.data() + gNumVertices;
 	for (int tri = 0; tri < arrCount; tri++)

--- a/src/SexyAppFramework/graphics/Image.cpp
+++ b/src/SexyAppFramework/graphics/Image.cpp
@@ -61,16 +61,6 @@ int	Image::GetHeight()
 	return mHeight;
 }
 
-int Image::GetCelHeight()
-{
-	return mHeight / mNumRows;
-}
-
-int Image::GetCelWidth()
-{
-	return mWidth / mNumCols;
-}
-
 Rect Image::GetCelRect(int theCel)
 {
 	int h = GetCelHeight();

--- a/src/SexyAppFramework/graphics/Image.h
+++ b/src/SexyAppFramework/graphics/Image.h
@@ -96,8 +96,8 @@ public:
 
 	int						GetWidth();
 	int						GetHeight();
-	int						GetCelWidth();		// returns the width of just 1 cel in a strip of images
-	int						GetCelHeight();	// like above but for vertical strips
+	int						GetCelWidth() { return mWidth / mNumCols; }		// returns the width of just 1 cel in a strip of images
+	int						GetCelHeight() { return mHeight / mNumRows; }	// like above but for vertical strips
 	int						GetAnimCel(int theTime); // use animinfo to return appropriate cel to draw at the time
 	Rect					GetAnimCelRect(int theTime);
 	Rect					GetCelRect(int theCel);				// Gets the rectangle for the given cel at the specified row/col

--- a/src/SexyAppFramework/graphics/ImageFont.cpp
+++ b/src/SexyAppFramework/graphics/ImageFont.cpp
@@ -1379,26 +1379,29 @@ int ImageFont::CharWidthKern(char32_t theChar, char32_t thePrevChar)
 
 		int aLayerPointSize = anActiveFontLayer->mBaseFontLayer->mPointSize;
 
+		CharData* aCharData = anActiveFontLayer->mBaseFontLayer->GetCharData(theChar);
+		CharData* aPrevCharData = thePrevChar != 0 ? anActiveFontLayer->mBaseFontLayer->GetCharData(thePrevChar) : nullptr;
+
 		if (aLayerPointSize == 0)
 		{
-			aCharWidth = anActiveFontLayer->mBaseFontLayer->GetCharData(theChar)->mWidth * mScale;
+			aCharWidth = aCharData->mWidth * mScale;
 
 			if (thePrevChar != 0)
 			{
 				aSpacing = (anActiveFontLayer->mBaseFontLayer->mSpacing +
-					anActiveFontLayer->mBaseFontLayer->GetCharData(thePrevChar)->mKerningOffsets[theChar]) * mScale;
+					aPrevCharData->mKerningOffsets[theChar]) * mScale;
 			}
 			else
 				aSpacing = 0;
 		}
 		else
 		{
-			aCharWidth = (anActiveFontLayer->mBaseFontLayer->GetCharData(theChar)->mWidth * aPointSize / aLayerPointSize);
+			aCharWidth = (aCharData->mWidth * aPointSize / aLayerPointSize);
 
 			if (thePrevChar != 0)
 			{
 				aSpacing = (anActiveFontLayer->mBaseFontLayer->mSpacing +
-					anActiveFontLayer->mBaseFontLayer->GetCharData(thePrevChar)->mKerningOffsets[theChar]) * aPointSize / aLayerPointSize;
+					aPrevCharData->mKerningOffsets[theChar]) * aPointSize / aLayerPointSize;
 			}
 			else
 				aSpacing = 0;
@@ -1490,30 +1493,32 @@ void ImageFont::DrawStringEx(Graphics* g, int theX, int theY, std::string_view t
 			if (aLayerPointSize != 0)
 				aScale *= (float)mPointSize / (float)aLayerPointSize;
 
+			CharData* aCharData = anActiveFontLayer->mBaseFontLayer->GetCharData(aChar);
+
 			if (aScale == 1.0)
 			{
-				anImageX = aLayerXPos + anActiveFontLayer->mBaseFontLayer->mOffset.mX + anActiveFontLayer->mBaseFontLayer->GetCharData(aChar)->mOffset.mX;
-				anImageY = theY - (anActiveFontLayer->mBaseFontLayer->mAscent - anActiveFontLayer->mBaseFontLayer->mOffset.mY - anActiveFontLayer->mBaseFontLayer->GetCharData(aChar)->mOffset.mY);
-				aCharWidth = anActiveFontLayer->mBaseFontLayer->GetCharData(aChar)->mWidth;
+				anImageX = aLayerXPos + anActiveFontLayer->mBaseFontLayer->mOffset.mX + aCharData->mOffset.mX;
+				anImageY = theY - (anActiveFontLayer->mBaseFontLayer->mAscent - anActiveFontLayer->mBaseFontLayer->mOffset.mY - aCharData->mOffset.mY);
+				aCharWidth = aCharData->mWidth;
 
 				if (aNextChar != 0)
 				{
 					aSpacing = anActiveFontLayer->mBaseFontLayer->mSpacing +
-						anActiveFontLayer->mBaseFontLayer->GetCharData(aChar)->mKerningOffsets[aNextChar];
+						aCharData->mKerningOffsets[aNextChar];
 				}
 				else
 					aSpacing = 0;
 			}
 			else
 			{
-				anImageX = aLayerXPos + (int)((anActiveFontLayer->mBaseFontLayer->mOffset.mX + anActiveFontLayer->mBaseFontLayer->GetCharData(aChar)->mOffset.mX) * aScale);
-				anImageY = theY - (int)((anActiveFontLayer->mBaseFontLayer->mAscent - anActiveFontLayer->mBaseFontLayer->mOffset.mY - anActiveFontLayer->mBaseFontLayer->GetCharData(aChar)->mOffset.mY) * aScale);
-				aCharWidth = (anActiveFontLayer->mBaseFontLayer->GetCharData(aChar)->mWidth * aScale);
+				anImageX = aLayerXPos + (int)((anActiveFontLayer->mBaseFontLayer->mOffset.mX + aCharData->mOffset.mX) * aScale);
+				anImageY = theY - (int)((anActiveFontLayer->mBaseFontLayer->mAscent - anActiveFontLayer->mBaseFontLayer->mOffset.mY - aCharData->mOffset.mY) * aScale);
+				aCharWidth = (aCharData->mWidth * aScale);
 
 				if (aNextChar != 0)
 				{
 					aSpacing = (int)((anActiveFontLayer->mBaseFontLayer->mSpacing +
-						anActiveFontLayer->mBaseFontLayer->GetCharData(aChar)->mKerningOffsets[aNextChar]) * aScale);
+						aCharData->mKerningOffsets[aNextChar]) * aScale);
 				}
 				else
 					aSpacing = 0;
@@ -1525,10 +1530,12 @@ void ImageFont::DrawStringEx(Graphics* g, int theX, int theY, std::string_view t
 			aColor.mBlue = std::min((theColor.mBlue * anActiveFontLayer->mBaseFontLayer->mColorMult.mBlue / 255) + anActiveFontLayer->mBaseFontLayer->mColorAdd.mBlue, 255);
 			aColor.mAlpha = std::min((theColor.mAlpha * anActiveFontLayer->mBaseFontLayer->mColorMult.mAlpha / 255) + anActiveFontLayer->mBaseFontLayer->mColorAdd.mAlpha, 255);
 
-			int anOrder = aLayerOrderOffset + anActiveFontLayer->mBaseFontLayer->mBaseOrder + anActiveFontLayer->mBaseFontLayer->GetCharData(aChar)->mOrder;
+			int anOrder = aLayerOrderOffset + anActiveFontLayer->mBaseFontLayer->mBaseOrder + aCharData->mOrder;
 
 			if (aCurPoolIdx >= POOL_SIZE)
 				break;
+
+			Rect& aScaledCharRect = anActiveFontLayer->mScaledCharImageRects[aChar];
 
 			RenderCommand* aRenderCommand = &gRenderCommandPool[aCurPoolIdx++];
 
@@ -1536,10 +1543,10 @@ void ImageFont::DrawStringEx(Graphics* g, int theX, int theY, std::string_view t
 			aRenderCommand->mColor = aColor;
 			aRenderCommand->mDest[0] = anImageX;
 			aRenderCommand->mDest[1] = anImageY;
-			aRenderCommand->mSrc[0] = anActiveFontLayer->mScaledCharImageRects[aChar].mX;
-			aRenderCommand->mSrc[1] = anActiveFontLayer->mScaledCharImageRects[aChar].mY;
-			aRenderCommand->mSrc[2] = anActiveFontLayer->mScaledCharImageRects[aChar].mWidth;
-			aRenderCommand->mSrc[3] = anActiveFontLayer->mScaledCharImageRects[aChar].mHeight;
+			aRenderCommand->mSrc[0] = aScaledCharRect.mX;
+			aRenderCommand->mSrc[1] = aScaledCharRect.mY;
+			aRenderCommand->mSrc[2] = aScaledCharRect.mWidth;
+			aRenderCommand->mSrc[3] = aScaledCharRect.mHeight;
 			aRenderCommand->mMode = anActiveFontLayer->mBaseFontLayer->mDrawMode;
 			aRenderCommand->mNext = nullptr;
 
@@ -1558,7 +1565,7 @@ void ImageFont::DrawStringEx(Graphics* g, int theX, int theY, std::string_view t
 
 			if (theDrawnAreas != nullptr)
 			{
-				Rect aDestRect(anImageX, anImageY, anActiveFontLayer->mScaledCharImageRects[aChar].mWidth, anActiveFontLayer->mScaledCharImageRects[aChar].mHeight);
+				Rect aDestRect(anImageX, anImageY, aScaledCharRect.mWidth, aScaledCharRect.mHeight);
 
 				theDrawnAreas->push_back(aDestRect);
 


### PR DESCRIPTION
## Benchmark

I benchmarked this branch using the project's deterministic demo replay system. The test plays back a real gameplay recording (uncompressed dmo from [pvzp-20260822-011238.dmo.zip](https://github.com/user-attachments/files/32408693/pvzp-20260822-011238.dmo.zip), 52750 updates, ~8.8 minutes) using the `-play` flag, comparing this branch against the merge-base `ab2fbde`.

Since the demo was originally recorded on `fc99db4` (an ancestor of both builds), both versions replay the exact same input stream.

### Test Setup

To keep the comparison fair, both the native and Wasm benchmarks were run using the same methodology: **3 interleaved runs per build** (`base → head → base → ...`) to cancel out system drift. The results below are averages of these runs.

**Native Environment**
- AMD Ryzen 7 5800H, AMD Radeon (Renoir) iGPU, Mesa 26.2.1, Linux 7.1.11-zen
- `RelWithDebInfo` (`-O2`), `PVZ_DEBUG=ON`, identical CMake options for both builds.

**Determinism Check (Native)**
For the native build, determinism was verified: the update count is exactly 52750 in every single run, and the draw count only varies by about ±6 out of ~31600 draws. The logical and rendering workloads are effectively identical, so the performance differences come purely from the optimizations.

---

### Native Results

Confidence intervals are calculated using Welch's t-test.

| Metric | Baseline | This branch | Change | p-value | 95% CI |
|---|---:|---:|---:|---:|---:|
| Per-frame draw time | 2.890 ms | 2.485 ms | **-14.0%** | 7.9e-04 | [11.2%, 16.8%] |
| Total draw time | 91.3 s | 78.5 s | **-14.0%** | 8.1e-04 | [11.2%, 16.8%] |
| Process CPU time (user+sys) | 233.7 s | 216.4 s | **-7.4%** | 2.6e-03 | [4.8%, 10.0%] |

The average FPS logged at shutdown goes from 343 to around 400, which is consistent with the ~14% reduction in per-draw cost.

### WebAssembly (Node.js harness)

I also ran the same replay through the Node.js Wasm harness. 

| Metric | Baseline | This branch | Change | p-value | 95% CI |
|---|---:|---:|---:|---:|---:|
| Total draw time | 118.4 s | 81.4 s | **-31.2%** | 6.0e-07 | [29.7%, 32.7%] |
| Process CPU time (user+sys) | 146.9 s | 109.9 s | **-25.2%** | 4.6e-05 | [24.1%, 26.3%] |
| Main-loop busy time | 179.4 s | 145.3 s | **-19.0%** | 5.4e-07 | [18.4%, 19.6%] |

### Notes

**Native specific:**
- Demo playback is paced in real time (100 updates/s), so the total wall-clock duration is identical by design. The performance win shows up as lower CPU usage per frame, which means more headroom for thermals and battery life on mobile targets.
- The metrics mostly capture CPU-side costs (including GL driver calls). GPU-bound scenarios will see smaller effective gains. Scenes heavy in particles and reanimation tracks should benefit more than this average gameplay session.

**Wasm specific:**
- The Wasm harness stubs out GL calls (no real rendering happens), so the absolute Wasm numbers don't represent real browser performance — only the relative comparison is meaningful. 
- In a real browser, each eliminated GL call is actually more expensive (due to the wasm→JS boundary and WebGL validation). The direction of the improvement holds, but the exact magnitude in-browser will differ. It will mostly show up as extra headroom within the game's 10 ms update budget (100 updates/s, bunched into `requestAnimationFrame` callbacks).
- "Main-loop busy time" is polluted by ASYNCIFY sleep wall-clock time, so the Process CPU column is a much better metric to look at.
- Unlike native, the draw count actually differs between the Wasm builds (faster builds batch fewer updates per frame and draw more frames). Because of this, the Wasm comparisons are based on total times, not per-draw times.

**Behavior:**
- No behavioral changes: the replay relies on recorded demo asserts and completed without any divergence on either build.
