### PR TITLE
Fix: correct Leftpeater projectile origin

### DIFF
--- a/src/Lawn/Plant.cpp
+++ b/src/Lawn/Plant.cpp
@@ -4595,7 +4595,7 @@ void Plant::Fire(Zombie* theTargetZombie, int theRow, PlantWeapon thePlantWeapon
 	{
 		int aOffsetX, aOffsetY;
 		GetPeaHeadOffset(aOffsetX, aOffsetY);
-		aOriginX = mX + aOffsetX - 57;
+		aOriginX = mX - aOffsetX + 27;
 		aOriginY = mY + aOffsetY - 33;
 	}
 	else if (mSeedType == SeedType::SEED_GATLINGPEA)


### PR DESCRIPTION
In `Plant::Fire`, the Leftpeater projectile origin used `mX + aOffsetX - 57`. This only matches the official mirrored position when `aOffsetX == 42`. On other head-animation frames, the projectile spawn position moves in the wrong direction with the animation.

It now uses `mX - aOffsetX + 27`, matching the official GOTY.