### PR TITLE
Fix: handle inverted zombie rectangles safely

### DIFF
--- a/src/Lawn/Board.cpp
+++ b/src/Lawn/Board.cpp
@@ -8942,11 +8942,39 @@ int GetRectOverlap(const Rect& rect1, const Rect& rect2)
 
 bool GetCircleRectOverlap(int theCircleX, int theCircleY, int theRadius, const Rect& theRect)
 {
-	int aNearX = std::clamp(theCircleX, theRect.mX, theRect.mX + theRect.mWidth);
-	int aNearY = std::clamp(theCircleY, theRect.mY, theRect.mY + theRect.mHeight);
-	int dx = theCircleX - aNearX;
-	int dy = theCircleY - aNearY;
-	return dx * dx + dy * dy <= theRadius * theRadius;
+	int dx = 0;
+	int dy = 0;
+	bool xOut = false;
+	bool yOut = false;
+
+	if (theCircleX < theRect.mX)
+	{
+		xOut = true;
+		dx = theRect.mX - theCircleX;
+	}
+	else if (theCircleX > theRect.mX + theRect.mWidth)
+	{
+		xOut = true;
+		dx = theCircleX - theRect.mX - theRect.mWidth;
+	}
+	if (theCircleY < theRect.mY)
+	{
+		yOut = true;
+		dy = theRect.mY - theCircleY;
+	}
+	else if (theCircleY > theRect.mY + theRect.mHeight)
+	{
+		yOut = true;
+		dy = theCircleY - theRect.mY - theRect.mHeight;
+	}
+
+	if (!xOut && !yOut)
+		return true;
+	if (xOut && yOut)
+		return dx * dx + dy * dy <= theRadius * theRadius;
+	if (xOut)
+		return dx <= theRadius;
+	return dy <= theRadius;
 }
 
 void Board::KillAllPlantsInRadius(int theX, int theY, int theRadius)

--- a/src/Lawn/Zombie.cpp
+++ b/src/Lawn/Zombie.cpp
@@ -8309,7 +8309,6 @@ Rect Zombie::GetZombieRect()
 	if (aDrawPos.mClipHeight > CLIP_HEIGHT_LIMIT)
 	{
 		aZombieRect.mHeight -= aDrawPos.mClipHeight;
-		aZombieRect.mHeight = std::max(aZombieRect.mHeight, 0);
 	}
 
 	return aZombieRect;


### PR DESCRIPTION
PR #324 replaced the original branch-based `GetCircleRectOverlap` calculation with `std::clamp`. During zombie emergence, `GetZombieRect` can produce an inverted rectangle in the official GOTY executable, causing the clamp call to receive unordered bounds and potentially assert or invoke undefined behavior.

PR #444 prevented that crash by clamping negative rectangle heights to zero. While safe, this changed the original collision geometry.

`GetCircleRectOverlap` now restores the original branch-based calculation, and `GetZombieRect` again preserves negative heights. This fixes the Whack-A-Zombie crash without changing the official gameplay behavior.