### PR TITLE
Fix: handle SDL mouse enter and leave events

### DIFF
--- a/src/SexyAppFramework/platform/default/Input.cpp
+++ b/src/SexyAppFramework/platform/default/Input.cpp
@@ -399,6 +399,19 @@ static void RecordDemoEvent(SexyAppBase* theApp, const SDL_Event& theEvent)
 					theApp->mDemoBuffer.WriteNumBits(DEMO_ACTIVATE_APP, 5);
 					theApp->mDemoBuffer.WriteNumBits(theEvent.window.event == SDL_WINDOWEVENT_FOCUS_GAINED ? 1 : 0, 1);
 					break;
+
+				case SDL_WINDOWEVENT_ENTER:
+				case SDL_WINDOWEVENT_LEAVE:
+				{
+					bool aMouseIn = theEvent.window.event == SDL_WINDOWEVENT_ENTER;
+					if (theApp->mMouseIn != aMouseIn)
+					{
+						theApp->WriteDemoTimingBlock();
+						theApp->mDemoBuffer.WriteNumBits(0, 1);
+						theApp->mDemoBuffer.WriteNumBits(aMouseIn ? DEMO_MOUSE_ENTER : DEMO_MOUSE_EXIT, 5);
+					}
+					break;
+				}
 			}
 			break;
 
@@ -649,6 +662,27 @@ bool SexyAppBase::ProcessDeferredMessages(bool singleMessage)
 					case SDL_WINDOWEVENT_FOCUS_LOST:
 						mActive = event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED;
 						RehupFocus();
+						break;
+
+					case SDL_WINDOWEVENT_ENTER:
+						if (!mMouseIn)
+						{
+							int x, y;
+							SDL_GetMouseState(&x, &y);
+							mWidgetManager->RemapMouse(x, y);
+							mMouseIn = true;
+							mWidgetManager->MouseMove(x, y);
+							EnforceCursor();
+						}
+						break;
+
+					case SDL_WINDOWEVENT_LEAVE:
+						if (mMouseIn)
+						{
+							mWidgetManager->MouseExit(mWidgetManager->mLastMouseX, mWidgetManager->mLastMouseY);
+							mMouseIn = false;
+							EnforceCursor();
+						}
 						break;
 				}
 				break;


### PR DESCRIPTION
`SDL_WINDOWEVENT_ENTER` and `SDL_WINDOWEVENT_LEAVE` were not reflected in `SexyAppBase` or `WidgetManager`. Handle these events, record the corresponding demo transitions, and refresh the cursor so hover states, tooltips, and cursor feedback do not remain active after the pointer leaves the window.

Tested on Windows: leaving the window immediately clears its hover state.

The changes are implemented in the shared SDL input backend used by desktop and mobile builds; Emscripten also shares this input path. Other SDL platforms were not tested separately. Nintendo Switch uses its own input backend and is not changed by this PR.