### PR TITLE
Fix: serialize mMusicMap access between loading and main threads

### DIFF
--- a/src/Lawn/System/Music.cpp
+++ b/src/Lawn/System/Music.cpp
@@ -28,6 +28,8 @@
 #include "../../PvzpLib/PvzpCommon.h"
 #include "sound/SDLMusicInterface.h"
 
+#include <mutex>
+
 using namespace Sexy;
 
 Music::Music()
@@ -105,6 +107,8 @@ bool Music::PvzpLoadMusic(MusicFile theMusicFile, std::string_view theFileName)
 
 	SDLMusicInfo aMusicInfo;
 	aMusicInfo.mHMusic = aHMusic;
+
+	std::scoped_lock anAutoCrit(anSDL->mMusicMapMutex);
 	anSDL->mMusicMap.insert(SDLMusicMap::value_type(theMusicFile, aMusicInfo));
 	return true;
 }
@@ -193,6 +197,7 @@ void Music::MusicInit()
 void Music::MusicCreditScreenInit()
 {
 	SDLMusicInterface* anSDL = (SDLMusicInterface*)mApp->mMusicInterface.get();
+	std::scoped_lock anAutoCrit(anSDL->mMusicMapMutex);
 	if (anSDL->mMusicMap.find((int)MusicFile::MUSIC_FILE_CREDITS_ZOMBIES_ON_YOUR_LAWN) == anSDL->mMusicMap.end())
 		LoadSong(MusicFile::MUSIC_FILE_CREDITS_ZOMBIES_ON_YOUR_LAWN, "sounds/ZombiesOnYourLawn.ogg");
 }
@@ -223,6 +228,7 @@ void Music::StopAllMusic()
 Mix_Music* Music::GetMusicHandle(MusicFile theMusicFile)
 {
 	SDLMusicInterface* anSDL = (SDLMusicInterface*)mApp->mMusicInterface.get();
+	std::scoped_lock anAutoCrit(anSDL->mMusicMapMutex);
 	auto anItr = anSDL->mMusicMap.find((int)theMusicFile);
 	PVZP_ASSERT(anItr != anSDL->mMusicMap.end());
 	return anItr->second.mHMusic;
@@ -231,6 +237,7 @@ Mix_Music* Music::GetMusicHandle(MusicFile theMusicFile)
 void Music::PlayFromOffset(MusicFile theMusicFile, int theOffset, double theVolume)
 {
 	SDLMusicInterface* anSDL = (SDLMusicInterface*)mApp->mMusicInterface.get();
+	std::scoped_lock anAutoCrit(anSDL->mMusicMapMutex);
 	auto anItr = anSDL->mMusicMap.find((int)theMusicFile);
 	PVZP_ASSERT(anItr != anSDL->mMusicMap.end());
 	SDLMusicInfo* aMusicInfo = &anItr->second;

--- a/src/SexyAppFramework/sound/SDLMusicInterface.cpp
+++ b/src/SexyAppFramework/sound/SDLMusicInterface.cpp
@@ -62,6 +62,8 @@ bool SDLMusicInterface::LoadMusic(int theSongId, const std::string& theFileName)
 
 	SDLMusicInfo aMusicInfo;
 	aMusicInfo.mHMusic = aHMusic;
+
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
 	mMusicMap.insert(SDLMusicMap::value_type(theSongId, aMusicInfo));
 
 	return true;
@@ -69,6 +71,8 @@ bool SDLMusicInterface::LoadMusic(int theSongId, const std::string& theFileName)
 
 void SDLMusicInterface::PlayMusic(int theSongId, int theOffset, bool noLoop)
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	SDLMusicMap::iterator anItr = mMusicMap.find(theSongId);
 	if (anItr != mMusicMap.end())
 	{
@@ -86,6 +90,8 @@ void SDLMusicInterface::PlayMusic(int theSongId, int theOffset, bool noLoop)
 
 void SDLMusicInterface::StopMusic(int theSongId)
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	Mix_HaltMusic();
 
 	SDLMusicMap::iterator anItr = mMusicMap.find(theSongId);
@@ -99,6 +105,8 @@ void SDLMusicInterface::StopMusic(int theSongId)
 
 void SDLMusicInterface::PauseMusic(int theSongId)
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	SDLMusicMap::iterator anItr = mMusicMap.find(theSongId);
 	if (anItr != mMusicMap.end())
 	{
@@ -109,6 +117,8 @@ void SDLMusicInterface::PauseMusic(int theSongId)
 
 void SDLMusicInterface::ResumeMusic(int theSongId)
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	SDLMusicMap::iterator anItr = mMusicMap.find(theSongId);
 	if (anItr != mMusicMap.end())
 	{
@@ -119,6 +129,8 @@ void SDLMusicInterface::ResumeMusic(int theSongId)
 
 void SDLMusicInterface::StopAllMusic()
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	SDLMusicMap::iterator anItr = mMusicMap.begin();
 	while (anItr != mMusicMap.end())
 	{
@@ -131,6 +143,8 @@ void SDLMusicInterface::StopAllMusic()
 
 void SDLMusicInterface::UnloadMusic(int theSongId)
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	StopMusic(theSongId);
 
 	SDLMusicMap::iterator anItr = mMusicMap.find(theSongId);
@@ -145,6 +159,8 @@ void SDLMusicInterface::UnloadMusic(int theSongId)
 
 void SDLMusicInterface::UnloadAllMusic()
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	StopAllMusic();
 	for (SDLMusicMap::iterator anItr = mMusicMap.begin(); anItr != mMusicMap.end(); ++anItr)
 	{
@@ -156,6 +172,8 @@ void SDLMusicInterface::UnloadAllMusic()
 
 void SDLMusicInterface::PauseAllMusic()
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	for (SDLMusicMap::iterator anItr = mMusicMap.begin(); anItr != mMusicMap.end(); ++anItr)
 	{
 		SDLMusicInfo* aMusicInfo = &anItr->second;
@@ -166,6 +184,8 @@ void SDLMusicInterface::PauseAllMusic()
 
 void SDLMusicInterface::ResumeAllMusic()
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	for (SDLMusicMap::iterator anItr = mMusicMap.begin(); anItr != mMusicMap.end(); ++anItr)
 	{
 		SDLMusicInfo* aMusicInfo = &anItr->second;
@@ -176,6 +196,8 @@ void SDLMusicInterface::ResumeAllMusic()
 
 void SDLMusicInterface::FadeIn(int theSongId, int theOffset, double theSpeed, bool noLoop)
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	SDLMusicMap::iterator anItr = mMusicMap.find(theSongId);
 	if (anItr != mMusicMap.end())
 	{
@@ -194,6 +216,8 @@ void SDLMusicInterface::FadeIn(int theSongId, int theOffset, double theSpeed, bo
 
 void SDLMusicInterface::FadeOut(int theSongId, bool stopSong, double theSpeed)
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	SDLMusicMap::iterator anItr = mMusicMap.find(theSongId);
 	if (anItr != mMusicMap.end())
 	{
@@ -210,6 +234,8 @@ void SDLMusicInterface::FadeOut(int theSongId, bool stopSong, double theSpeed)
 
 void SDLMusicInterface::FadeOutAll(bool stopSong, double theSpeed)
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	SDLMusicMap::iterator anItr = mMusicMap.begin();
 	while (anItr != mMusicMap.end())
 	{
@@ -224,6 +250,8 @@ void SDLMusicInterface::FadeOutAll(bool stopSong, double theSpeed)
 
 void SDLMusicInterface::SetSongVolume(int theSongId, double theVolume)
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	SDLMusicMap::iterator anItr = mMusicMap.find(theSongId);
 	if (anItr != mMusicMap.end())
 	{
@@ -236,6 +264,8 @@ void SDLMusicInterface::SetSongVolume(int theSongId, double theVolume)
 
 void SDLMusicInterface::SetSongMaxVolume(int theSongId, double theMaxVolume)
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	SDLMusicMap::iterator anItr = mMusicMap.find(theSongId);
 	if (anItr != mMusicMap.end())
 	{
@@ -249,6 +279,8 @@ void SDLMusicInterface::SetSongMaxVolume(int theSongId, double theMaxVolume)
 
 bool SDLMusicInterface::IsPlaying(int theSongId)
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	SDLMusicMap::iterator anItr = mMusicMap.find(theSongId);
 	if (anItr != mMusicMap.end())
 	{
@@ -273,6 +305,8 @@ void SDLMusicInterface::Update()
 {
 	Mix_VolumeMusic(mGlobalVolume);
 	Mix_VolumeMusicGeneral(mGlobalVolume);
+
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
 
 	SDLMusicMap::iterator anItr = mMusicMap.begin();
 	while (anItr != mMusicMap.end())
@@ -307,6 +341,8 @@ void SDLMusicInterface::Update()
 // functions for dealing with MODs
 int SDLMusicInterface::GetMusicOrder(int theSongId)
 {
+	std::scoped_lock anAutoCrit(mMusicMapMutex);
+
 	SDLMusicMap::iterator anItr = mMusicMap.find(theSongId);
 	if (anItr != mMusicMap.end())
 	{

--- a/src/SexyAppFramework/sound/SDLMusicInterface.h
+++ b/src/SexyAppFramework/sound/SDLMusicInterface.h
@@ -30,6 +30,8 @@
 #include <SDL.h>
 #include <SDL_mixer_ext/SDL_mixer_ext.h>
 
+#include <mutex>
+
 namespace Sexy
 {
 
@@ -56,6 +58,7 @@ class SDLMusicInterface : public MusicInterface
 {
 public:
 	SDLMusicMap				mMusicMap;
+	std::recursive_mutex	mMusicMapMutex;
 	int						mGlobalVolume;
 	int						mMusicLoadFlags;
 


### PR DESCRIPTION
MusicInit() inserts into SDLMusicInterface::mMusicMap on the loading thread while the main thread iterates it in Update(). Guard all map access with a recursive mutex (recursive because UnloadMusic and UnloadAllMusic call StopMusic and StopAllMusic internally).