### PR TITLE
Fix: reset mPaused when allocating a reused foley slot

### DIFF
--- a/src/PvzpLib/PvzpFoley.cpp
+++ b/src/PvzpLib/PvzpFoley.cpp
@@ -288,6 +288,7 @@ void PvzpFoley::PlayFoleyPitch(FoleyType theFoleyType, float thePitch)
 	aFoleyInstance->mInstance = aSoundInstance;
 	aFoleyInstance->mRefCount = 1;
 	aFoleyInstance->mStartTime = gSexyAppBase->mUpdateCount;
+	aFoleyInstance->mPaused = false;
 	aFoleyData->mLastVariationPlayed = aVariation;
 	if (thePitch != 0.0f)
 		aSoundInstance->AdjustPitch(thePitch);


### PR DESCRIPTION
CancelPausedFoley() frees paused slots without clearing mPaused, and the stale flag leaks into the next occupant: the finished instance is never auto-released, and ONE_AT_A_TIME foley types go silent until the next pause cycle. Initialize mPaused at the single point where a slot becomes occupied, covering all release paths.