### PR TITLE
Fix: guard null candidate in portal lookup

### DIFF
--- a/src/Lawn/Challenge.cpp
+++ b/src/Lawn/Challenge.cpp
@@ -3444,8 +3444,7 @@ GridItem* Challenge::GetPortalLeftRight(int theGridX, int theGridY, int theToLef
 		int aIsDir = (aPortalX > theGridX) ^ theToLeft;
 		if (aGridItem->IsOpenPortal() && aIsDir && aGridItem->mGridY == theGridY)
 		{
-			int aIsCls = (aGridItemRecord->mGridX > aPortalX) ^ theToLeft;
-			if (!aGridItemRecord || aIsCls)
+			if (!aGridItemRecord || ((aGridItemRecord->mGridX > aPortalX) ^ theToLeft))
 			{
 				aGridItemRecord = aGridItem;
 			}


### PR DESCRIPTION
`Challenge::GetPortalLeftRight` accessed `aGridItemRecord->mGridX` before checking whether the candidate was null. The comparison now follows the null check so the first matching portal can be selected safely.
