### PR TITLE
Fix: gate the Pages deployment on the full build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -821,7 +821,7 @@ jobs:
 
   deploy-wasm-pages:
     name: Deploy WebAssembly to GitHub Pages
-    needs: build-wasm
+    needs: ['build-archlinux', 'build-linux-static', 'build-windows-msys2-ucrt64', 'build-windows-msvc-x64', 'build-windows-msvc-x86', 'build-macos', 'build-android', 'build-ios', 'build-wasm']
     # Auto-deploy on release tags; manual runs allowed via workflow_dispatch (main only)
     if: github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest


### PR DESCRIPTION
The deploy-wasm-pages job previously only needed build-wasm, so the web demo could go live from a tag even when another platform's build failed and no release was published. Its needs list now matches the release job's, so the Pages deployment only runs when the whole matrix is green.